### PR TITLE
Migrating tests from Java Driver

### DIFF
--- a/nutkit/frontend/driver.py
+++ b/nutkit/frontend/driver.py
@@ -4,13 +4,23 @@ from .session import Session
 
 
 class Driver:
-    def __init__(self, backend, uri, authToken, userAgent=None):
+    """
+    At present, the resolverFn is only supported in tx functions.
+    """
+    def __init__(self, backend, uri, authToken, userAgent=None, resolverFn=None):
         self._backend = backend
-        req = protocol.NewDriver(uri, authToken, userAgent=userAgent)
+        self._resolverFn = resolverFn
+        req = protocol.NewDriver(uri, authToken, userAgent=userAgent, resolverRegistered=resolverFn is not None)
         res = backend.sendAndReceive(req)
         if not isinstance(res, protocol.Driver):
             raise Exception("Should be driver")
         self._driver = res
+
+    def verifyConnectivity(self):
+        req = protocol.VerifyConnectivity(self._driver.id)
+        res = self._backend.sendAndReceive(req)
+        if not isinstance(res, protocol.Driver):
+            raise Exception("Should be driver")
 
     def close(self):
         req = protocol.DriverClose(self._driver.id)
@@ -26,4 +36,7 @@ class Driver:
         res = self._backend.sendAndReceive(req)
         if not isinstance(res, protocol.Session):
             raise Exception("Should be session")
-        return Session(self._backend, res)
+        return Session(self, self._backend, res)
+
+    def resolve(self, address):
+        return self._resolverFn(address)

--- a/nutkit/frontend/session.py
+++ b/nutkit/frontend/session.py
@@ -4,7 +4,8 @@ from .transaction import Transaction
 
 
 class Session:
-    def __init__(self, backend, session):
+    def __init__(self, driver, backend, session):
+        self._driver = driver
         self._backend = backend
         self._session = session
 
@@ -53,6 +54,9 @@ class Session:
                         errorId = e.id
                     self._backend.send(protocol.RetryableNegative(
                         self._session.id, errorId=errorId))
+            elif isinstance(res, protocol.ResolverResolutionRequired):
+                addresses = self._driver.resolve(res.address)
+                self._backend.send(protocol.ResolverResolutionCompleted(res.id, addresses))
             elif isinstance(res, protocol.RetryableDone):
                 return x
 

--- a/nutkit/protocol/requests.py
+++ b/nutkit/protocol/requests.py
@@ -22,13 +22,14 @@ class NewDriver:
     Backend should respond with a Driver response or an Error response.
     """
 
-    def __init__(self, uri, authToken, userAgent=None):
+    def __init__(self, uri, authToken, userAgent=None, resolverRegistered=False):
         # Neo4j URI to connect to
         self.uri = uri
         # Authorization token used by driver when connecting to Neo4j
         self.authorizationToken = authToken
         # Optional custom user agent string
         self.userAgent = userAgent
+        self.resolverRegistered = resolverRegistered
 
 
 class AuthorizationToken:
@@ -43,6 +44,25 @@ class AuthorizationToken:
         self.realm = realm
         self.ticket = ticket
 
+
+class VerifyConnectivity:
+    """ Request to verify connectivity on the driver
+    instance corresponding to the specified driver id.
+    Backend should respond with a Driver response or an Error response.
+    """
+
+    def __init__(self, driverId):
+        self.driverId = driverId
+
+class ResolverResolutionCompleted:
+    """ Pushes the results of the resolver function resolution back to the backend.
+    This must only be sent immediately after the backend requests a new address resolution
+    by replying with the ResolverResolutionRequired response.
+    """
+
+    def __init__(self, requestId, addresses):
+        self.requestId = requestId
+        self.addresses = addresses
 
 class DriverClose:
     """ Request to close the driver instance on the backend.
@@ -63,7 +83,7 @@ class NewSession:
 
     def __init__(self, driverId, accessMode, bookmarks=None,
                  database=None, fetchSize=None):
-        # Id of driver on backend that sessio should be created on
+        # Id of driver on backend that session should be created on
         self.driverId = driverId
         # Session accessmode: 'r' for read access and 'w' for write access.
         self.accessMode = accessMode

--- a/nutkit/protocol/responses.py
+++ b/nutkit/protocol/responses.py
@@ -30,6 +30,19 @@ class Driver:
         self.id = id
 
 
+class ResolverResolutionRequired:
+    """ Represents a need for new address resolution.
+    This means that the backend is expecting the frontend
+    to call the resolver function and submit a new request
+    with the results of it.
+    """
+
+    def __init__(self, id, address):
+        # Id of callback request
+        self.id = id
+        self.address = address
+
+
 class Session:
     """ Represents a session instance on the backend
     """

--- a/tests/stub/routing.py
+++ b/tests/stub/routing.py
@@ -612,7 +612,7 @@ class Routing(unittest.TestCase):
 
     def test_should_round_robin_readers_when_reading_using_session_run(self):
         # TODO remove this block once all languages work
-        if get_driver_name() in ['python']:
+        if get_driver_name() in ['python', 'go']:
             self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
@@ -634,7 +634,7 @@ class Routing(unittest.TestCase):
 
     def test_should_round_robin_readers_when_reading_using_tx_run(self):
         # TODO remove this block once all languages work
-        if get_driver_name() in ['python']:
+        if get_driver_name() in ['python', 'go']:
             self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
@@ -658,7 +658,7 @@ class Routing(unittest.TestCase):
 
     def test_should_fail_when_reading_from_unexpectedly_interrupting_reader_using_session_run(self):
         # TODO remove this block once all languages work
-        if get_driver_name() in ['python']:
+        if get_driver_name() in ['python', 'javascript', 'go']:
             self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
@@ -681,7 +681,7 @@ class Routing(unittest.TestCase):
 
     def test_should_fail_when_reading_from_unexpectedly_interrupting_reader_using_tx_run(self):
         # TODO remove this block once all languages work
-        if get_driver_name() in ['python']:
+        if get_driver_name() in ['python', 'go']:
             self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
@@ -753,7 +753,7 @@ class Routing(unittest.TestCase):
 
     def test_should_round_robin_writers_when_writing_using_session_run(self):
         # TODO remove this block once all languages work
-        if get_driver_name() in ['python']:
+        if get_driver_name() in ['python', 'go']:
             self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
@@ -772,7 +772,7 @@ class Routing(unittest.TestCase):
 
     def test_should_round_robin_writers_when_writing_using_tx_run(self):
         # TODO remove this block once all languages work
-        if get_driver_name() in ['python']:
+        if get_driver_name() in ['python', 'go']:
             self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
@@ -793,7 +793,7 @@ class Routing(unittest.TestCase):
 
     def test_should_fail_when_writing_on_unexpectedly_interrupting_writer_using_session_run(self):
         # TODO remove this block once all languages work
-        if get_driver_name() in ['python']:
+        if get_driver_name() in ['python', 'javascript', 'go']:
             self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
@@ -816,7 +816,7 @@ class Routing(unittest.TestCase):
 
     def test_should_fail_when_writing_on_unexpectedly_interrupting_writer_using_tx_run(self):
         # TODO remove this block once all languages work
-        if get_driver_name() in ['python']:
+        if get_driver_name() in ['python', 'go']:
             self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
@@ -902,7 +902,7 @@ class Routing(unittest.TestCase):
 
     def test_should_fail_when_writing_without_explicit_consumption_on_writer_that_returns_not_a_leader_code(self):
         # TODO remove this block once all languages work
-        if get_driver_name() in ['python']:
+        if get_driver_name() in ['python', 'javascript', 'go']:
             self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
@@ -925,7 +925,7 @@ class Routing(unittest.TestCase):
 
     def test_should_fail_when_writing_on_writer_that_returns_not_a_leader_code_using_tx_run(self):
         # TODO remove this block once all languages work
-        if get_driver_name() in ['dotnet']:
+        if get_driver_name() in ['dotnet', 'go']:
             self.skipTest("consume not implemented in backend")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
@@ -950,7 +950,7 @@ class Routing(unittest.TestCase):
     def test_should_fail_when_writing_without_explicit_consumption_on_writer_that_returns_not_a_leader_code_using_tx_run(
             self):
         # TODO remove this block once all languages work
-        if get_driver_name() in ['python']:
+        if get_driver_name() in ['python', 'go']:
             self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
@@ -1010,6 +1010,9 @@ class Routing(unittest.TestCase):
         self.assertEqual(["NewBookmark"], last_bookmarks)
 
     def test_should_pass_bookmark_from_tx_to_tx_using_tx_run(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['javascript']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_read_tx_script_with_bookmark(), vars=self.get_vars())
@@ -1093,7 +1096,7 @@ class Routing(unittest.TestCase):
 
     def test_should_retry_read_tx_and_rediscovery_until_success(self):
         # TODO remove this block once all languages work
-        if get_driver_name() in ['dotnet', 'python']:
+        if get_driver_name() in ['dotnet', 'python', 'javascript', 'go']:
             self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_another_router(), vars=self.get_vars())
@@ -1126,7 +1129,7 @@ class Routing(unittest.TestCase):
 
     def test_should_retry_write_tx_and_rediscovery_until_success(self):
         # TODO remove this block once all languages work
-        if get_driver_name() in ['dotnet', 'python']:
+        if get_driver_name() in ['dotnet', 'python', 'javascript', 'go']:
             self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_another_router(), vars=self.get_vars())
@@ -1226,7 +1229,7 @@ class Routing(unittest.TestCase):
 
     def test_should_serve_reads_and_fail_writes_when_no_writers_available(self):
         # TODO remove this block once all languages work
-        if get_driver_name() in ['dotnet', 'python']:
+        if get_driver_name() in ['dotnet', 'python', 'go']:
             self.skipTest("consume not implemented in backend or requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_empty_writers(), vars=self.get_vars())
@@ -1289,7 +1292,7 @@ class Routing(unittest.TestCase):
 
     def test_should_accept_routing_table_with_single_router(self):
         # TODO remove this block once all languages work
-        if get_driver_name() in ['python']:
+        if get_driver_name() in ['python', 'go']:
             self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
@@ -1332,7 +1335,7 @@ class Routing(unittest.TestCase):
 
     def test_should_forget_address_on_database_unavailable_error(self):
         # TODO remove this block once all languages work
-        if get_driver_name() in ['dotnet', 'python']:
+        if get_driver_name() in ['dotnet', 'python', 'go']:
             self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_one_writer(), vars=self.get_vars())

--- a/tests/stub/routing.py
+++ b/tests/stub/routing.py
@@ -611,6 +611,9 @@ class Routing(unittest.TestCase):
         self.assertEqual([[1]], sequences)
 
     def test_should_round_robin_readers_when_reading_using_session_run(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_script(), vars=self.get_vars())
@@ -630,6 +633,9 @@ class Routing(unittest.TestCase):
         self.assertEqual([[1], [1]], sequences)
 
     def test_should_round_robin_readers_when_reading_using_tx_run(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_tx_script(), vars=self.get_vars())
