### PR TITLE
Enable integration, stress and browser tests for javascript (#22)

### DIFF
--- a/driver/javascript/integration.py
+++ b/driver/javascript/integration.py
@@ -1,4 +1,11 @@
+import subprocess, os
+
+def run(args):
+    subprocess.run(
+        args, universal_newlines=True, stderr=subprocess.STDOUT, check=True)
 
 if __name__ == "__main__":
-    print("Integration tests not ported to testkit")
+    os.environ["TEST_NEO4J_IPV6_ENABLED"] = "False"
+    run(["gulp", "test-browser"])
+    run(["gulp", "test-nodejs-integration"])
 

--- a/driver/javascript/stress.py
+++ b/driver/javascript/stress.py
@@ -1,4 +1,9 @@
+import subprocess, os
+
+def run(args):
+    subprocess.run(
+        args, universal_newlines=True, stderr=subprocess.STDOUT, check=True)
 
 if __name__ == "__main__":
-    print("Stress tests not ported to testkit")
+    run(["gulp", "run-stress-tests"])
 

--- a/driver/javascript/unittests.py
+++ b/driver/javascript/unittests.py
@@ -12,4 +12,4 @@ def run(args):
 
 if __name__ == "__main__":
     run(["gulp", "test-nodejs-unit"])
-    #run(["gulp", "test-browser"])
+    run(["gulp", "run-ts-declaration-tests"])


### PR DESCRIPTION
The ipv6 support flag is necessary to skip the ipv6 tests when it is not supported.