### PR TITLE
Support for downloading last succesful build from TeamCity

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -48,3 +48,15 @@ def run(image, name, command=None, mountMap={}, hostMap={}, portMap={}, envMap={
     subprocess.run(cmd, check=True)
 
     return Container(name)
+
+def load(readable):
+    cmd = ["docker", "load"]
+    p = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+    outs, errs = p.communicate(input=readable.read())
+    if outs:
+        print(str(outs))
+    if errs:
+        print(str(errs))
+    if p.returncode != 0:
+        raise Exception("Failed to load docker image")
+

--- a/teamcity/__init__.py
+++ b/teamcity/__init__.py
@@ -1,0 +1,6 @@
+import os
+from teamcity.download import DockerImage
+from teamcity.testresult import TeamCityTestResult, escape
+
+
+in_teamcity = os.environ.get('TEST_IN_TEAMCITY', False)

--- a/teamcity/download.py
+++ b/teamcity/download.py
@@ -1,0 +1,26 @@
+from urllib import request
+from os import getenv
+import subprocess
+
+
+def download_artifact(build_id, build_spec, path):
+    """ Returns http response
+    """
+    root = "https://live.neo4j-build.io"
+    path = "{}/repository/download/{}/{}/{}".format(root, build_id, build_spec, path)
+    user = getenv("TEAMCITY_USER")
+    pasw = getenv("TEAMCITY_PASSWORD")
+    password_mgr = request.HTTPPasswordMgrWithDefaultRealm()
+    password_mgr.add_password(None, root, user, pasw)
+    handler = request.HTTPBasicAuthHandler(password_mgr)
+    opener = request.build_opener(handler)
+    return opener.open(path)
+
+
+class DockerImage:
+    def __init__(self, name):
+        self.name = name
+
+    def get(self):
+        return download_artifact("DriversTestkitNeo4jDockers", ".lastSuccessful", "neo4j-docker/" + self.name)
+

--- a/teamcity/testresult.py
+++ b/teamcity/testresult.py
@@ -1,0 +1,36 @@
+import os, unittest
+
+
+def escape(s):
+    s = s.replace("|", "||")
+    s = s.replace("\n", "|n")
+    s = s.replace("\r", "|r")
+    s = s.replace("'", "|'")
+    s = s.replace("[", "|[")
+    s = s.replace("]", "|]")
+    return s
+
+class TeamCityTestResult(unittest.TextTestResult):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def startTest(self, test):
+        print("##teamcity[testStarted name='%s']" % escape(str(test)))
+        return super().startTest(test)
+
+    def stopTest(self, test):
+        print("##teamcity[testFinished name='%s']\n" % escape(str(test)))
+        return super().stopTest(test)
+
+    def addError(self, test, err):
+        print("##teamcity[testFailed name='%s' message='%s' details='%s']" % (escape(str(test)), escape(str(err[1])), escape(str(err[2]))))
+        return super().addError(test, err)
+
+    def addFailure(self, test, err):
+        print("##teamcity[testFailed name='%s' message='%s' details='%s']" % (escape(str(test)), escape(str(err[1])), escape(str(err[2]))))
+        return super().addFailure(test, err)
+
+    def addSkip(self, test, reason):
+        print("##teamcity[testIgnored name='%s' message='%s']" % (escape(str(test)), escape(str(reason))))
+        return super().addSkip(test, reason)
+

--- a/tests/neo4j/suites.py
+++ b/tests/neo4j/suites.py
@@ -11,29 +11,37 @@ from tests.testenv import get_test_result_class, begin_test_suite, end_test_suit
 loader = unittest.TestLoader()
 
 """
-Suite for Neo4j 3.5 single instance enterprise edition
+Suite for Neo4j 3.5
 """
-single_enterprise_neo4j3x5 = unittest.TestSuite()
-single_enterprise_neo4j3x5.addTests(loader.loadTestsFromModule(datatypes))
-single_enterprise_neo4j3x5.addTests(loader.loadTestsFromModule(sessionrun))
-single_enterprise_neo4j3x5.addTests(loader.loadTestsFromModule(authentication))
+suite_3x5 = unittest.TestSuite()
+suite_3x5.addTests(loader.loadTestsFromModule(datatypes))
+suite_3x5.addTests(loader.loadTestsFromModule(sessionrun))
+suite_3x5.addTests(loader.loadTestsFromModule(authentication))
 
 """
-Suite for Neo4j 4.0 single instance community edition
+Suite for Neo4j 4.0
 """
-single_community_neo4j4x0 = unittest.TestSuite()
-single_community_neo4j4x0.addTests(loader.loadTestsFromModule(datatypes))
-single_community_neo4j4x0.addTests(loader.loadTestsFromModule(sessionrun))
-single_community_neo4j4x0.addTests(loader.loadTestsFromModule(authentication))
+suite_4x0 = unittest.TestSuite()
+suite_4x0.addTests(loader.loadTestsFromModule(datatypes))
+suite_4x0.addTests(loader.loadTestsFromModule(sessionrun))
+suite_4x0.addTests(loader.loadTestsFromModule(authentication))
 
 
 """
-Suite for Neo4j 4.1 single instance enterprise edition
+Suite for Neo4j 4.1
 """
-single_enterprise_neo4j4x1 = unittest.TestSuite()
-single_enterprise_neo4j4x1.addTests(loader.loadTestsFromModule(datatypes))
-single_enterprise_neo4j4x1.addTests(loader.loadTestsFromModule(sessionrun))
-single_enterprise_neo4j4x1.addTests(loader.loadTestsFromModule(authentication))
+suite_4x1 = unittest.TestSuite()
+suite_4x1.addTests(loader.loadTestsFromModule(datatypes))
+suite_4x1.addTests(loader.loadTestsFromModule(sessionrun))
+suite_4x1.addTests(loader.loadTestsFromModule(authentication))
+
+"""
+Suite for Neo4j 4.2
+"""
+suite_4x2 = unittest.TestSuite()
+suite_4x2.addTests(loader.loadTestsFromModule(datatypes))
+suite_4x2.addTests(loader.loadTestsFromModule(sessionrun))
+suite_4x2.addTests(loader.loadTestsFromModule(authentication))
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
@@ -42,11 +50,13 @@ if __name__ == "__main__":
     name = sys.argv[1]
     suite = None
     if   name == "3.5":
-        suite = single_enterprise_neo4j3x5
+        suite = suite_3x5
     if   name == "4.0":
-        suite = single_community_neo4j4x0
+        suite = suite_4x0
     elif name == "4.1":
-        suite = single_enterprise_neo4j4x1
+        suite = suite_4x1
+    elif name == "4.2":
+        suite = suite_4x2
 
     if not suite:
         print("Unknown suite name: " + name)

--- a/tests/testenv.py
+++ b/tests/testenv.py
@@ -1,53 +1,17 @@
-import os, unittest
-
-
-in_teamcity = os.environ.get('TEST_IN_TEAMCITY', False)
-
-
-def _tc_escape(s):
-    s = s.replace("|", "||")
-    s = s.replace("\n", "|n")
-    s = s.replace("\r", "|r")
-    s = s.replace("'", "|'")
-    s = s.replace("[", "|[")
-    s = s.replace("]", "|]")
-    return s
-
-class TeamCityTestResult(unittest.TextTestResult):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def startTest(self, test):
-        print("##teamcity[testStarted name='%s']" % _tc_escape(str(test)))
-        return super().startTest(test)
-
-    def stopTest(self, test):
-        print("##teamcity[testFinished name='%s']\n" % _tc_escape(str(test)))
-        return super().stopTest(test)
-
-    def addError(self, test, err):
-        print("##teamcity[testFailed name='%s' message='%s' details='%s']" % (_tc_escape(str(test)), _tc_escape(str(err[1])), _tc_escape(str(err[2]))))
-        return super().addError(test, err)
-
-    def addFailure(self, test, err):
-        print("##teamcity[testFailed name='%s' message='%s' details='%s']" % (_tc_escape(str(test)), _tc_escape(str(err[1])), _tc_escape(str(err[2]))))
-        return super().addFailure(test, err)
-
-    def addSkip(self, test, reason):
-        print("##teamcity[testIgnored name='%s' message='%s']" % (_tc_escape(str(test)), _tc_escape(str(reason))))
-        return super().addSkip(test, reason)
+import unittest
+from teamcity import in_teamcity, TeamCityTestResult, escape
 
 
 def begin_test_suite(name):
     if in_teamcity:
-        print("##teamcity[testSuiteStarted name='%s']" % _tc_escape(name))
+        print("##teamcity[testSuiteStarted name='%s']" % escape(name))
     else:
         print(">>> Start test suite: %s" % name)
 
 
 def end_test_suite(name):
     if in_teamcity:
-        print("##teamcity[testSuiteFinished name='%s']" %  _tc_escape(name))
+        print("##teamcity[testSuiteFinished name='%s']" %  escape(name))
     else:
         print(">>> End test suite: %s" % name)
 


### PR DESCRIPTION
When running within Neo4j TeamCity environment the latest successful
build of Neo4j versions in development can be used to run test against.

Also moves some of the TeamCity logic into it's own module.

Also shortens and fixes somewhat misleading suite names.