@@ -651,6 +657,9 @@ class Routing(unittest.TestCase):
         self.assertEqual([[1], [1]], sequences)
 
     def test_should_fail_when_reading_from_unexpectedly_interrupting_reader_using_session_run(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_script_with_unexpected_interruption(), vars=self.get_vars())
@@ -671,6 +680,9 @@ class Routing(unittest.TestCase):
         self.assertTrue(failed)
 
     def test_should_fail_when_reading_from_unexpectedly_interrupting_reader_using_tx_run(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_tx_script_with_unexpected_interruption(), vars=self.get_vars())
@@ -740,6 +752,9 @@ class Routing(unittest.TestCase):
         self._writeServer1.done()
 
     def test_should_round_robin_writers_when_writing_using_session_run(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_script(), vars=self.get_vars())
@@ -756,6 +771,9 @@ class Routing(unittest.TestCase):
         self._writeServer2.done()
 
     def test_should_round_robin_writers_when_writing_using_tx_run(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script(), vars=self.get_vars())
@@ -774,6 +792,9 @@ class Routing(unittest.TestCase):
         self._writeServer2.done()
 
     def test_should_fail_when_writing_on_unexpectedly_interrupting_writer_using_session_run(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_script_with_unexpected_interruption(), vars=self.get_vars())
@@ -794,6 +815,9 @@ class Routing(unittest.TestCase):
         self.assertTrue(failed)
 
     def test_should_fail_when_writing_on_unexpectedly_interrupting_writer_using_tx_run(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script_with_unexpected_interruption(), vars=self.get_vars())
@@ -852,7 +876,8 @@ class Routing(unittest.TestCase):
         self.assertTrue(failed)
 
     def test_should_fail_when_writing_on_writer_that_returns_not_a_leader_code(self):
-        if get_driver_name() not in ['java']:
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['dotnet']:
             self.skipTest("consume not implemented in backend")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
@@ -874,6 +899,9 @@ class Routing(unittest.TestCase):
         self.assertTrue(failed)
 
     def test_should_fail_when_writing_without_explicit_consumption_on_writer_that_returns_not_a_leader_code(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_script_with_not_a_leader_failure(), vars=self.get_vars())
@@ -894,7 +922,8 @@ class Routing(unittest.TestCase):
         self.assertTrue(failed)
 
     def test_should_fail_when_writing_on_writer_that_returns_not_a_leader_code_using_tx_run(self):
-        if get_driver_name() not in ['java']:
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['dotnet']:
             self.skipTest("consume not implemented in backend")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
@@ -918,6 +947,9 @@ class Routing(unittest.TestCase):
 
     def test_should_fail_when_writing_without_explicit_consumption_on_writer_that_returns_not_a_leader_code_using_tx_run(
             self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script_with_not_a_leader_failure(), vars=self.get_vars())
@@ -1000,6 +1032,9 @@ class Routing(unittest.TestCase):
         self.assertEqual(["BookmarkC"], second_bookmark)
 
     def test_should_retry_read_tx_until_success(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['dotnet', 'python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_tx_script_with_unexpected_interruption(), vars=self.get_vars())
@@ -1026,6 +1061,9 @@ class Routing(unittest.TestCase):
         self.assertEqual(2, try_count)
 
     def test_should_retry_write_tx_until_success(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['dotnet', 'python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script_with_unexpected_interruption(), vars=self.get_vars())
@@ -1052,6 +1090,9 @@ class Routing(unittest.TestCase):
         self.assertEqual(2, try_count)
 
     def test_should_retry_read_tx_and_rediscovery_until_success(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['dotnet', 'python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_another_router(), vars=self.get_vars())
         self._routingServer2.start(script=self.router_script(), vars=self.get_vars())
@@ -1082,6 +1123,9 @@ class Routing(unittest.TestCase):
         self.assertEqual(3, try_count)
 
     def test_should_retry_write_tx_and_rediscovery_until_success(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['dotnet', 'python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_another_router(), vars=self.get_vars())
         self._routingServer2.start(script=self.router_script(), vars=self.get_vars())
@@ -1135,6 +1179,9 @@ class Routing(unittest.TestCase):
         self.assertEqual([[1]], sequences)
 
     def test_should_successfully_read_from_readable_router_using_tx_function(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_reader_support(), vars=self.get_vars())
 
@@ -1153,6 +1200,9 @@ class Routing(unittest.TestCase):
         self.assertEqual([[1]], sequences)
 
     def test_should_send_empty_hello(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, "neo4j://%s" % self._routingServer1.address, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_empty_context_and_reader_support(), vars=self.get_vars())
 
@@ -1171,8 +1221,9 @@ class Routing(unittest.TestCase):
         self.assertEqual([[1]], sequences)
 
     def test_should_serve_reads_and_fail_writes_when_no_writers_available(self):
-        if get_driver_name() not in ['java']:
-            self.skipTest("consume not implemented in backend")
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['dotnet', 'python']:
+            self.skipTest("consume not implemented in backend or requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_empty_writers(), vars=self.get_vars())
         self._routingServer2.start(script=self.router_script_with_empty_writers(), vars=self.get_vars())
@@ -1232,6 +1283,9 @@ class Routing(unittest.TestCase):
         self.assertEqual([[1]], sequences)
 
     def test_should_accept_routing_table_with_single_router(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_script(), vars=self.get_vars())
@@ -1272,6 +1326,9 @@ class Routing(unittest.TestCase):
         self.assertEqual(["neo4j:bookmark:v1:tx95"], last_bookmarks)
 
     def test_should_forget_address_on_database_unavailable_error(self):
+        # TODO remove this block once all languages work
+        if get_driver_name() in ['dotnet', 'python']:
+            self.skipTest("requires investigation")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_one_writer(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script_with_database_unavailable_failure(), vars=self.get_vars())
@@ -1709,7 +1766,7 @@ class RoutingV3(Routing):
         !: BOLT #VERSION#
         !: AUTO RESET
         !: AUTO GOODBYE
-        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007" #EXTRA_HELLO_PROPS# , "routing": {"address": "#HOST#:9000"}}
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007" #EXTRA_HELLO_PROPS# #EXTR_HELLO_ROUTING_PROPS_EMPTY_CTX#}
         S: SUCCESS {"server": "Neo4j/3.5.0", "connection_id": "bolt-123456789"}
         C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {"address": "#HOST#:9000"}} {#ROUTINGMODE#}
         C: PULL_ALL
@@ -2048,6 +2105,7 @@ class RoutingV3(Routing):
             "#ROUTINGCTX#": '{"address": "' + host + ':9000", "region": "china", "policy": "my_policy"}',
             "#EXTRA_HELLO_PROPS#": get_extra_hello_props(),
             "#EXTR_HELLO_ROUTING_PROPS#": "",
+            "#EXTR_HELLO_ROUTING_PROPS_EMPTY_CTX#": ""
         }
 
         if get_driver_name() in ['go']:
@@ -2055,6 +2113,7 @@ class RoutingV3(Routing):
 
         if get_driver_name() in ['java']:
             v["#EXTR_HELLO_ROUTING_PROPS#"] = ', "routing": ' + v['#ROUTINGCTX#']
+            v["#EXTR_HELLO_ROUTING_PROPS_EMPTY_CTX#"] = ', "routing": {"address": "' + host + ':9000"}'
 
         if get_driver_name() in ['javascript']:
             v["#ROUTINGCTX#"] = '{"region": "china", "policy": "my_policy"}'

--- a/tests/stub/routing.py
+++ b/tests/stub/routing.py
@@ -840,7 +840,8 @@ class Routing(unittest.TestCase):
         self.assertTrue(failed)
 
     def test_should_fail_discovery_when_router_fails_with_procedure_not_found_code(self):
-        if get_driver_name() not in ['java']:
+        # TODO add support and remove this block
+        if get_driver_name() in ['python', 'javascript', 'go', 'dotnet']:
             self.skipTest("verifyConnectivity not implemented in backend")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_procedure_not_found_failure(), vars=self.get_vars())
@@ -858,7 +859,8 @@ class Routing(unittest.TestCase):
         self.assertTrue(failed)
 
     def test_should_fail_discovery_when_router_fails_with_unknown_code(self):
-        if get_driver_name() not in ['java']:
+        # TODO add support and remove this block
+        if get_driver_name() in ['python', 'javascript', 'go', 'dotnet']:
             self.skipTest("verifyConnectivity not implemented in backend")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_unknown_failure(), vars=self.get_vars())
@@ -1156,7 +1158,8 @@ class Routing(unittest.TestCase):
         self.assertEqual(3, try_count)
 
     def test_should_use_initial_router_for_discovery_when_others_unavailable(self):
-        if get_driver_name() not in ['java']:
+        # TODO add support and remove this block
+        if get_driver_name() in ['python', 'javascript', 'go', 'dotnet']:
             self.skipTest("verifyConnectivity not implemented in backend")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_another_router(), vars=self.get_vars())
@@ -1204,7 +1207,8 @@ class Routing(unittest.TestCase):
         if get_driver_name() in ['python']:
             self.skipTest("requires investigation")
         driver = Driver(self._backend, "neo4j://%s" % self._routingServer1.address, self._auth, self._userAgent)
-        self._routingServer1.start(script=self.router_script_with_empty_context_and_reader_support(), vars=self.get_vars())
+        self._routingServer1.start(script=self.router_script_with_empty_context_and_reader_support(),
+                                   vars=self.get_vars())
 
         session = driver.session('r', database=self.get_db())
         sequences = []
@@ -1255,7 +1259,8 @@ class Routing(unittest.TestCase):
         self.assertTrue(failed)
 
     def test_should_accept_routing_table_without_writers_and_then_rediscover(self):
-        if get_driver_name() not in ['java']:
+        # TODO add support and remove this block
+        if get_driver_name() in ['python', 'javascript', 'go', 'dotnet']:
             self.skipTest("verifyConnectivity not implemented in backend")
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_empty_writers(), vars=self.get_vars())
@@ -1357,7 +1362,8 @@ class Routing(unittest.TestCase):
         self.assertEqual(2, try_count)
 
     def test_should_use_resolver_during_rediscovery_when_existing_routers_fail(self):
-        if get_driver_name() not in ['java']:
+        # TODO add support and remove this block
+        if get_driver_name() in ['python', 'javascript', 'go', 'dotnet']:
             self.skipTest("resolver not implemented in backend")
         resolver_invoked = False
 
@@ -1394,14 +1400,16 @@ class Routing(unittest.TestCase):
         self.assertEqual([[1], [1]], sequences)
 
     def test_should_revert_to_initial_router_if_known_router_throws_protocol_errors(self):
-        if get_driver_name() not in ['java']:
+        # TODO add support and remove this block
+        if get_driver_name() in ['python', 'javascript', 'go', 'dotnet']:
             self.skipTest("resolver not implemented in backend")
 
         def resolver(address):
             return [self._routingServer1.address, self._routingServer3.address]
 
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent, resolver)
-        self._routingServer1.start(script=self.router_script_with_another_router_and_non_existent_reader(), vars=self.get_vars())
+        self._routingServer1.start(script=self.router_script_with_another_router_and_non_existent_reader(),
+                                   vars=self.get_vars())
         self._routingServer2.start(script=self.router_script_with_empty_response(), vars=self.get_vars())
         self._routingServer3.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_tx_script(), vars=self.get_vars())

--- a/tests/stub/routing.py
+++ b/tests/stub/routing.py
@@ -3,6 +3,7 @@ import unittest
 from tests.shared import get_driver_name, new_backend
 from tests.stub.shared import StubServer
 from nutkit.frontend import Driver, AuthorizationToken
+import nutkit.protocol as types
 
 
 def get_extra_hello_props():
@@ -19,19 +20,31 @@ def get_extra_hello_props():
 class Routing(unittest.TestCase):
     def setUp(self):
         self._backend = new_backend()
-        self._routingServer = StubServer(9001)
-        self._readServer = StubServer(9002)
-        self._writeServer = StubServer(9003)
-        self._uri = "neo4j://%s?region=china&policy=my_policy" % self._routingServer.address
+        self._routingServer1 = StubServer(9000)
+        self._routingServer2 = StubServer(9001)
+        self._routingServer3 = StubServer(9002)
+        self._readServer1 = StubServer(9010)
+        self._readServer2 = StubServer(9011)
+        self._readServer3 = StubServer(9012)
+        self._writeServer1 = StubServer(9020)
+        self._writeServer2 = StubServer(9021)
+        self._writeServer3 = StubServer(9022)
+        self._uri = "neo4j://%s?region=china&policy=my_policy" % self._routingServer1.address
         self._auth = AuthorizationToken(
-                scheme="basic", principal="p", credentials="c")
+            scheme="basic", principal="p", credentials="c")
         self._userAgent = "007"
 
     def tearDown(self):
         self._backend.close()
-        self._routingServer.reset()
-        self._readServer.reset()
-        self._writeServer.reset()
+        self._routingServer1.reset()
+        self._routingServer2.reset()
+        self._routingServer3.reset()
+        self._readServer1.reset()
+        self._readServer2.reset()
+        self._readServer3.reset()
+        self._writeServer1.reset()
+        self._writeServer2.reset()
+        self._writeServer3.reset()
 
     def router_script(self):
         return """
@@ -42,7 +55,52 @@ class Routing(unittest.TestCase):
         C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS#}
         S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
         C: ROUTE #ROUTINGCTX# "adb"
-        S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9002"], "role":"READ"}, {"addresses": ["#HOST#:9003"], "role":"WRITE"}]}}
+        S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9021"], "role":"WRITE"}]}}
+        """
+
+    def router_script_with_procedure_not_found_failure(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: ROUTE #ROUTINGCTX# "adb"
+        S: FAILURE {"code": "Neo.ClientError.Procedure.ProcedureNotFound", "message": "blabla"}
+        S: IGNORED
+        S: <EXIT>
+        """
+
+    def router_script_with_unknown_failure(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: ROUTE #ROUTINGCTX# "adb"
+        S: FAILURE {"code": "Neo.ClientError.General.Unknown", "message": "wut!"}
+        S: IGNORED
+        S: <EXIT>
+        """
+
+    def router_script_with_leader_change(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        
+        C: ROUTE #ROUTINGCTX# "adb"
+        S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9020"],"role": "WRITE"}, {"addresses": ["#HOST#:9006","#HOST#:9007"], "role": "READ"}, {"addresses": ["#HOST#:9000"], "role": "ROUTE"}]}}
+        C: ROUTE #ROUTINGCTX# "adb"
+        S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9020"],"role": "WRITE"}, {"addresses": ["#HOST#:9006","#HOST#:9007"], "role": "READ"}, {"addresses": ["#HOST#:9000"], "role": "ROUTE"}]}}
+        C: ROUTE #ROUTINGCTX# "adb"
+        S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": [],"role": "WRITE"}, {"addresses": ["#HOST#:9006","#HOST#:9007"], "role": "READ"}, {"addresses": ["#HOST#:9000"], "role": "ROUTE"}]}}
+        C: ROUTE #ROUTINGCTX# "adb"
+        S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9021"],"role": "WRITE"}, {"addresses": ["#HOST#:9006","#HOST#:9007"], "role": "READ"}, {"addresses": ["#HOST#:9000"], "role": "ROUTE"}]}}
         """
 
     def router_script_default_db(self):
@@ -54,7 +112,131 @@ class Routing(unittest.TestCase):
         C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS#}
         S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
         C: ROUTE #ROUTINGCTX# None
-        S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9002"], "role":"READ"}, {"addresses": ["#HOST#:9003"], "role":"WRITE"}]}}
+        S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9021"], "role":"WRITE"}]}}
+        """
+
+    def router_script_with_another_router(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: ROUTE #ROUTINGCTX# "adb"
+        S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9012"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9022"], "role":"WRITE"}]}}
+        """
+
+    def router_script_with_reader_support(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: ROUTE #ROUTINGCTX# "adb"
+        S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9000", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9021"], "role":"WRITE"}]}}
+        C: BEGIN {"mode": "r", "db": "adb"}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL {"n": 1000}
+        S: SUCCESS {"fields": ["n"]}
+           RECORD [1]
+           SUCCESS {"type": "r"}
+        C: COMMIT
+        S: SUCCESS {}
+           <EXIT>
+        """
+
+    def router_script_with_context_and_reader_support(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: ROUTE #ROUTINGCTX# "adb"
+        S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9000", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9021"], "role":"WRITE"}]}}
+        C: BEGIN {"mode": "r", "db": "adb"}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL {"n": 1000}
+        S: SUCCESS {"fields": ["n"]}
+           RECORD [1]
+           SUCCESS {"type": "r"}
+        C: COMMIT
+        S: SUCCESS {}
+        """
+
+    def router_script_with_empty_context_and_reader_support(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": {"address": "#HOST#:9000"} #EXTRA_HELLO_PROPS#}
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: ROUTE {"address": "#HOST#:9000"} "adb"
+        S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9000", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9021"], "role":"WRITE"}]}}
+        C: BEGIN {"mode": "r", "db": "adb"}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL {"n": 1000}
+        S: SUCCESS {"fields": ["n"]}
+           RECORD [1]
+           SUCCESS {"type": "r"}
+        C: COMMIT
+        S: SUCCESS {}
+        """
+
+    def router_script_with_empty_writers(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: ROUTE #ROUTINGCTX# "adb"
+        S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": [], "role":"WRITE"}]}}
+        """
+
+    def router_script_with_one_writer(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: ROUTE #ROUTINGCTX# "adb"
+        S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020"], "role":"WRITE"}]}}
+        """
+
+    def router_script_with_another_router_and_non_existent_reader(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: ROUTE #ROUTINGCTX# "adb"
+        S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9099"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9021"], "role":"WRITE"}]}}
+        """
+
+    def router_script_with_empty_response(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: ROUTE #ROUTINGCTX# "adb"
+        S: SUCCESS { "rt": { "ttl": 1000, "servers": []}}
         """
 
     def read_script(self):
