### PR TITLE
Remove the edge case scenario for Float on TestDataTypes.testShouldEchoNestedLists

### DIFF
--- a/tests/neo4j/datatypes.py
+++ b/tests/neo4j/datatypes.py
@@ -94,7 +94,7 @@ class TestDataTypes(unittest.TestCase):
         self.verifyCanEcho(types.CypherString(long_string))
 
     def testShouldEchoNestedLists(self):
-        if get_driver_name() in ['java', 'javascript']:
+        if get_driver_name() in ['java']:
             self.skipTest("Not implemented in backend")
 
         test_lists = [
@@ -103,7 +103,7 @@ class TestDataTypes(unittest.TestCase):
             types.CypherList([types.CypherBool(True), types.CypherBool(False)]),
             types.CypherList([types.CypherFloat(1.1), types.CypherFloat(2.2), types.CypherFloat(3.3), types.CypherFloat(4.4)]),
             types.CypherList([types.CypherNull(None), types.CypherNull(None)]),
-            types.CypherList([types.CypherNull(None), types.CypherBool(True), types.CypherString("Hello world"), types.CypherInt(-1234567890), types.CypherFloat(1.7976931348623157E+308)])
+            types.CypherList([types.CypherNull(None), types.CypherBool(True), types.CypherString("Hello world"), types.CypherInt(-1234567890), types.CypherFloat(123.456)])
                      ]
 
         self.createDriverAndSession()


### PR DESCRIPTION
This edge scenario was not need to test the nested list scenarios and it was blocking this test to enabled to javascript.

This fix enables this test to run also for the javascript driver.