### PR TITLE
Enable javascript for bookmark, disconnected, iteration, session parameters and tx parameters stub tests

### DIFF
--- a/tests/stub/bookmark.py
+++ b/tests/stub/bookmark.py
@@ -39,7 +39,7 @@ class Tx(unittest.TestCase):
 
     # Tests that a committed transaction can return the last bookmark
     def test_last_bookmark(self):
-        if get_driver_name() not in ["go", "dotnet"]:
+        if get_driver_name() not in ["go", "dotnet", "javascript"]:
             self.skipTest("session.lastBookmark not implemented in backend")
 
         self._server.start(script=script_commit)

--- a/tests/stub/disconnected.py
+++ b/tests/stub/disconnected.py
@@ -14,7 +14,7 @@ customUserAgent = "Modesty"
 script_on_hello = """
 !: BOLT 4
 
-C: HELLO {"user_agent": "Modesty", "scheme": "basic", "principal": "neo4j", "credentials": "pass"}
+C: HELLO {"user_agent": "Modesty", "scheme": "basic", "principal": "neo4j", "credentials": "pass" #EXTRA_HELLO_PARAMS# }
 S: <EXIT>
 """
 script_on_run = """
@@ -75,9 +75,9 @@ class SessionRunDisconnected(unittest.TestCase):
     def test_disconnect_on_hello(self):
         # Verifies how the driver handles when server disconnects right after driver sent bolt
         # hello message.
-        if not self._driverName in ["go"]:
+        if not self._driverName in ["go", "javascript"]:
             self.skipTest("No support for custom user-agent in testkit backend")
-        self._server.start(script=script_on_hello)
+        self._server.start(script=script_on_hello, vars=self.get_vars())
         step = self._run()
         self._session.close()
         self._driver.close()
@@ -119,3 +119,10 @@ class SessionRunDisconnected(unittest.TestCase):
             expectedStep = "after run"
         self.assertEqual(step, expectedStep)
 
+    def get_vars(self):
+        return {
+            "#EXTRA_HELLO_PARAMS#": self.get_extra_hello_props()
+        }
+
+    def get_extra_hello_props(self):
+        return ', "realm": "", "ticket": ""' if self._driverName in ["javascript"] else ""

--- a/tests/stub/iteration.py
+++ b/tests/stub/iteration.py
@@ -95,31 +95,31 @@ class SessionRun(unittest.TestCase):
 
     # Last fetched batch is a full batch
     def test_full_batch(self):
-        if get_driver_name() not in ['go', 'dotnet']:
+        if get_driver_name() not in ['go', 'dotnet', 'javascript']:
             self.skipTest("Need support for specifying session fetch size in testkit backend")
         self._run(2, SessionRun.script_pull_n, SessionRun.end_full_batch, ["1", "2", "3", "4", "5", "6"])
 
     # Last fetched batch is half full (or more important not full)
     def test_half_batch(self):
-        if get_driver_name() not in ['go', 'dotnet']:
+        if get_driver_name() not in ['go', 'dotnet', 'javascript']:
             self.skipTest("Need support for specifying session fetch size in testkit backend")
         self._run(2, SessionRun.script_pull_n, SessionRun.end_half_batch, ["1", "2", "3", "4", "5"])
 
     # Last fetched batch is empty
     def test_empty_batch(self):
-        if get_driver_name() not in ['go', 'dotnet']:
+        if get_driver_name() not in ['go', 'dotnet', 'javascript']:
             self.skipTest("Need support for specifying session fetch size in testkit backend")
         self._run(2, SessionRun.script_pull_n, SessionRun.end_empty_batch, ["1", "2", "3", "4"])
 
     # Last batch returns an error
     def test_error(self):
-        if get_driver_name() not in ['go', 'dotnet']:
+        if get_driver_name() not in ['go', 'dotnet', 'javascript']:
             self.skipTest("Need support for specifying session fetch size in testkit backend")
         self._run(2, SessionRun.script_pull_n, SessionRun.end_error, ["1", "2", "3", "4", "5"], expectedError=True)
 
     # Support -1, not batched at all
     def test_all(self):
-        if get_driver_name() not in ['go', 'dotnet']:
+        if get_driver_name() not in ['go', 'dotnet', 'javascript']:
             self.skipTest("Need support for specifying session fetch size in testkit backend")
         self._run(-1, SessionRun.script_pull_all, "", ["1", "2", "3", "4", "5", "6"])
 
@@ -180,7 +180,7 @@ class TxRun(unittest.TestCase):
         self.assertEqual(expectedError, gotError)
 
     def test_all(self):
-        if get_driver_name() not in ['go', 'dotnet']:
+        if get_driver_name() not in ['go', 'dotnet', 'javascript']:
             self.skipTest("Need support for specifying session fetch size in testkit backend")
         self._iterate(2, TxRun.script_n, [1, 2, 3])
 

--- a/tests/stub/sessionparameters.py
+++ b/tests/stub/sessionparameters.py
@@ -116,7 +116,7 @@ class SessionRunParameters(unittest.TestCase):
             session.close()
 
     def test_accessmode_read(self):
-        if self._driverName not in ["go", "java", "dotnet"]:
+        if self._driverName not in ["go", "java", "dotnet", "javascript"]:
             self.skipTest("Session accessmode not implemented in backend")
 
         self._server.start(script=script_accessmode_read)
@@ -131,7 +131,7 @@ class SessionRunParameters(unittest.TestCase):
         self._server.done()
 
     def test_bookmarks(self):
-        if self._driverName not in ["go", "dotnet"]:
+        if self._driverName not in ["go", "dotnet", "javascript"]:
             self.skipTest("Session bookmarks not implemented in backend")
         self._server.start(script=script_bookmarks)
         self._run("w", bookmarks=["b1", "b2"])
@@ -139,7 +139,7 @@ class SessionRunParameters(unittest.TestCase):
         self._server.done()
 
     def test_txmeta(self):
-        if self._driverName not in ["go", "dotnet"]:
+        if self._driverName not in ["go", "dotnet", "javascript"]:
             self.skipTest("Session txmeta not implemented in backend")
         self._server.start(script=script_txmeta)
         self._run("w", txMeta={"akey": "aval"})
@@ -147,7 +147,7 @@ class SessionRunParameters(unittest.TestCase):
         self._server.done()
 
     def test_timeout(self):
-        if self._driverName not in ["go", "dotnet"]:
+        if self._driverName not in ["go", "dotnet", "javascript"]:
             self.skipTest("Session timeout not implemented in backend")
         self._server.start(script=script_timeout)
         self._run("w", timeout=17)
@@ -155,7 +155,7 @@ class SessionRunParameters(unittest.TestCase):
         self._server.done()
 
     def test_combined(self):
-        if self._driverName not in ["go", "dotnet"]:
+        if self._driverName not in ["go", "dotnet", "javascript"]:
             self.skipTest("Session parameters not implemented in backend")
         self._server.start(script=script_combined)
         self._run("r", params={"p": types.CypherInt(1)}, bookmarks=["b0"], txMeta={"k": "v"}, timeout=11)

--- a/tests/stub/txparameters.py
+++ b/tests/stub/txparameters.py
@@ -130,7 +130,7 @@ class TxBeginParameters(unittest.TestCase):
             session.close()
 
     def test_accessmode_read(self):
-        if self._driverName not in ["dotnet", "go"]:
+        if self._driverName not in ["dotnet", "go", "javascript"]:
             self.skipTest("Tx begin accessmode not implemented in backend")
         self._server.start(script=script_accessmode_read)
         self._run("r")
@@ -138,7 +138,7 @@ class TxBeginParameters(unittest.TestCase):
         self._server.done()
 
     def test_accessmode_write(self):
-        if self._driverName not in ["dotnet", "go"]:
+        if self._driverName not in ["dotnet", "go", "javascript"]:
             self.skipTest("Tx begin accessmode not implemented in backend")
         self._server.start(script=script_accessmode_write)
         self._run("w")
@@ -146,7 +146,7 @@ class TxBeginParameters(unittest.TestCase):
         self._server.done()
 
     def test_bookmarks(self):
-        if self._driverName not in ["dotnet", "go"]:
+        if self._driverName not in ["dotnet", "go", "javascript"]:
             self.skipTest("Tx begin bookmarks not implemented in backend")
         self._server.start(script=script_bookmarks)
         self._run("w", bookmarks=["b1", "b2"])
@@ -154,7 +154,7 @@ class TxBeginParameters(unittest.TestCase):
         self._server.done()
 
     def test_txmeta(self):
-        if self._driverName not in ["dotnet", "go"]:
+        if self._driverName not in ["dotnet", "go", "javascript"]:
             self.skipTest("Tx begin meta not implemented in backend")
         self._server.start(script=script_txmeta)
         self._run("w", txMeta={"akey": "aval"})
@@ -162,7 +162,7 @@ class TxBeginParameters(unittest.TestCase):
         self._server.done()
 
     def test_timeout(self):
-        if self._driverName not in ["dotnet", "go"]:
+        if self._driverName not in ["dotnet", "go", "javascript"]:
             self.skipTest("Tx begin timeout not implemented in backend")
         self._server.start(script=script_timeout)
         self._run("w", timeout=17)
@@ -170,7 +170,7 @@ class TxBeginParameters(unittest.TestCase):
         self._server.done()
 
     def test_combined(self):
-        if self._driverName not in ["dotnet", "go"]:
+        if self._driverName not in ["dotnet", "go", "javascript"]:
             self.skipTest("Tx begin params not implemented in backend")
         self._server.start(script=script_combined)
         self._run("r", params={"p": types.CypherInt(1)}, bookmarks=["b0"], txMeta={"k": "v"}, timeout=11)


### PR DESCRIPTION
`iteration.TxRun.test_nested` was not enabled because it's failing given a different behaviour in JS.
`retry.TestRetry.test_disconnect_on_commit` was not enabled because the JS driver is retrying when service is unavailable,
this behaviour should be verified on the 4.3 release.