@@ -71,6 +253,18 @@ class Routing(unittest.TestCase):
            SUCCESS {"type": "r"}
         """
 
+    def read_script_with_unexpected_interruption(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+
+        C: RUN "RETURN 1 as n" {} {"mode": "r", "db": "adb"}
+        C: PULL {"n": 1000}
+        S: <EXIT>
+        """
+
     def read_tx_script(self):
         return """
         !: BOLT #VERSION#
@@ -83,9 +277,42 @@ class Routing(unittest.TestCase):
         C: RUN "RETURN 1 as n" {} {}
         C: PULL {"n": 1000}
         S: SUCCESS {"fields": ["n"]}
+           RECORD [1]
            SUCCESS {"type": "r"}
         C: COMMIT
         S: SUCCESS {}
+        """
+
+    def read_tx_script_with_bookmarks(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+
+        C: BEGIN {"mode": "r", "db": "adb", "bookmarks": ["OldBookmark"]}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL {"n": 1000}
+        S: SUCCESS {"fields": ["n"]}
+           RECORD [1]
+           SUCCESS {"type": "r"}
+        C: COMMIT
+        S: SUCCESS {"bookmark": "NewBookmark"}
+        """
+
+    def read_tx_script_with_unexpected_interruption(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+
+        C: BEGIN {"mode": "r", "db": "adb"}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL {"n": 1000}
+        S: <EXIT>
         """
 
     def write_script(self):
@@ -96,6 +323,32 @@ class Routing(unittest.TestCase):
         !: AUTO RESET
 
         C: RUN "RETURN 1 as n" {} {"db": "adb"}
+        C: PULL {"n": 1000}
+        S: SUCCESS {"fields": ["n"]}
+           RECORD [1]
+           SUCCESS {"type": "w"}
+        """
+
+    def write_script_with_unexpected_interruption(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+
+        C: RUN "RETURN 1 as n" {} {"db": "adb"}
+        C: PULL {"n": 1000}
+        S: <EXIT>
+        """
+
+    def write_script_with_bookmark(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+
+        C: RUN "RETURN 1 as n" {} {"db": "adb", "bookmarks": ["ABookmark"]}
         C: PULL {"n": 1000}
         S: SUCCESS {"fields": ["n"]}
            RECORD [1]
@@ -119,12 +372,151 @@ class Routing(unittest.TestCase):
         S: SUCCESS {}
         """
 
+    def write_tx_script_with_bookmarks(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+
+        C: BEGIN {"db": "adb", "bookmarks": ["OldBookmark"]}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL {"n": 1000}
+        S: SUCCESS {"fields": ["n"]}
+           SUCCESS {"type": "r"}
+        C: COMMIT
+        S: SUCCESS {"bookmark": "NewBookmark"}
+        """
+
+    def write_read_tx_script_with_bookmark(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+
+        C: BEGIN {"db": "adb", "bookmarks": ["BookmarkA"]}
+        S: SUCCESS {}
+        C: RUN "CREATE (n {name:'Bob'})" {} {}
+        C: PULL {"n": 1000}
+        S: SUCCESS {"fields": ["name"]}
+           SUCCESS {"type": "w"}
+        C: COMMIT
+        S: SUCCESS {"bookmark": "BookmarkB"}
+        C: BEGIN {"db": "adb", "bookmarks": ["BookmarkB"]}
+        S: SUCCESS {}
+        C: RUN "MATCH (n) RETURN n.name AS name" {} {}
+           PULL {"n": 1000}
+        S: SUCCESS {"fields": ["name"]}
+           RECORD ["Bob"]
+           SUCCESS {}
+        C: COMMIT
+        S: SUCCESS {"bookmark": "BookmarkC"}
+        """
+
+    def write_tx_script_with_unexpected_interruption(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+
+        C: BEGIN {"db": "adb"}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL {"n": 1000}
+        S: <EXIT>
+        """
+
+    def write_script_with_not_a_leader_failure(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+
+        C: RUN "RETURN 1 as n" {} {"db": "adb"}
+        C: PULL {"n": 1000}
+        S: FAILURE {"code": "Neo.ClientError.Cluster.NotALeader", "message": "blabla"}
+        S: IGNORED
+        C: RESET
+        S: SUCCESS {}
+        """
+
+    def write_tx_script_with_not_a_leader_failure(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+
+        C: BEGIN {"db": "adb"}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL {"n": 1000}
+        S: FAILURE {"code": "Neo.ClientError.Cluster.NotALeader", "message": "blabla"}
+        S: IGNORED
+        C: RESET
+        S: SUCCESS {}
+        """
+
+    def write_tx_script_with_database_unavailable_failure_on_commit(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+
+        C: BEGIN {"db": "adb"}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL {"n": 1000}
+        S: SUCCESS {"fields": ["n"]}
+           SUCCESS {"type": "r"}
+        C: COMMIT
+        S: FAILURE {"code": "Neo.TransientError.General.DatabaseUnavailable", "message": "Database shut down."}
+        S: <EXIT>
+        """
+
+    def write_tx_script_multiple_bookmarks(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+
+        C: BEGIN {"db": "adb", "bookmarks": ["neo4j:bookmark:v1:tx5", "neo4j:bookmark:v1:tx29", "neo4j:bookmark:v1:tx94", "neo4j:bookmark:v1:tx56", "neo4j:bookmark:v1:tx16", "neo4j:bookmark:v1:tx68"]}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL {"n": 1000}
+        S: SUCCESS {"fields": ["n"]}
+           SUCCESS {"type": "r"}
+        C: COMMIT
+        S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx95"}
+        """
+
+    def write_tx_script_with_database_unavailable_failure(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+
+        C: BEGIN {"db": "adb"}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL {"n": 1000}
+        S: FAILURE {"code": "Neo.TransientError.General.DatabaseUnavailable", "message": "Database is busy doing store copy"}
+        S: IGNORED
+        """
+
     def get_vars(self):
-        host = self._routingServer.host
+        host = self._routingServer1.host
         v = {
             "#VERSION#": "4.3",
             "#HOST#": host,
-            "#ROUTINGCTX#": '{"address": "' + host + ':9001", "region": "china", "policy": "my_policy"}',
+            "#ROUTINGCTX#": '{"address": "' + host + ':9000", "region": "china", "policy": "my_policy"}',
             "#EXTRA_HELLO_PROPS#": get_extra_hello_props(),
         }
         v["#HELLO_ROUTINGCTX#"] = v["#ROUTINGCTX#"]
@@ -137,82 +529,842 @@ class Routing(unittest.TestCase):
     def get_db(self):
         return "adb"
 
+    @staticmethod
+    def collectRecords(result):
+        sequence = []
+        while True:
+            next = result.next()
+            if isinstance(next, types.NullRecord):
+                break
+            sequence.append(next.values[0].value)
+        return sequence
+
     # Checks that routing is used to connect to correct server and that
     # parameters for session run is passed on to the target server
     # (not the router).
-    def test_session_run_read(self):
+    def test_should_read_successfully_from_reader_using_session_run(self):
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
-        self._routingServer.start(script=self.router_script(),
-                                  vars=self.get_vars())
-        self._readServer.start(script=self.read_script(), vars=self.get_vars())
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
-        session = driver.session('r', database=self.get_db())
-        session.run("RETURN 1 as n")
-        session.close()
-        driver.close()
-        self._routingServer.done()
-        self._readServer.done()
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._readServer1.start(script=self.read_script(), vars=self.get_vars())
 
-    def test_default_db(self):
-        vars = self.get_vars()
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
-        self._routingServer.start(script=self.router_script_default_db(),
-                                  vars=vars)
-        self._readServer.start(script=self.read_script(),
-                               vars=vars)
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
-        session = driver.session('r')
-        session.run("RETURN 1 as n")
+        session = driver.session('r', database=self.get_db())
+        result = session.run("RETURN 1 as n")
+        sequence = self.collectRecords(result)
         session.close()
         driver.close()
-        self._routingServer.done()
-        self._readServer.done()
+
+        self._routingServer1.done()
+        self._readServer1.done()
+        self.assertEqual([1], sequence)
+
+    def test_should_read_successfully_from_reader_using_session_run_with_default_db_driver(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script_default_db(), vars=self.get_vars())
+        self._readServer1.start(script=self.read_script(), vars=self.get_vars())
+
+        session = driver.session('r')
+        result = session.run("RETURN 1 as n")
+        sequence = self.collectRecords(result)
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._readServer1.done()
+        self.assertEqual([1], sequence)
 
     # Same test as for session.run but for transaction run.
-    def test_tx_run_read(self):
+    def test_should_read_successfully_from_reader_using_tx_run(self):
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
-        self._routingServer.start(script=self.router_script(),
-                                  vars=self.get_vars())
-        self._readServer.start(script=self.read_tx_script(),
-                               vars=self.get_vars())
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._readServer1.start(script=self.read_tx_script(), vars=self.get_vars())
+
         session = driver.session('r', database=self.get_db())
         tx = session.beginTransaction()
-        tx.run("RETURN 1 as n")
+        result = tx.run("RETURN 1 as n")
+        sequence = self.collectRecords(result)
         tx.commit()
         session.close()
         driver.close()
-        self._routingServer.done()
-        self._readServer.done()
+
+        self._routingServer1.done()
+        self._readServer1.done()
+        self.assertEqual([1], sequence)
+
+    def test_should_read_successfully_from_reader_using_tx_function(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._readServer1.start(script=self.read_tx_script(), vars=self.get_vars())
+
+        session = driver.session('r', database=self.get_db())
+        sequences = []
+
+        def work(tx):
+            result = tx.run("RETURN 1 as n")
+            sequences.append(self.collectRecords(result))
+
+        session.readTransaction(work)
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._readServer1.done()
+        self.assertEqual([[1]], sequences)
+
+    def test_should_round_robin_readers_when_reading_using_session_run(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._readServer1.start(script=self.read_script(), vars=self.get_vars())
+        self._readServer2.start(script=self.read_script(), vars=self.get_vars())
+
+        sequences = []
+        for x in range(0, 2):
+            session = driver.session('r', database=self.get_db())
+            result = session.run("RETURN 1 as n")
+            sequences.append(self.collectRecords(result))
+            session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._readServer1.done()
+        self._readServer2.done()
+        self.assertEqual([[1], [1]], sequences)
+
+    def test_should_round_robin_readers_when_reading_using_tx_run(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._readServer1.start(script=self.read_tx_script(), vars=self.get_vars())
+        self._readServer2.start(script=self.read_tx_script(), vars=self.get_vars())
+
+        sequences = []
+        for x in range(0, 2):
+            session = driver.session('r', database=self.get_db())
+            tx = session.beginTransaction()
+            result = tx.run("RETURN 1 as n")
+            sequences.append(self.collectRecords(result))
+            tx.commit()
+            session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._readServer1.done()
+        self._readServer2.done()
+        self.assertEqual([[1], [1]], sequences)
+
+    def test_should_fail_when_reading_from_unexpectedly_interrupting_reader_using_session_run(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._readServer1.start(script=self.read_script_with_unexpected_interruption(), vars=self.get_vars())
+
+        session = driver.session('r', database=self.get_db())
+        session.run("RETURN 1 as n")
+        failed = False
+        try:
+            session.close()
+        except types.DriverError as e:
+            if get_driver_name() in ['java']:
+                self.assertEqual('org.neo4j.driver.exceptions.SessionExpiredException', e.errorType)
+            failed = True
+        driver.close()
+
+        self._routingServer1.done()
+        self._readServer1.done()
+        self.assertTrue(failed)
+
+    def test_should_fail_when_reading_from_unexpectedly_interrupting_reader_using_tx_run(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._readServer1.start(script=self.read_tx_script_with_unexpected_interruption(), vars=self.get_vars())
+
+        session = driver.session('r', database=self.get_db())
+        tx = session.beginTransaction()
+        tx.run("RETURN 1 as n")
+        failed = False
+        try:
+            tx.commit()
+        except types.DriverError as e:
+            if get_driver_name() in ['java']:
+                self.assertEqual('org.neo4j.driver.exceptions.SessionExpiredException', e.errorType)
+            failed = True
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._readServer1.done()
+        self.assertTrue(failed)
 
     # Checks that write server is used
-    def test_session_run_write(self):
+    def test_should_write_successfully_on_writer_using_session_run(self):
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
-        self._routingServer.start(script=self.router_script(),
-                                  vars=self.get_vars())
-        self._writeServer.start(script=self.write_script(),
-                                vars=self.get_vars())
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_script(), vars=self.get_vars())
+
         session = driver.session('w', database=self.get_db())
         session.run("RETURN 1 as n")
         session.close()
         driver.close()
-        self._routingServer.done()
-        self._writeServer.done()
+
+        self._routingServer1.done()
+        self._writeServer1.done()
 
     # Checks that write server is used
-    def test_tx_run_write(self):
+    def test_should_write_successfully_on_writer_using_tx_run(self):
         driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
-        self._routingServer.start(script=self.router_script(),
-                                  vars=self.get_vars())
-        self._writeServer.start(script=self.write_tx_script(),
-                                vars=self.get_vars())
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_tx_script(), vars=self.get_vars())
+
         session = driver.session('w', database=self.get_db())
         tx = session.beginTransaction()
         tx.run("RETURN 1 as n")
         tx.commit()
         session.close()
         driver.close()
-        self._routingServer.done()
-        self._writeServer.done()
+
+        self._routingServer1.done()
+        self._writeServer1.done()
+
+    def test_should_write_successfully_on_writer_using_tx_function(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_tx_script(), vars=self.get_vars())
+
+        session = driver.session('w', database=self.get_db())
+
+        def work(tx):
+            tx.run("RETURN 1 as n")
+
+        session.writeTransaction(work)
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._writeServer1.done()
+
+    def test_should_round_robin_writers_when_writing_using_session_run(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_script(), vars=self.get_vars())
+        self._writeServer2.start(script=self.write_script(), vars=self.get_vars())
+
+        for x in range(0, 2):
+            session = driver.session('w', database=self.get_db())
+            session.run("RETURN 1 as n")
+            session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._writeServer1.done()
+        self._writeServer2.done()
+
+    def test_should_round_robin_writers_when_writing_using_tx_run(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_tx_script(), vars=self.get_vars())
+        self._writeServer2.start(script=self.write_tx_script(), vars=self.get_vars())
+
+        for x in range(0, 2):
+            session = driver.session('w', database=self.get_db())
+            tx = session.beginTransaction()
+            tx.run("RETURN 1 as n")
+            tx.commit()
+            session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._writeServer1.done()
+        self._writeServer2.done()
+
+    def test_should_fail_when_writing_on_unexpectedly_interrupting_writer_using_session_run(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_script_with_unexpected_interruption(), vars=self.get_vars())
+
+        session = driver.session('w', database=self.get_db())
+        session.run("RETURN 1 as n")
+        failed = False
+        try:
+            session.close()
+        except types.DriverError as e:
+            if get_driver_name() in ['java']:
+                self.assertEqual('org.neo4j.driver.exceptions.SessionExpiredException', e.errorType)
+            failed = True
+        driver.close()
+
+        self._routingServer1.done()
+        self._writeServer1.done()
+        self.assertTrue(failed)
+
+    def test_should_fail_when_writing_on_unexpectedly_interrupting_writer_using_tx_run(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_tx_script_with_unexpected_interruption(), vars=self.get_vars())
+
+        session = driver.session('w', database=self.get_db())
+        tx = session.beginTransaction()
+        tx.run("RETURN 1 as n")
+        failed = False
+        try:
+            tx.commit()
+        except types.DriverError as e:
+            if get_driver_name() in ['java']:
+                self.assertEqual('org.neo4j.driver.exceptions.SessionExpiredException', e.errorType)
+            failed = True
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._writeServer1.done()
+        self.assertTrue(failed)
+
+    def test_should_fail_discovery_when_router_fails_with_procedure_not_found_code(self):
+        if get_driver_name() not in ['java']:
+            self.skipTest("verifyConnectivity not implemented in backend")
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script_with_procedure_not_found_failure(), vars=self.get_vars())
+
+        failed = False
+        try:
+            driver.verifyConnectivity()
+        except types.DriverError as e:
+            if get_driver_name() in ['java']:
+                self.assertEqual('org.neo4j.driver.exceptions.ServiceUnavailableException', e.errorType)
+            failed = True
+        driver.close()
+
+        self._routingServer1.done()
+        self.assertTrue(failed)
+
+    def test_should_fail_discovery_when_router_fails_with_unknown_code(self):
+        if get_driver_name() not in ['java']:
+            self.skipTest("verifyConnectivity not implemented in backend")
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script_with_unknown_failure(), vars=self.get_vars())
+
+        failed = False
+        try:
+            driver.verifyConnectivity()
+        except types.DriverError as e:
+            if get_driver_name() in ['java']:
+                self.assertEqual('org.neo4j.driver.exceptions.ServiceUnavailableException', e.errorType)
+            failed = True
+        driver.close()
+
+        self._routingServer1.done()
+        self.assertTrue(failed)
+
+    def test_should_fail_when_writing_on_writer_that_returns_not_a_leader_code(self):
+        if get_driver_name() not in ['java']:
+            self.skipTest("consume not implemented in backend")
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_script_with_not_a_leader_failure(), vars=self.get_vars())
+
+        session = driver.session('w', database=self.get_db())
+        failed = False
+        try:
+            session.run("RETURN 1 as n").consume()
+        except types.DriverError as e:
+            if get_driver_name() in ['java']:
+                self.assertEqual('org.neo4j.driver.exceptions.SessionExpiredException', e.errorType)
+            failed = True
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._writeServer1.done()
+        self.assertTrue(failed)
+
+    def test_should_fail_when_writing_without_explicit_consumption_on_writer_that_returns_not_a_leader_code(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_script_with_not_a_leader_failure(), vars=self.get_vars())
+
+        session = driver.session('w', database=self.get_db())
+        session.run("RETURN 1 as n")
+        failed = False
+        try:
+            session.close()
+        except types.DriverError as e:
+            if get_driver_name() in ['java']:
+                self.assertEqual('org.neo4j.driver.exceptions.SessionExpiredException', e.errorType)
+            failed = True
+        driver.close()
+
+        self._routingServer1.done()
+        self._writeServer1.done()
+        self.assertTrue(failed)
+
+    def test_should_fail_when_writing_on_writer_that_returns_not_a_leader_code_using_tx_run(self):
+        if get_driver_name() not in ['java']:
+            self.skipTest("consume not implemented in backend")
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_tx_script_with_not_a_leader_failure(), vars=self.get_vars())
+
+        session = driver.session('w', database=self.get_db())
+        tx = session.beginTransaction()
+        failed = False
+        try:
+            tx.run("RETURN 1 as n").consume()
+        except types.DriverError as e:
+            if get_driver_name() in ['java']:
+                self.assertEqual('org.neo4j.driver.exceptions.SessionExpiredException', e.errorType)
+            failed = True
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._writeServer1.done()
+        self.assertTrue(failed)
+
+    def test_should_fail_when_writing_without_explicit_consumption_on_writer_that_returns_not_a_leader_code_using_tx_run(
+            self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_tx_script_with_not_a_leader_failure(), vars=self.get_vars())
+
+        session = driver.session('w', database=self.get_db())
+        tx = session.beginTransaction()
+        failed = False
+        tx.run("RETURN 1 as n")
+        try:
+            tx.commit()
+        except types.DriverError as e:
+            if get_driver_name() in ['java']:
+                self.assertEqual('org.neo4j.driver.exceptions.SessionExpiredException', e.errorType)
+            failed = True
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._writeServer1.done()
+        self.assertTrue(failed)
+
+    def test_should_use_write_session_mode_and_initial_bookmark_when_writing_using_tx_run(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_tx_script_with_bookmarks(), vars=self.get_vars())
+
+        session = driver.session('w', bookmarks=["OldBookmark"], database=self.get_db())
+        tx = session.beginTransaction()
+        tx.run("RETURN 1 as n")
+        tx.commit()
+        last_bookmarks = session.lastBookmarks()
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._writeServer1.done()
+        self.assertEqual(["NewBookmark"], last_bookmarks)
+
+    def test_should_use_read_session_mode_and_initial_bookmark_when_reading_using_tx_run(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._readServer1.start(script=self.read_tx_script_with_bookmarks(), vars=self.get_vars())
+
+        session = driver.session('r', bookmarks=["OldBookmark"], database=self.get_db())
+        tx = session.beginTransaction()
+        result = tx.run("RETURN 1 as n")
+        sequence = self.collectRecords(result)
+        tx.commit()
+        last_bookmarks = session.lastBookmarks()
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._readServer1.done()
+        self.assertEqual([1], sequence)
+        self.assertEqual(["NewBookmark"], last_bookmarks)
+
+    def test_should_pass_bookmark_from_tx_to_tx_using_tx_run(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_read_tx_script_with_bookmark(), vars=self.get_vars())
+
+        session = driver.session('w', bookmarks=["BookmarkA"], database=self.get_db())
+        tx = session.beginTransaction()
+        tx.run("CREATE (n {name:'Bob'})")
+        tx.commit()
+        first_bookmark = session.lastBookmarks()
+        tx = session.beginTransaction()
+        result = tx.run("MATCH (n) RETURN n.name AS name")
+        sequence = self.collectRecords(result)
+        tx.commit()
+        second_bookmark = session.lastBookmarks()
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._writeServer1.done()
+        self.assertEqual(['Bob'], sequence)
+        self.assertEqual(["BookmarkB"], first_bookmark)
+        self.assertEqual(["BookmarkC"], second_bookmark)
+
+    def test_should_retry_read_tx_until_success(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._readServer1.start(script=self.read_tx_script_with_unexpected_interruption(), vars=self.get_vars())
+        self._readServer2.start(script=self.read_tx_script(), vars=self.get_vars())
+
+        session = driver.session('r', database=self.get_db())
+        sequences = []
+        try_count = 0
+
+        def work(tx):
+            nonlocal try_count
+            try_count = try_count + 1
+            result = tx.run("RETURN 1 as n")
+            sequences.append(self.collectRecords(result))
+
+        session.readTransaction(work)
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._readServer1.done()
+        self._readServer2.done()
+        self.assertEqual([[1]], sequences)
+        self.assertEqual(2, try_count)
+
+    def test_should_retry_write_tx_until_success(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_tx_script_with_unexpected_interruption(), vars=self.get_vars())
+        self._writeServer2.start(script=self.write_tx_script(), vars=self.get_vars())
+
+        session = driver.session('w', database=self.get_db())
+        sequences = []
+        try_count = 0
+
+        def work(tx):
+            nonlocal try_count
+            try_count = try_count + 1
+            result = tx.run("RETURN 1 as n")
+            sequences.append(self.collectRecords(result))
+
+        session.writeTransaction(work)
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._writeServer1.done()
+        self._writeServer2.done()
+        self.assertEqual([[]], sequences)
+        self.assertEqual(2, try_count)
+
+    def test_should_retry_read_tx_and_rediscovery_until_success(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script_with_another_router(), vars=self.get_vars())
+        self._routingServer2.start(script=self.router_script(), vars=self.get_vars())
+        self._readServer1.start(script=self.read_tx_script_with_unexpected_interruption(), vars=self.get_vars())
+        self._readServer2.start(script=self.read_tx_script(), vars=self.get_vars())
+        self._readServer3.start(script=self.read_tx_script_with_unexpected_interruption(), vars=self.get_vars())
+
+        session = driver.session('r', database=self.get_db())
+        sequences = []
+        try_count = 0
+
+        def work(tx):
+            nonlocal try_count
+            try_count = try_count + 1
+            result = tx.run("RETURN 1 as n")
+            sequences.append(self.collectRecords(result))
+
+        session.readTransaction(work)
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._routingServer2.done()
+        self._readServer1.done()
+        self._readServer2.done()
+        self._readServer3.done()
+        self.assertEqual([[1]], sequences)
+        self.assertEqual(3, try_count)
+
+    def test_should_retry_write_tx_and_rediscovery_until_success(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script_with_another_router(), vars=self.get_vars())
+        self._routingServer2.start(script=self.router_script(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_tx_script_with_unexpected_interruption(), vars=self.get_vars())
+        self._writeServer2.start(script=self.write_tx_script(), vars=self.get_vars())
+        self._writeServer3.start(script=self.write_tx_script_with_unexpected_interruption(), vars=self.get_vars())
+
+        session = driver.session('w', database=self.get_db())
+        sequences = []
+        try_count = 0
+
+        def work(tx):
+            nonlocal try_count
+            try_count = try_count + 1
+            result = tx.run("RETURN 1 as n")
+            sequences.append(self.collectRecords(result))
+
+        session.writeTransaction(work)
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._routingServer2.done()
+        self._writeServer1.done()
+        self._writeServer2.done()
+        self._writeServer3.done()
+        self.assertEqual([[]], sequences)
+        self.assertEqual(3, try_count)
+
+    def test_should_use_initial_router_for_discovery_when_others_unavailable(self):
+        if get_driver_name() not in ['java']:
+            self.skipTest("verifyConnectivity not implemented in backend")
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script_with_another_router(), vars=self.get_vars())
+
+        driver.verifyConnectivity()
+        self._routingServer1.done()
+        self._routingServer1.start(script=self.router_script_with_reader_support(), vars=self.get_vars())
+        session = driver.session('r', database=self.get_db())
+        sequences = []
+
+        def work(tx):
+            result = tx.run("RETURN 1 as n")
+            sequences.append(self.collectRecords(result))
+
+        session.readTransaction(work)
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self.assertEqual([[1]], sequences)
+
+    def test_should_successfully_read_from_readable_router_using_tx_function(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script_with_reader_support(), vars=self.get_vars())
+
+        session = driver.session('r', database=self.get_db())
+        sequences = []
+
+        def work(tx):
+            result = tx.run("RETURN 1 as n")
+            sequences.append(self.collectRecords(result))
+
+        session.readTransaction(work)
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self.assertEqual([[1]], sequences)
+
+    def test_should_send_empty_hello(self):
+        driver = Driver(self._backend, "neo4j://%s" % self._routingServer1.address, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script_with_empty_context_and_reader_support(), vars=self.get_vars())
+
+        session = driver.session('r', database=self.get_db())
+        sequences = []
+
+        def work(tx):
+            result = tx.run("RETURN 1 as n")
+            sequences.append(self.collectRecords(result))
+
+        session.readTransaction(work)
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self.assertEqual([[1]], sequences)
+
+    def test_should_serve_reads_and_fail_writes_when_no_writers_available(self):
+        if get_driver_name() not in ['java']:
+            self.skipTest("consume not implemented in backend")
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script_with_empty_writers(), vars=self.get_vars())
+        self._routingServer2.start(script=self.router_script_with_empty_writers(), vars=self.get_vars())
+        self._readServer1.start(script=self.read_tx_script(), vars=self.get_vars())
+
+        session = driver.session('w', database=self.get_db())
+        sequences = []
+
+        def work(tx):
+            result = tx.run("RETURN 1 as n")
+            sequences.append(self.collectRecords(result))
+
+        session.readTransaction(work)
+
+        failed = False
+        try:
+            session.run("CREATE (n {name:'Bob'})").consume()
+        except types.DriverError as e:
+            if get_driver_name() in ['java']:
+                self.assertEqual('org.neo4j.driver.exceptions.SessionExpiredException', e.errorType)
+            failed = True
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._routingServer2.done()
+        self._readServer1.done()
+        self.assertEqual([[1]], sequences)
+        self.assertTrue(failed)
+
+    def test_should_accept_routing_table_without_writers_and_then_rediscover(self):
+        if get_driver_name() not in ['java']:
+            self.skipTest("verifyConnectivity not implemented in backend")
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script_with_empty_writers(), vars=self.get_vars())
+        self._readServer1.start(script=self.read_tx_script_with_bookmarks(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_script_with_bookmark(), vars=self.get_vars())
+
+        driver.verifyConnectivity()
+        session = driver.session('w', bookmarks=["OldBookmark"], database=self.get_db())
+        sequences = []
+        self._routingServer1.done()
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+
+        def work(tx):
+            result = tx.run("RETURN 1 as n")
+            sequences.append(self.collectRecords(result))
+
+        session.readTransaction(work)
+        session.run("RETURN 1 as n").consume()
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._readServer1.done()
+        self._writeServer1.done()
+        self.assertEqual([[1]], sequences)
+
+    def test_should_accept_routing_table_with_single_router(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._readServer1.start(script=self.read_script(), vars=self.get_vars())
+        self._readServer2.start(script=self.read_script(), vars=self.get_vars())
+
+        session = driver.session('r', database=self.get_db())
+        result = session.run("RETURN 1 as n")
+        sequence1 = self.collectRecords(result)
+        result = session.run("RETURN 1 as n")
+        sequence2 = self.collectRecords(result)
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._readServer1.done()
+        self._readServer2.done()
+        self.assertEqual([1], sequence1)
+        self.assertEqual([1], sequence2)
+
+    def test_should_successfully_send_multiple_bookmarks(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_tx_script_multiple_bookmarks(), vars=self.get_vars())
+
+        session = driver.session('w',
+                                 bookmarks=["neo4j:bookmark:v1:tx5", "neo4j:bookmark:v1:tx29", "neo4j:bookmark:v1:tx94",
+                                            "neo4j:bookmark:v1:tx56",
+                                            "neo4j:bookmark:v1:tx16", "neo4j:bookmark:v1:tx68"], database=self.get_db())
+        tx = session.beginTransaction()
+        tx.run("RETURN 1 as n")
+        tx.commit()
+        last_bookmarks = session.lastBookmarks()
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._writeServer1.done()
+        self.assertEqual(["neo4j:bookmark:v1:tx95"], last_bookmarks)
+
+    def test_should_forget_address_on_database_unavailable_error(self):
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script_with_one_writer(), vars=self.get_vars())
+        self._writeServer1.start(script=self.write_tx_script_with_database_unavailable_failure(), vars=self.get_vars())
+        self._routingServer2.start(script=self.router_script(), vars=self.get_vars())
+        self._writeServer2.start(script=self.write_tx_script(), vars=self.get_vars())
+
+        session = driver.session('w', database=self.get_db())
+        sequences = []
+        try_count = 0
+
+        def work(tx):
+            nonlocal try_count
+            try_count = try_count + 1
+            result = tx.run("RETURN 1 as n")
+            sequences.append(self.collectRecords(result))
+
+        session.writeTransaction(work)
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._routingServer2.done()
+        self._writeServer1.done()
+        self._writeServer2.done()
+        self.assertEqual([[]], sequences)
+        self.assertEqual(2, try_count)
+
+    def test_should_use_resolver_during_rediscovery_when_existing_routers_fail(self):
+        if get_driver_name() not in ['java']:
+            self.skipTest("resolver not implemented in backend")
+        resolver_invoked = False
+
+        def resolver(address):
+            nonlocal resolver_invoked
+            address_tokens = address.split(':')
+            if not resolver_invoked:
+                resolver_invoked = True
+                return [address]
+            elif self._routingServer1.host == address_tokens[0] and self._routingServer1.port == int(address_tokens[1]):
+                return [self._routingServer2.address]
+            self.fail("unexpected")
+
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent, resolver)
+        self._routingServer1.start(script=self.router_script_with_reader_support(), vars=self.get_vars())
+        self._routingServer2.start(script=self.router_script(), vars=self.get_vars())
+        self._readServer1.start(script=self.read_tx_script(), vars=self.get_vars())
+
+        session = driver.session('w', database=self.get_db())
+        sequences = []
+
+        def work(tx):
+            result = tx.run("RETURN 1 as n")
+            sequences.append(self.collectRecords(result))
+
+        session.readTransaction(work)
+        session.readTransaction(work)
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._routingServer2.done()
+        self._readServer1.done()
+        self.assertEqual([[1], [1]], sequences)
+
+    def test_should_revert_to_initial_router_if_known_router_throws_protocol_errors(self):
+        if get_driver_name() not in ['java']:
+            self.skipTest("resolver not implemented in backend")
+
+        def resolver(address):
+            return [self._routingServer1.address, self._routingServer3.address]
+
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent, resolver)
+        self._routingServer1.start(script=self.router_script_with_another_router_and_non_existent_reader(), vars=self.get_vars())
+        self._routingServer2.start(script=self.router_script_with_empty_response(), vars=self.get_vars())
+        self._routingServer3.start(script=self.router_script(), vars=self.get_vars())
+        self._readServer1.start(script=self.read_tx_script(), vars=self.get_vars())
+
+        session = driver.session('r', database=self.get_db())
+        sequences = []
+
+        def work(tx):
+            result = tx.run("RETURN 1 as n")
+            sequences.append(self.collectRecords(result))
+
+        session.readTransaction(work)
+
+        session.close()
+        driver.close()
+        self._routingServer1.done()
+        self._routingServer2.done()
+        self._routingServer3.done()
+        self._readServer1.done()
+        self.assertEqual([[1]], sequences)
 
 
 class RoutingV4(Routing):
@@ -227,18 +1379,201 @@ class RoutingV4(Routing):
         C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {#ROUTINGMODE# "db": "system"}
         C: PULL {"n": -1}
         S: SUCCESS {"fields": ["ttl", "servers"]}
-        S: RECORD [1000, [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9002"], "role":"READ"}, {"addresses": ["#HOST#:9003"], "role":"WRITE"}]]
+        S: RECORD [1000, [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9021"], "role":"WRITE"}]]
+        S: SUCCESS {"type": "r"}
+        """
+
+    def router_script_with_procedure_not_found_failure(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+
+        !: AUTO GOODBYE
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS# }
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {#ROUTINGMODE# "db": "system"}
+        C: PULL {"n": -1}
+        S: FAILURE {"code": "Neo.ClientError.Procedure.ProcedureNotFound", "message": "blabla"}
+        S: IGNORED
+        S: <EXIT>
+        """
+
+    def router_script_with_unknown_failure(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+
+        !: AUTO GOODBYE
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS# }
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {#ROUTINGMODE# "db": "system"}
+        C: PULL {"n": -1}
+        S: FAILURE {"code": "Neo.ClientError.General.Unknown", "message": "wut!"}
+        S: IGNORED
+        S: <EXIT>
+        """
+
+    def router_script_with_leader_change(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        
+        C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {#ROUTINGMODE# "db": "system"}
+           PULL {"n": -1}
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+           RECORD [9223372036854775807, [{"addresses": ["#HOST#:9020"],"role": "WRITE"}, {"addresses": ["#HOST#:9006","#HOST#:9007"], "role": "READ"}, {"addresses": ["#HOST#:9000"], "role": "ROUTE"}]]
+           SUCCESS {}
+        C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {#ROUTINGMODE# "db": "system"}
+           PULL {"n": -1}
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+           RECORD [9223372036854775807, [{"addresses": ["#HOST#:9020"],"role": "WRITE"}, {"addresses": ["#HOST#:9006","#HOST#:9007"], "role": "READ"}, {"addresses": ["#HOST#:9000"], "role": "ROUTE"}]]
+           SUCCESS {}
+        C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {#ROUTINGMODE# "db": "system"}
+           PULL {"n": -1}
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+           RECORD [9223372036854775807, [{"addresses": [],"role": "WRITE"}, {"addresses": ["#HOST#:9006","#HOST#:9007"], "role": "READ"}, {"addresses": ["#HOST#:9000"], "role": "ROUTE"}]]
+           SUCCESS {}
+        C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {#ROUTINGMODE# "db": "system"}
+           PULL {"n": -1}
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+           RECORD [9223372036854775807, [{"addresses": ["#HOST#:9021"],"role": "WRITE"}, {"addresses": ["#HOST#:9006","#HOST#:9007"], "role": "READ"}, {"addresses": ["#HOST#:9000"], "role": "ROUTE"}]]
+           SUCCESS {}
+        """
+
+    def router_script_with_another_router(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+
+        !: AUTO GOODBYE
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS# }
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {#ROUTINGMODE# "db": "system"}
+        C: PULL {"n": -1}
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+        S: RECORD [1000, [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9012"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9022"], "role":"WRITE"}]]
+        S: SUCCESS {"type": "r"}
+        """
+
+    def router_script_with_reader_support(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+
+        !: AUTO GOODBYE
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS# }
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {#ROUTINGMODE# "db": "system"}
+        C: PULL {"n": -1}
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+        S: RECORD [1000, [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9000", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9021"], "role":"WRITE"}]]
+        S: SUCCESS {"type": "r"}
+        C: BEGIN {"mode": "r", "db": "adb"}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL {"n": 1000}
+        S: SUCCESS {"fields": ["n"]}
+           RECORD [1]
+           SUCCESS {"type": "r"}
+        C: COMMIT
+        S: SUCCESS {}
+           <EXIT>
+        """
+
+    def router_script_with_empty_context_and_reader_support(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        
+        !: AUTO GOODBYE
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": {"address": "#HOST#:9000"} #EXTRA_HELLO_PROPS# }
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": {"address": "#HOST#:9000"}, "database": "adb"} {#ROUTINGMODE# "db": "system"}
+        C: PULL {"n": -1}
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+        S: RECORD [1000, [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9000", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9021"], "role":"WRITE"}]]
+        S: SUCCESS {"type": "r"}
+        C: BEGIN {"mode": "r", "db": "adb"}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL {"n": 1000}
+        S: SUCCESS {"fields": ["n"]}
+           RECORD [1]
+           SUCCESS {"type": "r"}
+        C: COMMIT
+        S: SUCCESS {}
+        """
+
+    def router_script_with_empty_writers(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+        
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS# }
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {#ROUTINGMODE# "db": "system"}
+        C: PULL {"n": -1}
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+        S: RECORD [1000, [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": [], "role":"WRITE"}]]
+        S: SUCCESS {"type": "r"}
+        """
+
+    def router_script_with_one_writer(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+
+        !: AUTO GOODBYE
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS# }
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {#ROUTINGMODE# "db": "system"}
+        C: PULL {"n": -1}
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+        S: RECORD [1000, [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020"], "role":"WRITE"}]]
+        S: SUCCESS {"type": "r"}
+        """
+
+    def router_script_with_another_router_and_non_existent_reader(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+
+        !: AUTO GOODBYE
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS# }
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {#ROUTINGMODE# "db": "system"}
+        C: PULL {"n": -1}
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+        S: RECORD [1000, [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9099"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9021"], "role":"WRITE"}]]
+        S: SUCCESS {"type": "r"}
+        """
+
+    def router_script_with_empty_response(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+
+        !: AUTO GOODBYE
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS# }
+        S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {#ROUTINGMODE# "db": "system"}
+        C: PULL {"n": -1}
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+        S: RECORD [1000, []]
         S: SUCCESS {"type": "r"}
         """
 
     def get_vars(self):
-        host = self._routingServer.host
+        host = self._routingServer1.host
         v = {
             "#VERSION#": 4.1,
             "#HOST#": host,
             "#EXTRA_HELLO_PROPS#": get_extra_hello_props(),
             "#ROUTINGMODE#": '"mode": "r", ',
-            "#ROUTINGCTX#": '{"address": "' + host + ':9001", "region": "china", "policy": "my_policy"}',
+            "#ROUTINGCTX#": '{"address": "' + host + ':9000", "region": "china", "policy": "my_policy"}',
         }
 
         v["#HELLO_ROUTINGCTX#"] = v["#ROUTINGCTX#"]
@@ -252,7 +1587,7 @@ class RoutingV4(Routing):
         return v
 
     # Ignore this on older protocol versions than 4.3
-    def test_default_db(self):
+    def test_should_read_successfully_from_reader_using_session_run_with_default_db_driver(self):
         pass
 
 
@@ -267,12 +1602,187 @@ class RoutingV3(Routing):
         C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": #ROUTINGCTX#} {#ROUTINGMODE#}
         C: PULL_ALL
         S: SUCCESS {"fields": ["ttl", "servers"]}
-        S: RECORD [1000, [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9002"], "role":"READ"}, {"addresses": ["#HOST#:9003"], "role":"WRITE"}]]
+        S: RECORD [1000, [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9021"], "role":"WRITE"}]]
         S: SUCCESS {"type": "r"}
+        """
+
+    def router_script_with_procedure_not_found_failure(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007" #EXTRA_HELLO_PROPS# #EXTR_HELLO_ROUTING_PROPS#}
+        S: SUCCESS {"server": "Neo4j/3.5.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": #ROUTINGCTX#} {#ROUTINGMODE#}
+        C: PULL_ALL
+        S: FAILURE {"code": "Neo.ClientError.Procedure.ProcedureNotFound", "message": "blabla"}
+        S: IGNORED
+        S: <EXIT>
+        """
+
+    def router_script_with_unknown_failure(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007" #EXTRA_HELLO_PROPS# #EXTR_HELLO_ROUTING_PROPS#}
+        S: SUCCESS {"server": "Neo4j/3.5.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": #ROUTINGCTX#} {#ROUTINGMODE#}
+        C: PULL_ALL
+        S: FAILURE {"code": "Neo.ClientError.General.Unknown", "message": "wut!"}
+        S: IGNORED
+        S: <EXIT>
+        """
+
+    def router_script_with_leader_change(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        
+        C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {"address": "#HOST#:9000"}} {}
+           PULL_ALL
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+           RECORD [9223372036854775807, [{"addresses": ["#HOST#:9020"],"role": "WRITE"}, {"addresses": ["#HOST#:9006","#HOST#:9007"], "role": "READ"},{"addresses": ["#HOST#:9000"], "role": "ROUTE"}]]
+           SUCCESS {}
+        C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {"address": "#HOST#:9000"}} {}
+           PULL_ALL
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+           RECORD [9223372036854775807, [{"addresses": ["#HOST#:9020"],"role": "WRITE"}, {"addresses": ["#HOST#:9006","#HOST#:9007"], "role": "READ"},{"addresses": ["#HOST#:9000"], "role": "ROUTE"}]]
+           SUCCESS {}
+        C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {"address": "#HOST#:9000"}} {}
+           PULL_ALL
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+           RECORD [9223372036854775807, [{"addresses": [],"role": "WRITE"}, {"addresses": ["#HOST#:9006","#HOST#:9007"], "role": "READ"},{"addresses": ["#HOST#:9000"], "role": "ROUTE"}]]
+           SUCCESS {}
+        C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {"address": "#HOST#:9000"}} {}
+           PULL_ALL
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+           RECORD [9223372036854775807, [{"addresses": ["#HOST#:9021"],"role": "WRITE"}, {"addresses": ["#HOST#:9006","#HOST#:9007"], "role": "READ"},{"addresses": ["#HOST#:9000"], "role": "ROUTE"}]]
+           SUCCESS {}
         """
 
     def router_script_default_db(self):
         return self.router_script()
+
+    def router_script_with_another_router(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007" #EXTRA_HELLO_PROPS# #EXTR_HELLO_ROUTING_PROPS#}
+        S: SUCCESS {"server": "Neo4j/3.5.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": #ROUTINGCTX#} {#ROUTINGMODE#}
+        C: PULL_ALL
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+        S: RECORD [1000, [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9012"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9022"], "role":"WRITE"}]]
+        S: SUCCESS {"type": "r"}
+        """
+
+    def router_script_with_reader_support(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007" #EXTRA_HELLO_PROPS# #EXTR_HELLO_ROUTING_PROPS#}
+        S: SUCCESS {"server": "Neo4j/3.5.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": #ROUTINGCTX#} {#ROUTINGMODE#}
+        C: PULL_ALL
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+        S: RECORD [1000, [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9000", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9021"], "role":"WRITE"}]]
+        S: SUCCESS {"type": "r"}
+        C: BEGIN {"mode": "r"}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL_ALL
+        S: SUCCESS {"fields": ["n"]}
+           RECORD [1]
+           SUCCESS {"type": "r"}
+        C: COMMIT
+        S: SUCCESS {}
+           <EXIT>
+        """
+
+    def router_script_with_empty_context_and_reader_support(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007" #EXTRA_HELLO_PROPS# , "routing": {"address": "#HOST#:9000"}}
+        S: SUCCESS {"server": "Neo4j/3.5.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {"address": "#HOST#:9000"}} {#ROUTINGMODE#}
+        C: PULL_ALL
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+        S: RECORD [1000, [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9000", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9021"], "role":"WRITE"}]]
+        S: SUCCESS {"type": "r"}
+        C: BEGIN {"mode": "r"}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL_ALL
+        S: SUCCESS {"fields": ["n"]}
+           RECORD [1]
+           SUCCESS {"type": "r"}
+        C: COMMIT
+        S: SUCCESS {}
+        """
+
+    def router_script_with_empty_writers(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+        
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007" #EXTRA_HELLO_PROPS# #EXTR_HELLO_ROUTING_PROPS#}
+        S: SUCCESS {"server": "Neo4j/3.5.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": #ROUTINGCTX#} {#ROUTINGMODE#}
+        C: PULL_ALL
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+        S: RECORD [1000, [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": [], "role":"WRITE"}]]
+        S: SUCCESS {"type": "r"}
+        """
+
+    def router_script_with_one_writer(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007" #EXTRA_HELLO_PROPS# #EXTR_HELLO_ROUTING_PROPS#}
+        S: SUCCESS {"server": "Neo4j/3.5.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": #ROUTINGCTX#} {#ROUTINGMODE#}
+        C: PULL_ALL
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+        S: RECORD [1000, [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020"], "role":"WRITE"}]]
+        S: SUCCESS {"type": "r"}
+        """
+
+    def router_script_with_another_router_and_non_existent_reader(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007" #EXTRA_HELLO_PROPS# #EXTR_HELLO_ROUTING_PROPS#}
+        S: SUCCESS {"server": "Neo4j/3.5.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": #ROUTINGCTX#} {#ROUTINGMODE#}
+        C: PULL_ALL
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+        S: RECORD [1000, [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9099"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9021"], "role":"WRITE"}]]
+        S: SUCCESS {"type": "r"}
+        """
+
+    def router_script_with_empty_response(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO RESET
+        !: AUTO GOODBYE
+        C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007" #EXTRA_HELLO_PROPS# #EXTR_HELLO_ROUTING_PROPS#}
+        S: SUCCESS {"server": "Neo4j/3.5.0", "connection_id": "bolt-123456789"}
+        C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": #ROUTINGCTX#} {#ROUTINGMODE#}
+        C: PULL_ALL
+        S: SUCCESS {"fields": ["ttl", "servers"]}
+        S: RECORD [1000, []]
+        S: SUCCESS {"type": "r"}
+        """
 
     def read_script(self):
         return """
@@ -287,6 +1797,17 @@ class RoutingV3(Routing):
            SUCCESS {"type": "r"}
         """
 
+    def read_script_with_unexpected_interruption(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+        C: RUN "RETURN 1 as n" {} {"mode": "r"}
+        C: PULL_ALL
+        S: <EXIT>
+        """
+
     def read_tx_script(self):
         return """
         !: BOLT #VERSION#
@@ -298,9 +1819,40 @@ class RoutingV3(Routing):
         C: RUN "RETURN 1 as n" {} {}
         C: PULL_ALL
         S: SUCCESS {"fields": ["n"]}
+           RECORD [1]
            SUCCESS {"type": "r"}
         C: COMMIT
         S: SUCCESS {}
+        """
+
+    def read_tx_script_with_bookmarks(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+        C: BEGIN {"mode": "r", "bookmarks": ["OldBookmark"]}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL_ALL
+        S: SUCCESS {"fields": ["n"]}
+           RECORD [1]
+           SUCCESS {"type": "r"}
+        C: COMMIT
+        S: SUCCESS {"bookmark": "NewBookmark"}
+        """
+
+    def read_tx_script_with_unexpected_interruption(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+        C: BEGIN {"mode": "r"}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL_ALL
+        S: <EXIT>
         """
 
     def write_script(self):
@@ -310,6 +1862,30 @@ class RoutingV3(Routing):
         !: AUTO GOODBYE
         !: AUTO RESET
         C: RUN "RETURN 1 as n" {} {}
+        C: PULL_ALL
+        S: SUCCESS {"fields": ["n"]}
+           RECORD [1]
+           SUCCESS {"type": "w"}
+        """
+
+    def write_script_with_unexpected_interruption(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL_ALL
+        S: <EXIT>
+        """
+
+    def write_script_with_bookmark(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+        C: RUN "RETURN 1 as n" {} {"bookmarks": ["ABookmark"]}
         C: PULL_ALL
         S: SUCCESS {"fields": ["n"]}
            RECORD [1]
@@ -332,13 +1908,144 @@ class RoutingV3(Routing):
         S: SUCCESS {}
         """
 
+    def write_tx_script_with_bookmarks(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+        C: BEGIN {"bookmarks": ["OldBookmark"]}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL_ALL
+        S: SUCCESS {"fields": ["n"]}
+           SUCCESS {"type": "w"}
+        C: COMMIT
+        S: SUCCESS {"bookmark": "NewBookmark"}
+        """
+
+    def write_read_tx_script_with_bookmark(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+        C: BEGIN {"bookmarks": ["BookmarkA"]}
+        S: SUCCESS {}
+        C: RUN "CREATE (n {name:'Bob'})" {} {}
+           PULL_ALL
+        S: SUCCESS {}
+           SUCCESS {}
+        C: COMMIT
+        S: SUCCESS {"bookmark": "BookmarkB"}
+        C: BEGIN {"bookmarks": ["BookmarkB"]}
+        S: SUCCESS {}
+        C: RUN "MATCH (n) RETURN n.name AS name" {} {}
+           PULL_ALL
+        S: SUCCESS {"fields": ["name"]}
+           RECORD ["Bob"]
+           SUCCESS {}
+        C: COMMIT
+        S: SUCCESS {"bookmark": "BookmarkC"}
+        """
+
+    def write_tx_script_with_unexpected_interruption(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+        C: BEGIN {}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL_ALL
+        S: <EXIT>
+        """
+
+    def write_script_with_not_a_leader_failure(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL_ALL
+        S: FAILURE {"code": "Neo.ClientError.Cluster.NotALeader", "message": "blabla"}
+        S: IGNORED
+        C: RESET
+        S: SUCCESS {}
+        """
+
+    def write_tx_script_with_not_a_leader_failure(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+        C: BEGIN {}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL_ALL
+        S: FAILURE {"code": "Neo.ClientError.Cluster.NotALeader", "message": "blabla"}
+        S: IGNORED
+        C: RESET
+        S: SUCCESS {}
+        """
+
+    def write_tx_script_with_database_unavailable_failure_on_commit(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+        C: BEGIN {}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL_ALL
+        S: SUCCESS {"fields": ["n"]}
+           SUCCESS {"type": "w"}
+        C: COMMIT
+        S: FAILURE {"code": "Neo.TransientError.General.DatabaseUnavailable", "message": "Database shut down."}
+        S: <EXIT>
+        """
+
+    def write_tx_script_multiple_bookmarks(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+        C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx5", "neo4j:bookmark:v1:tx29", "neo4j:bookmark:v1:tx94", "neo4j:bookmark:v1:tx56", "neo4j:bookmark:v1:tx16", "neo4j:bookmark:v1:tx68"]}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL_ALL
+        S: SUCCESS {"fields": ["n"]}
+           SUCCESS {"type": "w"}
+        C: COMMIT
+        S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx95"}
+        """
+
+    def write_tx_script_with_database_unavailable_failure(self):
+        return """
+        !: BOLT #VERSION#
+        !: AUTO HELLO
+        !: AUTO GOODBYE
+        !: AUTO RESET
+        C: BEGIN {}
+        S: SUCCESS {}
+        C: RUN "RETURN 1 as n" {} {}
+        C: PULL_ALL
+        S: FAILURE {"code": "Neo.TransientError.General.DatabaseUnavailable", "message": "Database is busy doing store copy"}
+        S: IGNORED
+        """
+
     def get_vars(self):
-        host = self._routingServer.host
+        host = self._routingServer1.host
         v = {
             "#VERSION#": 3,
             "#HOST#": host,
             "#ROUTINGMODE#": "",
-            "#ROUTINGCTX#": '{"address": "' + host + ':9001", "region": "china", "policy": "my_policy"}',
+            "#ROUTINGCTX#": '{"address": "' + host + ':9000", "region": "china", "policy": "my_policy"}',
             "#EXTRA_HELLO_PROPS#": get_extra_hello_props(),
             "#EXTR_HELLO_ROUTING_PROPS#": "",
         }
@@ -361,7 +2068,7 @@ class RoutingV3(Routing):
 class NoRouting(unittest.TestCase):
     def setUp(self):
         self._backend = new_backend()
-        self._server = StubServer(9001)
+        self._server = StubServer(9000)
 
     def tearDown(self):
         self._backend.close()
@@ -392,15 +2099,17 @@ class NoRouting(unittest.TestCase):
     # Checks that routing is disabled when URI is bolt, no routing in HELLO and
     # no call to retrieve routing table. From bolt >= 4.1 the routing context
     # is used to disable/enable server side routing.
-    def test_session_run_read(self):
+    def test_should_read_successfully_using_session_run(self):
         # Driver is configured to talk to "routing" stub server
         uri = "bolt://%s" % self._server.address
         self._server.start(script=self.script(), vars=self.get_vars())
         driver = Driver(self._backend, uri,
                         AuthorizationToken(scheme="basic", principal="p",
                                            credentials="c"), userAgent="007")
+
         session = driver.session('r', database="adb")
         session.run("RETURN 1 as n")
         session.close()
         driver.close()
+
         self._server.done()


### PR DESCRIPTION
Short summary of this update:
- refactoring
- new tests & migrated tests
- verifyConnectivity support
- resolver support

Java Driver commit id: 61767e8dc3747ea9217b579052fd5d556609b8cb

Test mapping (source: org.neo4j.driver.integration.RoutingDriverBoltKitIT):
- shouldHandleAcquireReadSession -> test_should_read_successfully_from_reader_using_session_run
- shouldHandleAcquireReadTransaction -> test_should_read_successfully_from_reader_using_tx_function
- shouldHandleAcquireReadSessionAndTransaction -> test_should_read_successfully_from_reader_using_tx_run
- shouldRoundRobinReadServers -> test_should_round_robin_readers_when_reading_using_session_run
- shouldRoundRobinReadServersWhenUsingTransaction -> test_should_round_robin_readers_when_reading_using_tx_run
- shouldThrowSessionExpiredIfReadServerDisappears -> test_should_fail_when_reading_from_unexpectedly_interrupting_reader_using_session_run
- shouldThrowSessionExpiredIfReadServerDisappearsWhenUsingTransaction -> test_should_fail_when_reading_from_unexpectedly_interrupting_reader_using_tx_run
- shouldThrowSessionExpiredIfWriteServerDisappears -> test_should_fail_when_writing_on_unexpectedly_interrupting_writer_using_session_run
- shouldThrowSessionExpiredIfWriteServerDisappearsWhenUsingTransaction -> test_should_fail_when_writing_on_unexpectedly_interrupting_writer_using_tx_run
- shouldHandleAcquireWriteSession -> test_should_write_successfully_on_writer_using_session_run
- shouldHandleAcquireWriteTransaction -> test_should_write_successfully_on_writer_using_tx_function
- shouldHandleAcquireWriteSessionAndTransaction -> test_should_write_successfully_on_writer_using_tx_run
- shouldRoundRobinWriteSessions -> test_should_round_robin_writers_when_writing_using_session_run
- shouldRoundRobinWriteSessionsInTransaction -> test_should_round_robin_writers_when_writing_using_tx_run
- shouldFailOnNonDiscoverableServer -> test_should_fail_discovery_when_router_fails_with_procedure_not_found_code
- shouldFailRandomFailureInGetServers -> test_should_fail_discovery_when_router_fails_with_unknown_code
- shouldHandleLeaderSwitchWhenWriting -> test_should_fail_when_writing_on_writer_that_returns_not_a_leader_code
- shouldHandleLeaderSwitchWhenWritingWithoutConsuming -> test_should_fail_when_writing_without_explicit_consumption_on_writer_that_returns_not_a_leader_code
- shouldHandleLeaderSwitchWhenWritingInTransaction -> test_should_fail_when_writing_on_writer_that_returns_not_a_leader_code_using_tx_run
- shouldUseWriteSessionModeAndInitialBookmark -> test_should_use_write_session_mode_and_initial_bookmark_when_writing_using_tx_run
- shouldUseReadSessionModeAndInitialBookmark -> test_should_use_read_session_mode_and_initial_bookmark_when_reading_using_tx_run
- shouldPassBookmarkFromTransactionToTransaction -> test_should_pass_bookmark_from_tx_to_tx_using_tx_run
- shouldRetryReadTransactionUntilSuccess -> test_should_retry_read_tx_until_success
- shouldRetryWriteTransactionUntilSuccess -> test_should_retry_write_tx_until_success
- shouldRetryReadTransactionAndPerformRediscoveryUntilSuccess -> test_should_retry_read_tx_and_rediscovery_until_success
- shouldRetryWriteTransactionAndPerformRediscoveryUntilSuccess -> test_should_retry_write_tx_and_rediscovery_until_success
- shouldUseInitialRouterForRediscoveryWhenAllOtherRoutersAreDead -> test_should_use_initial_router_for_discovery_when_others_unavailable
- shouldInvokeProcedureGetRoutingTableWhenServerVersionPermits -> test_should_successfully_read_from_readable_router_using_tx_function
- shouldSendEmptyRoutingContextInHelloMessage -> test_should_send_empty_hello
- shouldServeReadsButFailWritesWhenNoWritersAvailable -> test_should_serve_reads_and_fail_writes_when_no_writers_available
- shouldAcceptRoutingTableWithoutWritersAndThenRediscover -> test_should_accept_routing_table_without_writers_and_then_rediscover
- shouldTreatRoutingTableWithSingleRouterAsValid -> test_should_accept_routing_table_with_single_router
- shouldSendMultipleBookmarks -> test_should_successfully_send_multiple_bookmarks
- shouldForgetAddressOnDatabaseUnavailableError -> test_should_forget_address_on_database_unavailable_error
- shouldUseResolverDuringRediscoveryWhenExistingRoutersFail -> test_should_use_resolver_during_rediscovery_when_existing_routers_fail
- shouldRevertToInitialRouterIfKnownRouterThrowsProtocolErrors -> test_should_revert_to_initial_router_if_known_router_throws_protocol_errors