### PR TITLE
Stub tests migration part 4

### DIFF
--- a/nutkit/protocol/responses.py
+++ b/nutkit/protocol/responses.py
@@ -198,10 +198,11 @@ class DriverError(BaseError):
     test framework needs to check detailed error handling.
     """
 
-    def __init__(self, id=None, errorType="", msg=""):
+    def __init__(self, id=None, errorType="", msg="", code=""):
         self.id = id
         self.errorType = errorType
         self.msg = msg
+        self.code = code
 
     def __str__(self):
         return "DriverError : " + self.errorType + " : " + self.msg


### PR DESCRIPTION
- shouldRetryOnEmptyDiscoveryResult -> test_should_read_successfully_on_empty_discovery_result_using_session_run (adder custom resolver support for session.run)
- shouldThrowRoutingErrorIfDatabaseNotFound -> test_should_fail_with_routing_failure_on_db_not_found_discovery_failure (added code support)
- shouldBeAbleToServeReachableDatabase -> test_should_read_successfully_from_reachable_db_after_trying_unreachable_db (message check has been removed)
- shouldPassSystemBookmarkWhenGettingRoutingTableForMultiDB -> test_should_pass_system_bookmark_when_getting_rt_for_multi_db (seems to be applicable to V4 only, also the stub server doesn't seem to check bookmarks)
- shouldIgnoreSystemBookmarkWhenGettingRoutingTable -> test_should_ignore_system_bookmark_when_getting_rt_for_multi_db

Added support for custom resolver in session run calls.

The backend protocol has been extended by including code in DriverError.