### PR TITLE
Enable TestDataTypes.testShouldEchoVeryLongList for javascript

### DIFF
--- a/tests/neo4j/datatypes.py
+++ b/tests/neo4j/datatypes.py
@@ -67,7 +67,7 @@ class TestDataTypes(unittest.TestCase):
 
 
     def testShouldEchoVeryLongList(self):
-        if get_driver_name() in ['java', 'javascript']:
+        if get_driver_name() in ['java']:
             self.skipTest("Not implemented in backend")
 
         vals = [


### PR DESCRIPTION
It's safe to re-enable it since the test-backend was update with the datatypes