### PR TITLE
Stub tests migration part 3

### DIFF
--- a/nutkit/frontend/driver.py
+++ b/nutkit/frontend/driver.py
@@ -22,6 +22,13 @@ class Driver:
         if not isinstance(res, protocol.Driver):
             raise Exception("Should be driver")
 
+    def supportsMultiDB(self):
+        req = protocol.CheckMultiDBSupport(self._driver.id)
+        res = self._backend.sendAndReceive(req)
+        if not isinstance(res, protocol.MultiDBSupport):
+            raise Exception("Should be MultiDBSupport")
+        return res.available
+
     def close(self):
         req = protocol.DriverClose(self._driver.id)
         res = self._backend.sendAndReceive(req)

--- a/nutkit/protocol/requests.py
+++ b/nutkit/protocol/requests.py
@@ -54,6 +54,16 @@ class VerifyConnectivity:
     def __init__(self, driverId):
         self.driverId = driverId
 
+
+class CheckMultiDBSupport:
+    """ Request to check if the server or cluster the driver connects to supports multi-databases.
+    Backend should respond with a MultiDBSupport response.
+    """
+
+    def __init__(self, driverId):
+        self.driverId = driverId
+
+
 class ResolverResolutionCompleted:
     """ Pushes the results of the resolver function resolution back to the backend.
     This must only be sent immediately after the backend requests a new address resolution
@@ -63,6 +73,7 @@ class ResolverResolutionCompleted:
     def __init__(self, requestId, addresses):
         self.requestId = requestId
         self.addresses = addresses
+
 
 class DriverClose:
     """ Request to close the driver instance on the backend.

--- a/nutkit/protocol/responses.py
+++ b/nutkit/protocol/responses.py
@@ -43,6 +43,16 @@ class ResolverResolutionRequired:
         self.address = address
 
 
+class MultiDBSupport:
+    """ Specifies whether the server or cluster the driver connects to supports multi-databases.
+    It is sent in response to the CheckMultiDBSupport request.
+    """
+
+    def __init__(self, id, available):
+        self.id = id
+        self.available = available
+
+
 class Session:
     """ Represents a session instance on the backend
     """

--- a/tests/stub/routing.py
+++ b/tests/stub/routing.py
@@ -1574,6 +1574,23 @@ class Routing(unittest.TestCase):
         self._readServer1.done()
         self.assertEqual([[1]], sequences)
 
+    def should_support_multi_db(self):
+        return True
+
+    def test_should_successfully_check_if_support_for_multi_db_is_available(self):
+        # TODO add support and remove this block
+        if get_driver_name() in ['python', 'javascript', 'go', 'dotnet']:
+            self.skipTest("supportsMultiDb not implemented in backend")
+
+        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
+
+        supports_multi_db = driver.supportsMultiDB()
+
+        driver.close()
+        self._routingServer1.done()
+        self.assertEqual(self.should_support_multi_db(), supports_multi_db)
+
 
 class RoutingV4(Routing):
     def router_script(self):
@@ -2342,6 +2359,9 @@ class RoutingV3(Routing):
 
     def get_db(self):
         return None
+
+    def should_support_multi_db(self):
+        return False
 
 
 class NoRouting(unittest.TestCase):


### PR DESCRIPTION
Adding support for supportsMultiDB call.

Importing the following tests from the Java Driver:
shouldServerWithBoltV4SupportMultiDb -> test_should_successfully_check_if_support_for_multi_db_is_available
shouldServerWithBoltV3NotSupportMultiDb -> test_should_successfully_check_if_support_for_multi_db_is_available