### PR TITLE
Initial support for starting and running tests on clusters

### DIFF
--- a/driver/go/stress.py
+++ b/driver/go/stress.py
@@ -3,16 +3,22 @@ Executed in Go driver container.
 Responsible for running stress tests.
 Assumes driver has been setup by build script prior to this.
 """
-import os, subprocess, sys
+import os
+import subprocess
 
 root_package = "github.com/neo4j/neo4j-go-driver"
+
 
 def run(args):
     subprocess.run(
         args, universal_newlines=True, stderr=subprocess.STDOUT, check=True)
 
+
 if __name__ == "__main__":
-    uri = "%s://%s:%s" % (os.environ["TEST_NEO4J_SCHEME"], os.environ["TEST_NEO4J_HOST"], os.environ["TEST_NEO4J_PORT"])
+    uri = "%s://%s:%s" % (
+            os.environ["TEST_NEO4J_SCHEME"],
+            os.environ["TEST_NEO4J_HOST"],
+            os.environ["TEST_NEO4J_PORT"])
     user = os.environ["TEST_NEO4J_USER"]
     password = os.environ["TEST_NEO4J_PASS"]
 
@@ -20,4 +26,8 @@ if __name__ == "__main__":
     os.environ["GOPATH"] = "/home/build"
     run(["go", "install", "-v", "--race", root_package + "/test-stress"])
     # Run the stress tests
-    run(["/home/build/bin/test-stress", "-uri", uri, "-user", user, "-password", password])
+    cmd = ["/home/build/bin/test-stress", "-uri", uri,
+           "-user", user, "-password", password]
+    if os.environ.get("TEST_NEO4J_IS_CLUSTER"):
+        cmd.append("-cluster")
+    run(cmd)


### PR DESCRIPTION
No tests are actually running against the started 4.2 cluster since no
driver works 100% in the current setup. More work needed to fix tests in
the different drivers and enable different sets of tests against the
cluster.