### PR TITLE
Skip messages

### DIFF
--- a/boltstub/scripting.py
+++ b/boltstub/scripting.py
@@ -97,7 +97,7 @@ class BoltScript:
                 request[versionindex + minor_offset],
                 request[versionindex + minor_version_difference_offset])
 
-    def _get_versions(self, request): 
+    def _get_versions(self, request):
         for n in range(0, 4):
             (major, max_minor, minor_difference) = self._get_version_range_defintion(request, n)
             for minor in range(max_minor, max_minor - minor_difference - 1 , -1):

--- a/docker.py
+++ b/docker.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 
+
 _running = {}
 _created_tags = set()
 

--- a/driver.py
+++ b/driver.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import subprocess
 
 import docker
 import neo4j

--- a/main.py
+++ b/main.py
@@ -12,19 +12,22 @@ orchestrate which suites that are executed in each context.
 import argparse
 import atexit
 import os
-import signal
 import subprocess
 import sys
 import traceback
 
-from tests.testenv import (
-        begin_test_suite, end_test_suite, in_teamcity)
 import docker
-import teamcity
-import neo4j
 import driver
+import neo4j
 import runner
 import settings
+import teamcity
+from tests.testenv import (
+    begin_test_suite,
+    end_test_suite,
+    in_teamcity,
+)
+
 
 # TODO: Move to docker.py
 networks = ["testkit_1", "testkit_2"]

--- a/neo4j.py
+++ b/neo4j.py
@@ -1,6 +1,7 @@
-import docker
 import collections
 from os.path import join
+
+import docker
 
 
 """ Neo4j instance test configuration (no runtime properties)

--- a/nutkit/frontend/__init__.py
+++ b/nutkit/frontend/__init__.py
@@ -1,2 +1,1 @@
-from nutkit.frontend.driver import Driver
-from nutkit.protocol import AuthorizationToken, NullRecord
+from .driver import Driver

--- a/nutkit/frontend/driver.py
+++ b/nutkit/frontend/driver.py
@@ -1,6 +1,5 @@
-import nutkit.protocol as protocol
-
 from .session import Session
+from .. import protocol
 
 
 class Driver:

--- a/nutkit/frontend/result.py
+++ b/nutkit/frontend/result.py
@@ -1,4 +1,4 @@
-import nutkit.protocol as protocol
+from .. import protocol
 
 
 class Result:

--- a/nutkit/frontend/session.py
+++ b/nutkit/frontend/session.py
@@ -1,6 +1,6 @@
-import nutkit.protocol as protocol
 from .result import Result
 from .transaction import Transaction
+from .. import protocol
 
 
 class Session:

--- a/nutkit/frontend/transaction.py
+++ b/nutkit/frontend/transaction.py
@@ -1,5 +1,5 @@
-import nutkit.protocol as protocol
 from .result import Result
+from .. import protocol
 
 
 class Transaction:

--- a/nutkit/protocol/__init__.py
+++ b/nutkit/protocol/__init__.py
@@ -1,3 +1,3 @@
-from nutkit.protocol.requests import *
-from nutkit.protocol.cypher import *
-from nutkit.protocol.responses import *
+from .requests import *
+from .cypher import *
+from .responses import *

--- a/nutkit/protocol/requests.py
+++ b/nutkit/protocol/requests.py
@@ -17,6 +17,16 @@ in errors.py. See the requests for information on which response they expect.
 """
 
 
+class StartTest:
+    """ Request the backend to confirm to run a specific test. The backend
+    should respond with RunTest if the backend wants the test to be skipped it
+    must respond with SkipTest.
+    """
+
+    def __init__(self, test_name):
+        self.testName = test_name
+
+
 class NewDriver:
     """ Request to create a new driver instance on the backend.
     Backend should respond with a Driver response or an Error response.
@@ -227,10 +237,8 @@ class ResultNext:
 
 class ResultConsume:
     """ Request to close the result and to discard all remaining records back
-    in the response.  Backend should respond with ClosedResult or an Error if
-    an error occured.  If an error occures on the backend while iterating the
-    result for serialization this error should be set in ClosedResult.error
-    and iteration stopped, the ClosedResult should be returned.
+    in the response. Backend should respond with Summary or an Error if an error
+    occured.
     """
 
     def __init__(self, resultId):

--- a/nutkit/protocol/responses.py
+++ b/nutkit/protocol/responses.py
@@ -22,12 +22,12 @@ For example response to NewDriver request should be sent from backend as:
 
 
 class RunTest:
-    """ Response to StartTest indicating the the test can be started"""
+    """ Response to StartTest indicating that the test can be started"""
     pass
 
 
 class SkipTest:
-    """ Response to StartTest indicating the the test should be skipped"""
+    """ Response to StartTest indicating that the test should be skipped"""
 
     def __init__(self, reason):
         self.reason = reason

--- a/nutkit/protocol/responses.py
+++ b/nutkit/protocol/responses.py
@@ -21,6 +21,18 @@ For example response to NewDriver request should be sent from backend as:
 """
 
 
+class RunTest:
+    """ Response to StartTest indicating the the test can be started"""
+    pass
+
+
+class SkipTest:
+    """ Response to StartTest indicating the the test should be skipped"""
+
+    def __init__(self, reason):
+        self.reason = reason
+
+
 class Driver:
     """ Represents a driver instance on the backend
     """

--- a/run_all.py
+++ b/run_all.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import traceback
 
