### PR TITLE
Make it possible to setup testkit in driver repo

### DIFF
--- a/driver/README
+++ b/driver/README
@@ -3,3 +3,25 @@ Scripts in this folder will be executed within all driver Docker images.
 Scripts within the specifiec driver folders will be executed within that specific driver
 Docker image.
 
+Within the driver specific driver image the following mounts exists when scripts
+are executed:
+/testkit   - the testkit repository.
+/driver    - the driver repository.
+/artifacts - location where driver can put artifacts like logs when running
+             tests.
+
+Order of scripts can be assumed the following:
+1. build.py
+2. unittests.py
+3. backend.py
+4. stress.py/integration.py in any order and multiple times. The following
+   environment variables exists when these scripts execute:
+        TEST_NEO4J_HOST    - Hostname or IP address of running Neo4j 
+        TEST_NEO4J_USER    - Username needed to connect running Neo4j
+        TEST_NEO4J_PASS    - Password used to connect to running Neo4j
+        TEST_NEO4J_SCHEME  - "neo4j", "bolt", "neo4j+ssc", ...
+        TEST_NEO4J_PORT    - Port that Neo4j is listening on like "7687"
+        TEST_NEO4J_EDITION - "enterprise" or "community"
+        TEST_NEO4J_VERSION - Version of running Neo4j like "4.2"
+   If TEST_NEO4J_IS_CLUSTER exists then the tests are running against a
+   cluster.

--- a/main.py
+++ b/main.py
@@ -28,20 +28,17 @@ def cleanup():
                        stderr=subprocess.DEVNULL)
 
 
-def ensure_driver_image(root_path, branch_name, driver_name):
+def ensure_driver_image(root_path, driver_glue_path, branch_name, driver_name):
     """ Ensures that an up to date Docker image exists for the driver.
     """
     # Construct Docker image name from driver name (i.e drivers-go) and
     # branch name (i.e 4.2, go-1.14-image)
     image_name = "drivers-%s:%s" % (driver_name, branch_name)
-    # Context path is the Docker build context, all files added/copied to the
-    # driver image needs to be here.
-    context_path = os.path.join(root_path, "driver", driver_name)
     # Copy CAs that the driver should know of to the Docker build context
     # (first remove any previous...). Each driver container should contain
     # those CAs in such a way that driver language can use them as system
     # CAs without any custom modification of the driver.
-    cas_path = os.path.join(context_path, "CAs")
+    cas_path = os.path.join(driver_glue_path, "CAs")
     shutil.rmtree(cas_path, ignore_errors=True)
     cas_source_path = os.path.join(root_path, "tests", "tls",
                                    "certs", "driver")
@@ -49,9 +46,9 @@ def ensure_driver_image(root_path, branch_name, driver_name):
 
     # This will use the driver folder as build context.
     print("Building driver Docker image %s from %s"
-          % (image_name, context_path))
+          % (image_name, driver_glue_path))
     subprocess.check_call([
-        "docker", "build", "--tag", image_name, context_path])
+        "docker", "build", "--tag", image_name, driver_glue_path])
 
     print("Checking for dangling intermediate images")
     images = subprocess.check_output([
@@ -65,10 +62,40 @@ def ensure_driver_image(root_path, branch_name, driver_name):
     return image_name
 
 
+def ensure_runner_image(root_path, testkitBranch):
+    # Use Go driver image for this since we need to build TLS server and
+    # use that in the runner.
+    # TODO: Use a dedicated Docker image for this.
+    return ensure_driver_image(
+            root_path, os.path.join(root_path, "driver", "go"),
+            testkitBranch, "go")
+
+
+def get_driver_glue(thisPath, driverName, driverRepo):
+    """ Locates where driver has it's docker image and Python "glue" scripts
+    needed to build and run tests for the driver.
+    Returns a tuple consisting of the absolute path on this machine along with
+    the path as it will be mounted in the driver container.
+    """
+    in_driver_repo = os.path.join(driverRepo, "testkit")
+    if os.path.isdir(in_driver_repo):
+        return (in_driver_repo, "/driver/testkit")
+
+    in_this_repo = os.path.join(thisPath, "driver", driverName)
+    if os.path.isdir(in_this_repo):
+        return (in_this_repo, "/testkit/driver/%s" % driverName)
+
+    raise Exception("No glue found for %s" % driverName)
+
+
 def main(thisPath, driverName, testkitBranch, driverRepo):
-    driverImage = ensure_driver_image(thisPath, testkitBranch, driverName)
-    if not driverImage:
-        sys.exit(1)
+    # Path where scripts are that adapts driver to testkit.
+    # Both absolute path and path relative to driver container.
+    absGlue, driverGlue = get_driver_glue(
+            thisPath, driverName, driverRepo)
+
+    driverImage = ensure_driver_image(thisPath, absGlue,
+                                      testkitBranch, driverName)
 
     # Prepare collecting of artifacts, collected to ./artifcats/
     artifactsPath = os.path.abspath(os.path.join(".", "artifacts"))
@@ -119,7 +146,7 @@ def main(thisPath, driverName, testkitBranch, driverRepo):
     # Build the driver and it's testkit backend
     print("Build driver and test backend in driver container")
     driverContainer.exec(
-            ["python3", "/testkit/driver/%s/build.py" % driverName],
+            ["python3", os.path.join(driverGlue, "build.py")],
             envMap=driverEnv)
     print("Finished building driver and test backend")
 
@@ -128,7 +155,7 @@ def main(thisPath, driverName, testkitBranch, driverRepo):
     """
     begin_test_suite('Unit tests')
     driverContainer.exec(
-            ["python3", "/testkit/driver/%s/unittests.py" % driverName],
+            ["python3", os.path.join(driverGlue, "unittests.py")],
             envMap=driverEnv)
     end_test_suite('Unit tests')
 
@@ -152,9 +179,7 @@ def main(thisPath, driverName, testkitBranch, driverRepo):
     print("Started test backend")
 
     # Start runner container, responsible for running the unit tests.
-    # Use Go driver image for this since we need to build TLS server and
-    # use that in the runner.
-    runnerImage = ensure_driver_image(thisPath, testkitBranch, "go")
+    runnerImage = ensure_runner_image(thisPath, testkitBranch)
     runnerEnv = {
         "PYTHONPATH": "/testkit",  # To use modules
     }
@@ -341,7 +366,7 @@ def main(thisPath, driverName, testkitBranch, driverRepo):
         if not cluster or driverName in ['go', 'javascript']:
             print("Building and running stress tests...")
             driverContainer.exec([
-                "python3", "/testkit/driver/%s/stress.py" % driverName],
+                "python3", os.path.join(driverGlue, "stress.py")],
                 envMap=driverEnv)
         else:
             print("Skipping stress tests for %s" % serverName)
@@ -353,7 +378,7 @@ def main(thisPath, driverName, testkitBranch, driverRepo):
         if not cluster or driverName in []:
             print("Building and running integration tests...")
             driverContainer.exec([
-                "python3", "/testkit/driver/%s/integration.py" % driverName],
+                "python3", os.path.join(driverGlue, "integration.py")],
                 envMap=driverEnv)
         else:
             print("Skipping integration tests for %s" % serverName)


### PR DESCRIPTION
If driver contains a testkit directory, that directory will be used for
invoking python scripts that builds and runs tests instead of the one in
driver/<driver name>.