### PR TITLE
Add support to the extended handshake

### DIFF
--- a/boltstub/__main__.py
+++ b/boltstub/__main__.py
@@ -76,9 +76,9 @@ useful for Bolt client integration testing.
     if service.exceptions:
         for error in service.exceptions:
             extra = ""
-            if error.script.filename:
+            if hasattr(error, 'script') and error.script.filename:
                 extra += " in {!r}".format(error.script.filename)
-            if error.line_no:
+            if hasattr(error, 'line_no') and error.line_no:
                 extra += " at line {}".format(error.line_no)
             print("Script mismatch{}:\n{}".format(extra, error))
         exit(1)

--- a/tests/stub/versions.py
+++ b/tests/stub/versions.py
@@ -34,7 +34,8 @@ class ProtocolVersions(unittest.TestCase):
         self._server.start(script=script,
                            vars={"#VERSION#": version, "#PULL#": pull})
         session = driver.session("w", fetchSize=1000)
-        session.run("RETURN 1 AS n")
+        result = session.run("RETURN 1 AS n")
+        record = result.next() # otherwise the script will not fail when the protocol is not present
         session.close()
         driver.close()
 
@@ -43,6 +44,11 @@ class ProtocolVersions(unittest.TestCase):
 
     def test_supports_bolt_4x1(self):
         self._run("4.1")
+
+    def test_supports_bolt_4x2(self):
+        if get_driver_name() not in ['javascript']:
+            self.skipTest("Does not supports extended handshake")
+        self._run("4.2")
 
     def test_supports_bolt_4x3(self):
         if get_driver_name() in ['java']:


### PR DESCRIPTION
* [x] Treat 4.2 as a separated protocol, this way given an error when it is not sent in the handshake
* [x] Fix the error message build (to not get error when it is missing script and other properties)
* [x] Create a test to check if the driver implements the version 4.2
* [x] Accept/implement the new extend handshake format
* [x] Make the test fail properly when the version is not there