+
 drivers = [
     {
         "name": "go",

--- a/runner.py
+++ b/runner.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 
 import docker
 

--- a/settings.py
+++ b/settings.py
@@ -1,8 +1,8 @@
 """
 Retrieves the information needed to run main, stress or other test suite.
 """
-import os
 import collections
+import os
 
 
 class InvalidArgs(Exception):

--- a/stress.py
+++ b/stress.py
@@ -11,8 +11,8 @@ import urllib.parse
 
 import docker
 import driver
-import settings
 import neo4j
+import settings
 
 
 def run(settings):

--- a/teamcity/__init__.py
+++ b/teamcity/__init__.py
@@ -1,4 +1,5 @@
 import os
+
 from teamcity.download import DockerImage
 from teamcity.testresult import TeamCityTestResult, escape
 

--- a/teamcity/download.py
+++ b/teamcity/download.py
@@ -1,6 +1,5 @@
-from urllib import request
 from os import getenv
-import subprocess
+from urllib import request
 
 
 def download_artifact(build_id, build_spec, path):

--- a/teamcity/testresult.py
+++ b/teamcity/testresult.py
@@ -1,4 +1,4 @@
-import os, unittest
+import unittest
 
 
 def escape(s):

--- a/tests/neo4j/authentication.py
+++ b/tests/neo4j/authentication.py
@@ -1,10 +1,13 @@
 import os
 
-from nutkit.frontend import Driver, AuthorizationToken
+from nutkit.frontend import Driver
 import nutkit.protocol as types
 from tests.neo4j.shared import (
-        get_neo4j_host_and_port, env_neo4j_user, env_neo4j_pass)
-from tests.shared import new_backend, TestkitTestCase
+    env_neo4j_user,
+    env_neo4j_pass,
+    get_neo4j_host_and_port,
+)
+from tests.shared import TestkitTestCase
 
 
 class TestAuthenticationBasic(TestkitTestCase):
@@ -33,16 +36,16 @@ class TestAuthenticationBasic(TestkitTestCase):
             result.next(), types.Record(values=[types.CypherInt(2)]))
 
     def testErrorOnIncorrectCredentials(self):
-        auth_token = AuthorizationToken(scheme="basic",
-                                        principal="fake",
-                                        credentials="fake")
+        auth_token = types.AuthorizationToken(scheme="basic",
+                                              principal="fake",
+                                              credentials="fake")
         # TODO: Expand this to check errorType is AuthenticationError
         with self.assertRaises(types.DriverError):
             self.verifyConnectivity(auth_token)
 
     # Tests both basic with realm specified and also custom auth token. All
     def testSuccessOnProvideRealmWithBasicToken(self):
-        auth_token = AuthorizationToken(
+        auth_token = types.AuthorizationToken(
             scheme="basic",
             realm="native",
             principal=os.environ.get(env_neo4j_user, "neo4j"),
@@ -50,7 +53,7 @@ class TestAuthenticationBasic(TestkitTestCase):
         self.verifyConnectivity(auth_token)
 
     def testSuccessOnBasicToken(self):
-        auth_token = AuthorizationToken(
+        auth_token = types.AuthorizationToken(
             scheme="basic",
             principal=os.environ.get(env_neo4j_user, "neo4j"),
             credentials=os.environ.get(env_neo4j_pass, "pass"))

--- a/tests/neo4j/authentication.py
+++ b/tests/neo4j/authentication.py
@@ -1,16 +1,15 @@
-import unittest
-
 import os
+
 from nutkit.frontend import Driver, AuthorizationToken
 import nutkit.protocol as types
 from tests.neo4j.shared import (
         get_neo4j_host_and_port, env_neo4j_user, env_neo4j_pass)
-from tests.shared import new_backend
+from tests.shared import new_backend, TestkitTestCase
 
 
-class TestAuthenticationBasic(unittest.TestCase):
+class TestAuthenticationBasic(TestkitTestCase):
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._host, self._port = get_neo4j_host_and_port()
         self._scheme = "bolt://%s:%d" % (self._host, self._port)
         self._driver = None
@@ -21,7 +20,7 @@ class TestAuthenticationBasic(unittest.TestCase):
             self._session.close()
         if self._driver:
             self._driver.close()
-        self._backend.close()
+        super().tearDown()
 
     def createDriverAndSession(self, token):
         self._driver = Driver(self._backend, self._scheme, token)

--- a/tests/neo4j/datatypes.py
+++ b/tests/neo4j/datatypes.py
@@ -1,13 +1,11 @@
-import unittest
-
 import nutkit.protocol as types
 from tests.neo4j.shared import *
 from tests.shared import *
 
 
-class TestDataTypes(unittest.TestCase):
+class TestDataTypes(TestkitTestCase):
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._host, self._port = get_neo4j_host_and_port()
         self._scheme = "bolt://%s:%d" % (self._host, self._port)
         self._session = None
@@ -18,7 +16,7 @@ class TestDataTypes(unittest.TestCase):
             self._session.close()
         if self._driver:
             self._driver.close()
-        self._backend.close()
+        super().tearDown()
 
     def createDriverAndSession(self):
         auth_token = AuthorizationToken(scheme="basic",

--- a/tests/neo4j/datatypes.py
+++ b/tests/neo4j/datatypes.py
@@ -1,6 +1,13 @@
+import os
+
+from nutkit.frontend import Driver
 import nutkit.protocol as types
-from tests.neo4j.shared import *
-from tests.shared import *
+from tests.neo4j.shared import (
+    env_neo4j_pass,
+    env_neo4j_user,
+    get_neo4j_host_and_port,
+)
+from tests.shared import TestkitTestCase
 
 
 class TestDataTypes(TestkitTestCase):
@@ -19,9 +26,11 @@ class TestDataTypes(TestkitTestCase):
         super().tearDown()
 
     def createDriverAndSession(self):
-        auth_token = AuthorizationToken(scheme="basic",
-                                        principal=os.environ.get(env_neo4j_user, "neo4j"),
-                                        credentials=os.environ.get(env_neo4j_pass, "pass"))
+        auth_token = types.AuthorizationToken(
+            scheme="basic",
+            principal=os.environ.get(env_neo4j_user, "neo4j"),
+            credentials=os.environ.get(env_neo4j_pass, "pass")
+        )
         self._driver = Driver(self._backend, self._scheme, auth_token)
         self._session = self._driver.session("w")
 

--- a/tests/neo4j/sessionrun.py
+++ b/tests/neo4j/sessionrun.py
@@ -1,13 +1,11 @@
-import unittest
-
 import nutkit.protocol as types
 from tests.neo4j.shared import get_driver
-from tests.shared import get_driver_name, new_backend
+from tests.shared import get_driver_name, new_backend, TestkitTestCase
 
 
-class TestSessionRun(unittest.TestCase):
+class TestSessionRun(TestkitTestCase):
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._driver = get_driver(self._backend)
         self._session = None
 
@@ -15,7 +13,7 @@ class TestSessionRun(unittest.TestCase):
         if self._session:
             self._session.close()
         self._driver.close()
-        self._backend.close()
+        super().tearDown()
 
     def test_iteration_smaller_than_fetch_size(self):
         if get_driver_name() not in ['go', 'dotnet', 'javascript', 'java']:

--- a/tests/neo4j/sessionrun.py
+++ b/tests/neo4j/sessionrun.py
@@ -1,6 +1,9 @@
 import nutkit.protocol as types
 from tests.neo4j.shared import get_driver
-from tests.shared import get_driver_name, new_backend, TestkitTestCase
+from tests.shared import (
+    get_driver_name,
+    TestkitTestCase,
+)
 
 
 class TestSessionRun(TestkitTestCase):

--- a/tests/neo4j/shared.py
+++ b/tests/neo4j/shared.py
@@ -14,6 +14,7 @@ env_neo4j_host = "TEST_NEO4J_HOST"
 env_neo4j_user = "TEST_NEO4J_USER"
 env_neo4j_pass = "TEST_NEO4J_PASS"
 
+
 def get_authorization():
     """ Returns default authorization for tests that do not test this aspect
     """

--- a/tests/neo4j/shared.py
+++ b/tests/neo4j/shared.py
@@ -7,7 +7,8 @@ TEST_NEO4J_HOST    Neo4j server host, no default, required
 TEST_NEO4J_PORT    Neo4j server port, default is 7687
 """
 import os
-from nutkit.frontend import Driver, AuthorizationToken
+from nutkit.frontend import Driver
+from nutkit.protocol import AuthorizationToken
 
 
 env_neo4j_host = "TEST_NEO4J_HOST"

--- a/tests/neo4j/suites.py
+++ b/tests/neo4j/suites.py
@@ -2,15 +2,19 @@
 Defines suites of test to run in different setups
 """
 
-import unittest
 import sys
+import unittest
+
+import tests.neo4j.authentication as authentication
 import tests.neo4j.datatypes as datatypes
 import tests.neo4j.sessionrun as sessionrun
 import tests.neo4j.txfuncrun as txfuncrun
 import tests.neo4j.txrun as txrun
-import tests.neo4j.authentication as authentication
 from tests.testenv import (
-        get_test_result_class, begin_test_suite, end_test_suite)
+    begin_test_suite,
+    end_test_suite,
+    get_test_result_class,
+)
 
 loader = unittest.TestLoader()
 

--- a/tests/neo4j/txfuncrun.py
+++ b/tests/neo4j/txfuncrun.py
@@ -1,13 +1,11 @@
-import unittest
-
 import nutkit.protocol as types
 from tests.neo4j.shared import get_driver
-from tests.shared import new_backend, get_driver_name
+from tests.shared import new_backend, get_driver_name, TestkitTestCase
 
 
-class TestTxFuncRun(unittest.TestCase):
+class TestTxFuncRun(TestkitTestCase):
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._driver = get_driver(self._backend)
         self._session = None
 
@@ -15,7 +13,7 @@ class TestTxFuncRun(unittest.TestCase):
         if self._session:
             self._session.close()
         self._driver.close()
-        self._backend.close()
+        super().tearDown()
 
     def test_iteration_nested(self):
         # Verifies that it is possible to nest results with small fetch sizes

--- a/tests/neo4j/txfuncrun.py
+++ b/tests/neo4j/txfuncrun.py
@@ -1,6 +1,9 @@
 import nutkit.protocol as types
 from tests.neo4j.shared import get_driver
-from tests.shared import new_backend, get_driver_name, TestkitTestCase
+from tests.shared import (
+    get_driver_name,
+    TestkitTestCase,
+)
 
 
 class TestTxFuncRun(TestkitTestCase):

--- a/tests/neo4j/txrun.py
+++ b/tests/neo4j/txrun.py
@@ -1,12 +1,10 @@
-import unittest
-
 from tests.neo4j.shared import get_driver
-from tests.shared import new_backend, get_driver_name
+from tests.shared import new_backend, get_driver_name, TestkitTestCase
 
 
-class TestTxRun(unittest.TestCase):
+class TestTxRun(TestkitTestCase):
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._driver = get_driver(self._backend)
         self._session = None
 
@@ -14,7 +12,7 @@ class TestTxRun(unittest.TestCase):
         if self._session:
             self._session.close()
         self._driver.close()
-        self._backend.close()
+        super().tearDown()
 
     def test_updates_last_bookmark_on_commit(self):
         # Verifies that last bookmark is set on the session upon

--- a/tests/neo4j/txrun.py
+++ b/tests/neo4j/txrun.py
@@ -1,5 +1,8 @@
 from tests.neo4j.shared import get_driver
-from tests.shared import new_backend, get_driver_name, TestkitTestCase
+from tests.shared import (
+    get_driver_name,
+    TestkitTestCase,
+)
 
 
 class TestTxRun(TestkitTestCase):

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -9,13 +9,18 @@ TEST_BACKEND_PORT  Port on backend host, default is 9876
 """
 
 import os
+import re
+
+import unittest
+
+from nutkit import protocol
 from nutkit.backend import Backend
 
 
 def get_backend_host_and_port():
     host = os.environ.get('TEST_BACKEND_HOST', '127.0.0.1')
     port = os.environ.get('TEST_BACKEND_PORT', 9876)
-    return (host, port)
+    return host, port
 
 
 def new_backend():
@@ -27,3 +32,25 @@ def new_backend():
 
 def get_driver_name():
     return os.environ['TEST_DRIVER_NAME']
+
+
+class TestkitTestCase(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        id_ = re.sub(r"^([^\.]+\.)*?tests\.", "", self.id())
+        self._backend = new_backend()
+        response = self._backend.sendAndReceive(protocol.StartTest(id_))
+        try:
+            if isinstance(response, protocol.SkipTest):
+                self.skipTest(response.reason)
+            elif not isinstance(response, protocol.RunTest):
+                raise Exception("Should be SkipTest or RunTest, "
+                                "received {}: {}".format(type(response),
+                                                         response))
+        except Exception:
+            self._backend.close()
+            raise
+
+    def tearDown(self):
+        self._backend.close()
+        super().tearDown()

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -10,7 +10,6 @@ TEST_BACKEND_PORT  Port on backend host, default is 9876
 
 import os
 import re
-
 import unittest
 
 from nutkit import protocol

--- a/tests/stub/bookmark.py
+++ b/tests/stub/bookmark.py
@@ -1,7 +1,7 @@
-from tests.shared import new_backend, TestkitTestCase
+from nutkit.frontend import Driver
+from nutkit.protocol import AuthorizationToken
+from tests.shared import TestkitTestCase
 from tests.stub.shared import StubServer
-from nutkit.frontend import Driver, AuthorizationToken
-
 
 # TODO: Tests for 3.5 (no support for PULL n)
 script_commit = """

--- a/tests/stub/bookmark.py
+++ b/tests/stub/bookmark.py
@@ -1,6 +1,4 @@
-import unittest
-
-from tests.shared import new_backend
+from tests.shared import new_backend, TestkitTestCase
 from tests.stub.shared import StubServer
 from nutkit.frontend import Driver, AuthorizationToken
 
@@ -24,19 +22,19 @@ S: SUCCESS {"bookmark": "bm"}
 
 
 # Tests bookmarks from transaction
-class Tx(unittest.TestCase):
+class Tx(TestkitTestCase):
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._server = StubServer(9001)
         uri = "bolt://%s" % self._server.address
         auth = AuthorizationToken(scheme="basic")
         self._driver = Driver(self._backend, uri, auth)
 
     def tearDown(self):
-        self._backend.close()
         # If test raised an exception this will make sure that the stub server
-        # is killed and it's output is dumped for analys.
+        # is killed and it's output is dumped for analysis.
         self._server.reset()
+        super().tearDown()
 
     # Tests that a committed transaction can return the last bookmark
     def test_last_bookmark(self):

--- a/tests/stub/disconnected.py
+++ b/tests/stub/disconnected.py
@@ -1,6 +1,4 @@
-import unittest
-
-from tests.shared import new_backend, get_driver_name
+from tests.shared import new_backend, get_driver_name, TestkitTestCase
 from tests.stub.shared import StubServer
 from nutkit.frontend import Driver, AuthorizationToken
 import nutkit.protocol as types
@@ -36,9 +34,9 @@ S: <EXIT>
 """
 
 
-class SessionRunDisconnected(unittest.TestCase):
+class SessionRunDisconnected(TestkitTestCase):
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._server = StubServer(9001)
         self._driverName = get_driver_name()
         auth = AuthorizationToken(scheme="basic", principal="neo4j",
@@ -49,10 +47,10 @@ class SessionRunDisconnected(unittest.TestCase):
         self._session = self._driver.session("w")
 
     def tearDown(self):
-        self._backend.close()
         # If test raised an exception this will make sure that the stub server
-        # is killed and it's output is dumped for analys.
+        # is killed and it's output is dumped for analysis.
         self._server.reset()
+        super().tearDown()
 
     # Helper function that runs the sequence and returns the name of the step
     # at which the error happened.

--- a/tests/stub/disconnected.py
+++ b/tests/stub/disconnected.py
@@ -1,8 +1,10 @@
-from tests.shared import new_backend, get_driver_name, TestkitTestCase
-from tests.stub.shared import StubServer
-from nutkit.frontend import Driver, AuthorizationToken
+from nutkit.frontend import Driver
 import nutkit.protocol as types
-
+from tests.shared import (
+    get_driver_name,
+    TestkitTestCase,
+)
+from tests.stub.shared import StubServer
 
 # Should match user-agent of disconnect_on_hello.script
 # Indirectly tests implementation of custom user-agent
@@ -39,8 +41,8 @@ class SessionRunDisconnected(TestkitTestCase):
         super().setUp()
         self._server = StubServer(9001)
         self._driverName = get_driver_name()
-        auth = AuthorizationToken(scheme="basic", principal="neo4j",
-                                  credentials="pass")
+        auth = types.AuthorizationToken(scheme="basic", principal="neo4j",
+                                        credentials="pass")
         uri = "bolt://%s" % self._server.address
         self._driver = Driver(self._backend, uri, auth,
                               userAgent=customUserAgent)

--- a/tests/stub/iteration.py
+++ b/tests/stub/iteration.py
@@ -1,7 +1,10 @@
-from tests.shared import *
-from tests.stub.shared import *
-from nutkit.frontend import Driver, AuthorizationToken
+from nutkit.frontend import Driver
 import nutkit.protocol as types
+from tests.shared import (
+    get_driver_name,
+    TestkitTestCase,
+)
+from tests.stub.shared import StubServer
 
 
 class SessionRun(TestkitTestCase):
@@ -70,7 +73,8 @@ class SessionRun(TestkitTestCase):
 
     def _run(self, n, script, end, expectedSequence, expectedError=False):
         uri = "bolt://%s" % self._server.address
-        driver = Driver(self._backend, uri, AuthorizationToken(scheme="basic"))
+        driver = Driver(self._backend, uri,
+                        types.AuthorizationToken(scheme="basic"))
         self._server.start(script=script, vars={"#END#": end, "#VERSION#": "4"})
         session = driver.session("w", fetchSize=n)
         result = session.run("RETURN 1 AS n")
@@ -144,7 +148,8 @@ class TxRun(TestkitTestCase):
 
     def _iterate(self, n, script, expectedSequence, expectedError=False):
         uri = "bolt://%s" % self._server.address
-        driver = Driver(self._backend, uri, AuthorizationToken(scheme="basic"))
+        driver = Driver(self._backend, uri,
+                        types.AuthorizationToken(scheme="basic"))
         self._server.start(script=script, vars={"#VERSION#": "4"})
         session = driver.session("w", fetchSize=n)
         tx = session.beginTransaction()
@@ -212,7 +217,8 @@ class TxRun(TestkitTestCase):
         if get_driver_name() not in ['go', 'dotnet', 'javascript']:
             self.skipTest("Need support for specifying session fetch size in testkit backend")
         uri = "bolt://%s" % self._server.address
-        driver = Driver(self._backend, uri, AuthorizationToken(scheme="basic"))
+        driver = Driver(self._backend, uri,
+                        types.AuthorizationToken(scheme="basic"))
         self._server.start(script=TxRun.script_nested_n, vars={"#VERSION#": "4"})
         session = driver.session("w", fetchSize=1)
         tx = session.beginTransaction()

--- a/tests/stub/iteration.py
+++ b/tests/stub/iteration.py
@@ -1,12 +1,10 @@
-import unittest
-
 from tests.shared import *
 from tests.stub.shared import *
 from nutkit.frontend import Driver, AuthorizationToken
 import nutkit.protocol as types
 
 
-class SessionRun(unittest.TestCase):
+class SessionRun(TestkitTestCase):
     script_pull_all = """
     !: BOLT #VERSION#
     !: AUTO RESET
@@ -63,12 +61,12 @@ class SessionRun(unittest.TestCase):
     """
 
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._server = StubServer(9001)
 
     def tearDown(self):
-        self._backend.close()
         self._server.reset()
+        super().tearDown()
 
     def _run(self, n, script, end, expectedSequence, expectedError=False):
         uri = "bolt://%s" % self._server.address
@@ -114,7 +112,7 @@ class SessionRun(unittest.TestCase):
         self._run(-1, SessionRun.script_pull_all, "", ["1", "2", "3", "4", "5", "6"])
 
 
-class TxRun(unittest.TestCase):
+class TxRun(TestkitTestCase):
     script_n = """
     !: BOLT #VERSION#
     !: AUTO HELLO
@@ -136,14 +134,13 @@ class TxRun(unittest.TestCase):
     S: SUCCESS {"bookmark": "bm"}
     """
 
-
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._server = StubServer(9001)
 
     def tearDown(self):
-        self._backend.close()
         self._server.reset()
+        super().tearDown()
 
     def _iterate(self, n, script, expectedSequence, expectedError=False):
         uri = "bolt://%s" % self._server.address

--- a/tests/stub/retry.py
+++ b/tests/stub/retry.py
@@ -1,8 +1,10 @@
-from tests.shared import new_backend, get_driver_name, TestkitTestCase
-from tests.stub.shared import StubServer
-from nutkit.frontend import Driver, AuthorizationToken
+from nutkit.frontend import Driver
 import nutkit.protocol as types
-
+from tests.shared import (
+    get_driver_name,
+    TestkitTestCase,
+)
+from tests.stub.shared import StubServer
 
 script_read = """
 !: BOLT 4
@@ -148,8 +150,8 @@ class TestRetry(TestkitTestCase):
             record = result.next()
             return record.values[0]
 
-        auth = AuthorizationToken(scheme="basic", principal="neo4j",
-                                  credentials="pass")
+        auth = types.AuthorizationToken(scheme="basic", principal="neo4j",
+                                        credentials="pass")
         driver = Driver(self._backend,
                         "bolt://%s" % self._server.address, auth)
         session = driver.session("r")
@@ -185,8 +187,8 @@ class TestRetry(TestkitTestCase):
             record = result.next()
             return record.values[0]
 
-        auth = AuthorizationToken(scheme="basic", principal="neo4j",
-                                  credentials="pass")
+        auth = types.AuthorizationToken(scheme="basic", principal="neo4j",
+                                        credentials="pass")
         driver = Driver(self._backend,
                         "bolt://%s" % self._server.address, auth)
         session = driver.session("r")
@@ -227,7 +229,7 @@ class TestRetry(TestkitTestCase):
             num_retries = num_retries + 1
             result = tx.run("RETURN 1")
             result.next()
-        auth = AuthorizationToken(scheme="basic")
+        auth = types.AuthorizationToken(scheme="basic")
         driver = Driver(self._backend,
                         "bolt://%s" % self._server.address, auth)
         session = driver.session("w")
@@ -248,8 +250,8 @@ class TestRetryClustering(TestkitTestCase):
         self._readServer = StubServer(9002)
         self._writeServer = StubServer(9003)
         self._uri = "neo4j://%s?region=china&policy=my_policy" % self._routingServer.address
-        self._auth = AuthorizationToken(
-                scheme="basic", principal="p", credentials="c")
+        self._auth = types.AuthorizationToken(scheme="basic", principal="p",
+                                              credentials="c")
         self._userAgent = "007"
 
     def tearDown(self):

--- a/tests/stub/routing.py
+++ b/tests/stub/routing.py
@@ -1,6 +1,4 @@
-import unittest
-
-from tests.shared import get_driver_name, new_backend
+from tests.shared import get_driver_name, new_backend, TestkitTestCase
 from tests.stub.shared import StubServer
 from nutkit.frontend import Driver, AuthorizationToken
 from sys import platform
@@ -21,9 +19,9 @@ def get_extra_hello_props():
 # This should be the latest/current version of the protocol.
 # Older protocol that needs to be tested inherits from this and override
 # to handle variations.
-class Routing(unittest.TestCase):
+class Routing(TestkitTestCase):
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._routingServer1 = StubServer(9000)
         self._routingServer2 = StubServer(9001)
         self._routingServer3 = StubServer(9002)
@@ -39,7 +37,6 @@ class Routing(unittest.TestCase):
         self._userAgent = "007"
 
     def tearDown(self):
-        self._backend.close()
         self._routingServer1.reset()
         self._routingServer2.reset()
         self._routingServer3.reset()
@@ -49,6 +46,7 @@ class Routing(unittest.TestCase):
         self._writeServer1.reset()
         self._writeServer2.reset()
         self._writeServer3.reset()
+        super().tearDown()
 
     def router_script(self):
         return """
@@ -2826,14 +2824,14 @@ class RoutingV3(Routing):
         pass
 
 
-class NoRouting(unittest.TestCase):
+class NoRouting(TestkitTestCase):
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._server = StubServer(9000)
 
     def tearDown(self):
-        self._backend.close()
         self._server.reset()
+        super().tearDown()
 
     def script(self):
         return """

--- a/tests/stub/routing.py
+++ b/tests/stub/routing.py
@@ -1,11 +1,15 @@
-from tests.shared import get_driver_name, new_backend, TestkitTestCase
-from tests.stub.shared import StubServer
-from nutkit.frontend import Driver, AuthorizationToken
-from sys import platform
-import nutkit.protocol as types
-import socket
 import fcntl
+import socket
 import struct
+from sys import platform
+
+from nutkit.frontend import Driver
+import nutkit.protocol as types
+from tests.shared import (
+    get_driver_name,
+    TestkitTestCase,
+)
+from tests.stub.shared import StubServer
 
 
 def get_extra_hello_props():
@@ -32,7 +36,7 @@ class Routing(TestkitTestCase):
         self._writeServer2 = StubServer(9021)
         self._writeServer3 = StubServer(9022)
         self._uri = "neo4j://%s?region=china&policy=my_policy" % self._routingServer1.address
-        self._auth = AuthorizationToken(
+        self._auth = types.AuthorizationToken(
             scheme="basic", principal="p", credentials="c")
         self._userAgent = "007"
 
@@ -2863,8 +2867,9 @@ class NoRouting(TestkitTestCase):
         uri = "bolt://%s" % self._server.address
         self._server.start(script=self.script(), vars=self.get_vars())
         driver = Driver(self._backend, uri,
-                        AuthorizationToken(scheme="basic", principal="p",
-                                           credentials="c"), userAgent="007")
+                        types.AuthorizationToken(scheme="basic", principal="p",
+                                                 credentials="c"),
+                        userAgent="007")
 
         session = driver.session('r', database="adb")
         session.run("RETURN 1 as n")

--- a/tests/stub/sessionparameters.py
+++ b/tests/stub/sessionparameters.py
@@ -1,9 +1,10 @@
-import os
-
-from tests.shared import *
-from tests.stub.shared import *
-from nutkit.frontend import Driver, AuthorizationToken
+from nutkit.frontend import Driver
 import nutkit.protocol as types
+from tests.shared import (
+    get_driver_name,
+    TestkitTestCase,
+)
+from tests.stub.shared import StubServer
 
 script_accessmode_read = """
 !: BOLT 4
@@ -97,9 +98,9 @@ class SessionRunParameters(TestkitTestCase):
         super().setUp()
         self._server = StubServer(9001)
         self._driverName = get_driver_name()
-        auth = AuthorizationToken()
         uri = "bolt://%s" % self._server.address
-        self._driver = Driver(self._backend, uri, AuthorizationToken(scheme="basic"))
+        self._driver = Driver(self._backend, uri,
+                              types.AuthorizationToken(scheme="basic"))
 
     def tearDown(self):
         # If test raised an exception this will make sure that the stub server

--- a/tests/stub/sessionparameters.py
+++ b/tests/stub/sessionparameters.py
@@ -1,4 +1,4 @@
-import unittest, os
+import os
 
 from tests.shared import *
 from tests.stub.shared import *
@@ -92,9 +92,9 @@ S: SUCCESS {"fields": ["n"]}
 #   Transaction meta data + write mode
 #   Transaction timeout + write mode
 #   Read mode + transaction meta data + transaction timeout + bookmarks
-class SessionRunParameters(unittest.TestCase):
+class SessionRunParameters(TestkitTestCase):
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._server = StubServer(9001)
         self._driverName = get_driver_name()
         auth = AuthorizationToken()
@@ -102,10 +102,10 @@ class SessionRunParameters(unittest.TestCase):
         self._driver = Driver(self._backend, uri, AuthorizationToken(scheme="basic"))
 
     def tearDown(self):
-        self._backend.close()
         # If test raised an exception this will make sure that the stub server
-        # is killed and it's output is dumped for analys.
+        # is killed and it's output is dumped for analysis.
         self._server.reset()
+        super().tearDown()
 
     def _run(self, accessMode, params=None, bookmarks=None, txMeta=None, timeout=None):
         session = self._driver.session(accessMode, bookmarks=bookmarks)

--- a/tests/stub/shared.py
+++ b/tests/stub/shared.py
@@ -2,10 +2,10 @@
 
 Uses environment variables for configuration:
 """
-import subprocess
 import os
-import tempfile
 import platform
+import subprocess
+import tempfile
 import time
 
 

--- a/tests/stub/suites.py
+++ b/tests/stub/suites.py
@@ -2,19 +2,23 @@
 Defines stub suites
 """
 
-import unittest
 import sys
-import tests.stub.retry as retry
-import tests.stub.disconnected as disconnected
-import tests.stub.transport as transport
-import tests.stub.sessionparameters as sessionparameters
-import tests.stub.txparameters as txparameters
-import tests.stub.routing as routing
+import unittest
+
 import tests.stub.bookmark as bookmark
+import tests.stub.disconnected as disconnected
 import tests.stub.iteration as iteration
+import tests.stub.retry as retry
+import tests.stub.routing as routing
+import tests.stub.sessionparameters as sessionparameters
+import tests.stub.transport as transport
+import tests.stub.txparameters as txparameters
 import tests.stub.versions as versions
 from tests.testenv import (
-        get_test_result_class, begin_test_suite, end_test_suite)
+    begin_test_suite,
+    end_test_suite,
+    get_test_result_class,
+)
 
 loader = unittest.TestLoader()
 

--- a/tests/stub/transport.py
+++ b/tests/stub/transport.py
@@ -1,9 +1,10 @@
-import os
-
-from tests.shared import *
-from tests.stub.shared import *
-from nutkit.frontend import Driver, AuthorizationToken
+from nutkit.frontend import Driver
 import nutkit.protocol as types
+from tests.shared import (
+    get_driver_name,
+    TestkitTestCase,
+)
+from tests.stub.shared import StubServer
 
 script = """
 !: BOLT $bolt_version
@@ -30,7 +31,8 @@ class Transport(TestkitTestCase):
         super().setUp()
         self._server = StubServer(9001)
         self._driverName = get_driver_name()
-        auth = AuthorizationToken(scheme="basic", principal="neo4j", credentials="pass")
+        auth = types.AuthorizationToken(scheme="basic", principal="neo4j",
+                                        credentials="pass")
         uri = "bolt://%s" % self._server.address
         self._driver = Driver(self._backend, uri, auth)
         self._session = self._driver.session("w")

--- a/tests/stub/transport.py
+++ b/tests/stub/transport.py
@@ -1,5 +1,4 @@
-
-import unittest, os
+import os
 
 from tests.shared import *
 from tests.stub.shared import *
@@ -24,16 +23,21 @@ S: SUCCESS {"fields": ["n"]}
    SUCCESS {"type": "w"}
 """
 
+
 # Low-level network transport tests
-class Transport(unittest.TestCase):
+class Transport(TestkitTestCase):
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._server = StubServer(9001)
         self._driverName = get_driver_name()
         auth = AuthorizationToken(scheme="basic", principal="neo4j", credentials="pass")
         uri = "bolt://%s" % self._server.address
         self._driver = Driver(self._backend, uri, auth)
         self._session = self._driver.session("w")
+
+    def tearDown(self):
+        self._server.reset()
+        super().tearDown()
 
     def test_noop(self):
         # Verifies that no op messages sent on bolt chunking layer are ignored. The no op messages

--- a/tests/stub/txparameters.py
+++ b/tests/stub/txparameters.py
@@ -1,4 +1,4 @@
-import unittest, os
+import os
 
 from tests.shared import *
 from tests.stub.shared import *
@@ -105,19 +105,19 @@ S: SUCCESS {}
 #   Transaction meta data + write mode
 #   Transaction timeout + write mode
 #   Read mode + transaction meta data + transaction timeout + bookmarks
-class TxBeginParameters(unittest.TestCase):
+class TxBeginParameters(TestkitTestCase):
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._server = StubServer(9001)
         self._driverName = get_driver_name()
         uri = "bolt://%s" % self._server.address
         self._driver = Driver(self._backend, uri, AuthorizationToken(scheme="basic"))
 
     def tearDown(self):
-        self._backend.close()
         # If test raised an exception this will make sure that the stub server
-        # is killed and it's output is dumped for analys.
+        # is killed and it's output is dumped for analysis.
         self._server.reset()
+        super().tearDown()
 
     def _run(self, accessMode, params=None, bookmarks=None, txMeta=None, timeout=None):
         session = self._driver.session(accessMode, bookmarks=bookmarks)

--- a/tests/stub/txparameters.py
+++ b/tests/stub/txparameters.py
@@ -1,9 +1,10 @@
-import os
-
-from tests.shared import *
-from tests.stub.shared import *
-from nutkit.frontend import Driver, AuthorizationToken
+from nutkit.frontend import Driver
 import nutkit.protocol as types
+from tests.shared import (
+    get_driver_name,
+    TestkitTestCase,
+)
+from tests.stub.shared import StubServer
 
 script_accessmode_read = """
 !: BOLT 4
@@ -111,7 +112,8 @@ class TxBeginParameters(TestkitTestCase):
         self._server = StubServer(9001)
         self._driverName = get_driver_name()
         uri = "bolt://%s" % self._server.address
-        self._driver = Driver(self._backend, uri, AuthorizationToken(scheme="basic"))
+        self._driver = Driver(self._backend, uri,
+                              types.AuthorizationToken(scheme="basic"))
 
     def tearDown(self):
         # If test raised an exception this will make sure that the stub server

--- a/tests/stub/versions.py
+++ b/tests/stub/versions.py
@@ -1,21 +1,20 @@
-import unittest
-from tests.shared import new_backend, get_driver_name
+from tests.shared import new_backend, get_driver_name, TestkitTestCase
 from tests.stub.shared import StubServer
 from nutkit.frontend import Driver, AuthorizationToken
 
 
-class ProtocolVersions(unittest.TestCase):
+class ProtocolVersions(TestkitTestCase):
     """ Verifies that the driver can connect to a server that speaks a specific
     bolt protocol version.
     """
 
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._server = StubServer(9001)
 
     def tearDown(self):
-        self._backend.close()
         self._server.reset()
+        super().tearDown()
 
     def _run(self, version, pull='PULL {"n": 1000}'):
         script = """

--- a/tests/stub/versions.py
+++ b/tests/stub/versions.py
@@ -1,6 +1,10 @@
-from tests.shared import new_backend, get_driver_name, TestkitTestCase
+from nutkit.frontend import Driver
+from nutkit.protocol import AuthorizationToken
+from tests.shared import (
+    get_driver_name,
+    TestkitTestCase,
+)
 from tests.stub.shared import StubServer
-from nutkit.frontend import Driver, AuthorizationToken
 
 
 class ProtocolVersions(TestkitTestCase):

--- a/tests/testenv.py
+++ b/tests/testenv.py
@@ -1,5 +1,8 @@
-import unittest
-from teamcity import in_teamcity, TeamCityTestResult, escape
+from teamcity import (
+    escape,
+    in_teamcity,
+    TeamCityTestResult,
+)
 
 
 def begin_test_suite(name):

--- a/tests/tls/securescheme.py
+++ b/tests/tls/securescheme.py
@@ -1,5 +1,12 @@
-from tests.shared import *
-from tests.tls.shared import *
+from tests.shared import (
+    get_driver_name,
+    TestkitTestCase,
+)
+from tests.tls.shared import (
+    TlsServer,
+    try_connect,
+)
+
 
 schemes = ["neo4j+s", "bolt+s"]
 

--- a/tests/tls/securescheme.py
+++ b/tests/tls/securescheme.py
@@ -1,25 +1,25 @@
-import unittest
 from tests.shared import *
 from tests.tls.shared import *
 
 schemes = ["neo4j+s", "bolt+s"]
 
-class TestSecureScheme(unittest.TestCase):
+
+class TestSecureScheme(TestkitTestCase):
     """ Tests URL scheme neo4j+s/bolt+s where server is assumed to present a server certificate
     signed by a certificate authority recognized by the driver.
     """
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._server = None
         self._driver = get_driver_name()
 
     def tearDown(self):
         if self._server:
-            # If test raised an exception this will make sure that the stub server
-            # is killed and it's output is dumped for analys.
+            # If test raised an exception this will make sure that the stub
+            # server is killed and it's output is dumped for analysis.
             self._server.reset()
             self._server = None
-        self._backend.close()
+        super().tearDown()
 
     """ Happy path, the server has a valid server certificate signed by a trusted
     certificate authority.

--- a/tests/tls/selfsignedscheme.py
+++ b/tests/tls/selfsignedscheme.py
@@ -1,25 +1,24 @@
-import unittest
 from tests.shared import *
 from tests.tls.shared import *
 
 schemes = ["neo4j+ssc", "bolt+ssc"]
 
-class TestSelfSignedScheme(unittest.TestCase):
+class TestSelfSignedScheme(TestkitTestCase):
     """ Tests URL scheme neo4j+ssc/bolt+ssc where server is assumed to present a signed server certificate
     but not necessarily signed by an authority recognized by the driver.
     """
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._server = None
         self._driver = get_driver_name()
 
     def tearDown(self):
         if self._server:
-            # If test raised an exception this will make sure that the stub server
-            # is killed and it's output is dumped for analys.
+            # If test raised an exception this will make sure that the stub
+            # server is killed and it's output is dumped for analysis.
             self._server.reset()
             self._server = None
-        self._backend.close()
+        super().tearDown()
 
     """ A server certificate signed by a trusted CA should be accepted even when configured
     for self signed.

--- a/tests/tls/selfsignedscheme.py
+++ b/tests/tls/selfsignedscheme.py
@@ -1,7 +1,15 @@
-from tests.shared import *
-from tests.tls.shared import *
+from tests.shared import (
+    get_driver_name,
+    TestkitTestCase,
+)
+from tests.tls.shared import (
+    TlsServer,
+    try_connect,
+)
+
 
 schemes = ["neo4j+ssc", "bolt+ssc"]
+
 
 class TestSelfSignedScheme(TestkitTestCase):
     """ Tests URL scheme neo4j+ssc/bolt+ssc where server is assumed to present a signed server certificate

--- a/tests/tls/shared.py
+++ b/tests/tls/shared.py
@@ -1,11 +1,11 @@
 import os
-import platform
 import subprocess
 import sys
 import time
 
-from tests.shared import *
-from nutkit.frontend import Driver, AuthorizationToken
+from nutkit.frontend import Driver
+from nutkit.protocol import AuthorizationToken
+
 
 # Retrieve path to the repository containing this script.
 # Use this path as base for locating a whole bunch of other stuff.

--- a/tests/tls/shared.py
+++ b/tests/tls/shared.py
@@ -1,4 +1,9 @@
-import subprocess, platform, os, time, sys
+import os
+import platform
+import subprocess
+import sys
+import time
+
 from tests.shared import *
 from nutkit.frontend import Driver, AuthorizationToken
 

--- a/tests/tls/suites.py
+++ b/tests/tls/suites.py
@@ -2,12 +2,19 @@
 Define TLS suite
 """
 
-import unittest, sys
+import sys
+import unittest
+
+from tests.testenv import (
+    begin_test_suite,
+    end_test_suite,
+    get_test_result_class,
+)
 import tests.tls.securescheme as securescheme
 import tests.tls.selfsignedscheme as selfsignedscheme
-import tests.tls.unsecurescheme as unsecurescheme
 import tests.tls.tlsversions as tlsversions
-from tests.testenv import get_test_result_class, begin_test_suite, end_test_suite, in_teamcity
+import tests.tls.unsecurescheme as unsecurescheme
+
 
 loader = unittest.TestLoader()
 

--- a/tests/tls/tlsversions.py
+++ b/tests/tls/tlsversions.py
@@ -1,5 +1,11 @@
-from tests.shared import get_driver_name, new_backend, TestkitTestCase
-from tests.tls.shared import TlsServer, try_connect
+from tests.shared import (
+    get_driver_name,
+    TestkitTestCase,
+)
+from tests.tls.shared import (
+    TlsServer,
+    try_connect,
+)
 
 
 class TestTlsVersions(TestkitTestCase):

--- a/tests/tls/tlsversions.py
+++ b/tests/tls/tlsversions.py
@@ -1,22 +1,21 @@
-import unittest
-from tests.shared import get_driver_name, new_backend
+from tests.shared import get_driver_name, new_backend, TestkitTestCase
 from tests.tls.shared import TlsServer, try_connect
 
 
-class TestTlsVersions(unittest.TestCase):
+class TestTlsVersions(TestkitTestCase):
 
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._server = None
         self._driver = get_driver_name()
 
     def tearDown(self):
         if self._server:
             # If test raised an exception this will make sure that the stub
-            # server is killed and it's output is dumped for analys.
+            # server is killed and it's output is dumped for analysis.
             self._server.reset()
             self._server = None
-        self._backend.close()
+        super().tearDown()
 
     def test_1_1(self):
         if self._driver in ["dotnet", "python"]:

--- a/tests/tls/unsecurescheme.py
+++ b/tests/tls/unsecurescheme.py
@@ -1,5 +1,12 @@
-from tests.shared import *
-from tests.tls.shared import *
+from tests.shared import (
+    get_driver_name,
+    TestkitTestCase,
+)
+from tests.tls.shared import (
+    TlsServer,
+    try_connect,
+)
+
 
 schemes = ["neo4j", "bolt"]
 

--- a/tests/tls/unsecurescheme.py
+++ b/tests/tls/unsecurescheme.py
@@ -1,26 +1,26 @@
-import unittest
 from tests.shared import *
 from tests.tls.shared import *
 
 schemes = ["neo4j", "bolt"]
 
-class TestUnsecureScheme(unittest.TestCase):
+
+class TestUnsecureScheme(TestkitTestCase):
     """ Tests URL scheme neo4j/bolt where TLS is not used. The fact that driver can not connect
     to a TLS server with this configuration is less interesting than the error handling when
     this happens, the driver backend should "survive" (without special hacks in it).
     """
     def setUp(self):
-        self._backend = new_backend()
+        super().setUp()
         self._server = None
         self._driver = get_driver_name()
 
     def tearDown(self):
         if self._server:
-            # If test raised an exception this will make sure that the stub server
-            # is killed and it's output is dumped for analys.
+            # If test raised an exception this will make sure that the stub
+            # server is killed and it's output is dumped for analysis.
             self._server.reset()
             self._server = None
-        self._backend.close()
+        super().tearDown()
 
     def test_secure_server(self):
         for scheme in schemes:


### PR DESCRIPTION
Instead of having to change testkit code whenever a driver want's to skip a test, this introduces 3 messages with which testkit and the driver's backend can negotiate which tests to run.