### PR TITLE
Enabled 2 tests for java driver where router is also a reader

### DIFF
--- a/tests/stub/routing.py
+++ b/tests/stub/routing.py
@@ -36,7 +36,8 @@ class Routing(TestkitTestCase):
         self._writeServer2 = StubServer(9021)
         self._writeServer3 = StubServer(9022)
         self._uri_template = "neo4j://%s:%d"
-        self._uri_template_with_context = self._uri_template + "?region=china&policy=my_policy"
+        self._uri_template_with_context = \
+            self._uri_template + "?region=china&policy=my_policy"
         self._uri_with_context = self._uri_template_with_context % (
             self._routingServer1.host, self._routingServer1.port)
         self._auth = types.AuthorizationToken(
@@ -1569,24 +1570,28 @@ class Routing(TestkitTestCase):
         self._readServer1.done()
         self.assertEqual([[1]], sequences)
 
-    def test_should_successfully_read_from_readable_router_using_tx_function(self):
+    def test_should_successfully_read_from_readable_router_using_tx_function(
+            self):
         # TODO remove this block once all languages work
         if get_driver_name() in ['dotnet', 'go', 'javascript']:
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python']:
             self.skipTest("requires investigation")
-        # Some drivers (for instance, java) may use separate connections for readers and writers when they are addressed
-        # by domain names in routing table. Since this test is not for testing DNS resolution, it has been switched to
-        # IP-based address model.
+        # Some drivers (for instance, java) may use separate connections for
+        # readers and writers when they are addressed by domain names in routing
+        # table. Since this test is not for testing DNS resolution, it has been
+        # switched to IP-based address model.
         ip_addresses = []
         if platform == "linux":
             ip_addresses = self.get_ip_addresses()
         if len(ip_addresses) < 1:
             self.skipTest("only linux is supported at the moment")
         ip_address = ip_addresses[0]
-        driver = Driver(self._backend, self._uri_template_with_context % (ip_address, self._routingServer1.port),
-                        self._auth, self._userAgent)
-        self._routingServer1.start(script=self.router_script_with_reader_support(), vars=self.get_vars(ip_address))
+        driver = Driver(self._backend, self._uri_template_with_context % (
+            ip_address, self._routingServer1.port), self._auth, self._userAgent)
+        self._routingServer1.start(
+            script=self.router_script_with_reader_support(),
+            vars=self.get_vars(host=ip_address))
 
         session = driver.session('r', database=self.get_db())
         sequences = []
@@ -1608,19 +1613,21 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python']:
             self.skipTest("requires investigation")
-        # Some drivers (for instance, java) may use separate connections for readers and writers when they are addressed
-        # by domain names in routing table. Since this test is not for testing DNS resolution, it has been switched to
-        # IP-based address model.
+        # Some drivers (for instance, java) may use separate connections for
+        # readers and writers when they are addressed by domain names in routing
+        # table. Since this test is not for testing DNS resolution, it has been
+        # switched to IP-based address model.
         ip_addresses = []
         if platform == "linux":
             ip_addresses = self.get_ip_addresses()
         if len(ip_addresses) < 1:
             self.skipTest("only linux is supported at the moment")
         ip_address = ip_addresses[0]
-        driver = Driver(self._backend, self._uri_template % (ip_address, self._routingServer1.port), self._auth,
-                        self._userAgent)
-        self._routingServer1.start(script=self.router_script_with_empty_context_and_reader_support(),
-                                   vars=self.get_vars(ip_address))
+        driver = Driver(self._backend, self._uri_template % (
+            ip_address, self._routingServer1.port), self._auth, self._userAgent)
+        self._routingServer1.start(
+            script=self.router_script_with_empty_context_and_reader_support(),
+            vars=self.get_vars(host=ip_address))
 
         session = driver.session('r', database=self.get_db())
         sequences = []

--- a/tests/stub/routing.py
+++ b/tests/stub/routing.py
@@ -35,7 +35,10 @@ class Routing(TestkitTestCase):
         self._writeServer1 = StubServer(9020)
         self._writeServer2 = StubServer(9021)
         self._writeServer3 = StubServer(9022)
-        self._uri = "neo4j://%s?region=china&policy=my_policy" % self._routingServer1.address
+        self._uri_template = "neo4j://%s:%d"
+        self._uri_template_with_context = self._uri_template + "?region=china&policy=my_policy"
+        self._uri_with_context = self._uri_template_with_context % (
+            self._routingServer1.host, self._routingServer1.port)
         self._auth = types.AuthorizationToken(
             scheme="basic", principal="p", credentials="c")
         self._userAgent = "007"
@@ -670,8 +673,9 @@ class Routing(TestkitTestCase):
         S: IGNORED
         """
 
-    def get_vars(self):
-        host = self._routingServer1.host
+    def get_vars(self, host=None):
+        if host is None:
+            host = self._routingServer1.host
         v = {
             "#VERSION#": "4.3",
             "#HOST#": host,
@@ -722,7 +726,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['go', 'python', 'javascript']:
             self.skipTest("needs verifyConnectivity support")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
 
         driver.verifyConnectivity()
@@ -737,7 +741,7 @@ class Routing(TestkitTestCase):
         # TODO remove this block once all languages work
         if get_driver_name() in ['go', 'javascript']:
             self.skipTest("needs ROUTE bookmark list support")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_script(), vars=self.get_vars())
 
@@ -755,7 +759,7 @@ class Routing(TestkitTestCase):
         # TODO remove this block once all languages work
         if get_driver_name() in ['go', 'javascript']:
             self.skipTest("needs ROUTE bookmark list support")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_default_db(), vars=self.get_vars())
         self._readServer1.start(script=self.read_script(), vars=self.get_vars())
 
@@ -774,7 +778,7 @@ class Routing(TestkitTestCase):
         # TODO remove this block once all languages work
         if get_driver_name() in ['go', 'javascript']:
             self.skipTest("needs ROUTE bookmark list support")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_tx_script(), vars=self.get_vars())
 
@@ -797,7 +801,7 @@ class Routing(TestkitTestCase):
         if get_driver_name() in ["python"]:
             self.skipTest("opens a new connection each time to get a fresh "
                           "routing table")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_with_bookmarks_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.router_with_bookmarks_script_create_db(), vars=self.get_vars())
 
@@ -820,7 +824,7 @@ class Routing(TestkitTestCase):
         # TODO remove this block once all languages work
         if get_driver_name() in ['go', 'javascript']:
             self.skipTest("needs ROUTE bookmark list support")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_tx_script(), vars=self.get_vars())
 
@@ -845,7 +849,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python', 'go']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_script(), vars=self.get_vars())
         self._readServer2.start(script=self.read_script(), vars=self.get_vars())
@@ -869,7 +873,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python', 'go']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_tx_script(), vars=self.get_vars())
         self._readServer2.start(script=self.read_tx_script(), vars=self.get_vars())
@@ -895,7 +899,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python', 'javascript', 'go']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_script_with_unexpected_interruption(), vars=self.get_vars())
 
@@ -920,7 +924,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python', 'go']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_tx_script_with_unexpected_interruption(), vars=self.get_vars())
 
@@ -946,7 +950,7 @@ class Routing(TestkitTestCase):
         # TODO remove this block once all languages work
         if get_driver_name() in ['go', 'javascript']:
             self.skipTest("needs ROUTE bookmark list support")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_script(), vars=self.get_vars())
 
@@ -963,7 +967,7 @@ class Routing(TestkitTestCase):
         # TODO remove this block once all languages work
         if get_driver_name() in ['go', 'javascript']:
             self.skipTest("needs ROUTE bookmark list support")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script(), vars=self.get_vars())
 
@@ -981,7 +985,7 @@ class Routing(TestkitTestCase):
         # TODO remove this block once all languages work
         if get_driver_name() in ['go', 'javascript']:
             self.skipTest("needs ROUTE bookmark list support")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script(), vars=self.get_vars())
 
@@ -1003,7 +1007,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['dotnet', 'python']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent, None)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent, None)
         self._routingServer1.start(script=self.router_script_with_two_requests(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script_with_leader_switch_and_retry(), vars=self.get_vars())
 
@@ -1030,7 +1034,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['dotnet', 'go', 'python', 'javascript']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_leader_change(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script_with_unexpected_interruption(), vars=self.get_vars())
         self._writeServer2.start(script=self.write_tx_script(), vars=self.get_vars())
@@ -1061,7 +1065,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['dotnet', 'go', 'python', 'javascript']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_leader_change(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script_with_database_unavailable_failure_on_commit(),
                                  vars=self.get_vars())
@@ -1093,7 +1097,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python', 'go']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_script(), vars=self.get_vars())
         self._writeServer2.start(script=self.write_script(), vars=self.get_vars())
@@ -1114,7 +1118,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python', 'go']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script(), vars=self.get_vars())
         self._writeServer2.start(script=self.write_tx_script(), vars=self.get_vars())
@@ -1137,7 +1141,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python', 'javascript', 'go']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_script_with_unexpected_interruption(), vars=self.get_vars())
 
@@ -1162,7 +1166,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python', 'go']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script_with_unexpected_interruption(), vars=self.get_vars())
 
@@ -1189,7 +1193,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python', 'javascript', 'go']:
             self.skipTest("verifyConnectivity not implemented in backend")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_procedure_not_found_failure(), vars=self.get_vars())
 
         failed = False
@@ -1213,7 +1217,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python', 'javascript', 'go']:
             self.skipTest("verifyConnectivity not implemented in backend")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_unknown_failure(), vars=self.get_vars())
 
         failed = False
@@ -1235,7 +1239,7 @@ class Routing(TestkitTestCase):
         if get_driver_name() in ['go', 'javascript']:
             self.skipTest("needs ROUTE bookmark list support")
 
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_script_with_not_a_leader_failure(), vars=self.get_vars())
 
@@ -1260,7 +1264,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python', 'javascript', 'go']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_script_with_not_a_leader_failure(), vars=self.get_vars())
 
@@ -1285,7 +1289,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['go']:
             self.skipTest("consume not implemented in backend")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script_with_not_a_leader_failure(), vars=self.get_vars())
 
@@ -1312,7 +1316,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python', 'go']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script_with_not_a_leader_failure(), vars=self.get_vars())
 
@@ -1337,7 +1341,7 @@ class Routing(TestkitTestCase):
         # TODO remove this block once all languages work
         if get_driver_name() in ['go', 'javascript']:
             self.skipTest("needs ROUTE bookmark list support")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script_with_bookmarks(), vars=self.get_vars())
 
@@ -1357,7 +1361,7 @@ class Routing(TestkitTestCase):
         # TODO remove this block once all languages work
         if get_driver_name() in ['go', 'javascript']:
             self.skipTest("needs ROUTE bookmark list support")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_tx_script_with_bookmarks(), vars=self.get_vars())
 
@@ -1381,7 +1385,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['javascript']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_read_tx_script_with_bookmark(), vars=self.get_vars())
 
@@ -1410,7 +1414,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['dotnet', 'python']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_tx_script_with_unexpected_interruption(), vars=self.get_vars())
         self._readServer2.start(script=self.read_tx_script(), vars=self.get_vars())
@@ -1441,7 +1445,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['dotnet', 'python']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script_with_unexpected_interruption(), vars=self.get_vars())
         self._writeServer2.start(script=self.write_tx_script(), vars=self.get_vars())
@@ -1472,7 +1476,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['dotnet', 'python', 'javascript', 'go']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_another_router(), vars=self.get_vars())
         self._routingServer2.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_tx_script_with_unexpected_interruption(), vars=self.get_vars())
@@ -1507,7 +1511,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['dotnet', 'python', 'javascript', 'go']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_another_router(), vars=self.get_vars())
         self._routingServer2.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script_with_unexpected_interruption(), vars=self.get_vars())
@@ -1542,7 +1546,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python', 'javascript', 'go']:
             self.skipTest("verifyConnectivity not implemented in backend")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_another_router_and_fake_reader(),
                                    vars=self.get_vars())
         self._readServer1.start(script=self.read_tx_script(), vars=self.get_vars())
@@ -1571,12 +1575,18 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python']:
             self.skipTest("requires investigation")
-        # TODO remove this block once it works
-        if get_driver_name() in ['java']:
-            self.skipTest("java driver uses separate connections for routing and reading, "
-                          "but the stub server does not currently support this")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
-        self._routingServer1.start(script=self.router_script_with_reader_support(), vars=self.get_vars())
+        # Some drivers (for instance, java) may use separate connections for readers and writers when they are addressed
+        # by domain names in routing table. Since this test is not for testing DNS resolution, it has been switched to
+        # IP-based address model.
+        ip_addresses = []
+        if platform == "linux":
+            ip_addresses = self.get_ip_addresses()
+        if len(ip_addresses) < 1:
+            self.skipTest("only linux is supported at the moment")
+        ip_address = ip_addresses[0]
+        driver = Driver(self._backend, self._uri_template_with_context % (ip_address, self._routingServer1.port),
+                        self._auth, self._userAgent)
+        self._routingServer1.start(script=self.router_script_with_reader_support(), vars=self.get_vars(ip_address))
 
         session = driver.session('r', database=self.get_db())
         sequences = []
@@ -1598,13 +1608,19 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python']:
             self.skipTest("requires investigation")
-        # TODO remove this block once it works
-        if get_driver_name() in ['java']:
-            self.skipTest("java driver uses separate connections for routing and reading, "
-                          "but the stub server does not currently support this")
-        driver = Driver(self._backend, "neo4j://%s" % self._routingServer1.address, self._auth, self._userAgent)
+        # Some drivers (for instance, java) may use separate connections for readers and writers when they are addressed
+        # by domain names in routing table. Since this test is not for testing DNS resolution, it has been switched to
+        # IP-based address model.
+        ip_addresses = []
+        if platform == "linux":
+            ip_addresses = self.get_ip_addresses()
+        if len(ip_addresses) < 1:
+            self.skipTest("only linux is supported at the moment")
+        ip_address = ip_addresses[0]
+        driver = Driver(self._backend, self._uri_template % (ip_address, self._routingServer1.port), self._auth,
+                        self._userAgent)
         self._routingServer1.start(script=self.router_script_with_empty_context_and_reader_support(),
-                                   vars=self.get_vars())
+                                   vars=self.get_vars(ip_address))
 
         session = driver.session('r', database=self.get_db())
         sequences = []
@@ -1626,7 +1642,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['dotnet', 'python', 'go']:
             self.skipTest("consume not implemented in backend or requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_empty_writers(), vars=self.get_vars())
         self._routingServer2.start(script=self.router_script_with_empty_writers(), vars=self.get_vars())
         self._readServer1.start(script=self.read_tx_script(), vars=self.get_vars())
@@ -1662,7 +1678,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python', 'javascript', 'go', 'dotnet']:
             self.skipTest("verifyConnectivity not implemented in backend")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_empty_writers(), vars=self.get_vars())
         self._readServer1.start(script=self.read_tx_script_with_bookmarks(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_script_with_bookmark(), vars=self.get_vars())
@@ -1693,7 +1709,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['python', 'go']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_script(), vars=self.get_vars())
         self._readServer2.start(script=self.read_script(), vars=self.get_vars())
@@ -1716,7 +1732,7 @@ class Routing(TestkitTestCase):
         # TODO remove this block once all languages work
         if get_driver_name() in ['dotnet', 'go', 'javascript']:
             self.skipTest("needs ROUTE bookmark list support")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script_multiple_bookmarks(), vars=self.get_vars())
 
@@ -1741,7 +1757,7 @@ class Routing(TestkitTestCase):
             self.skipTest("needs ROUTE bookmark list support")
         if get_driver_name() in ['dotnet', 'python', 'go']:
             self.skipTest("requires investigation")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_one_writer(), vars=self.get_vars())
         self._writeServer1.start(script=self.write_tx_script_with_database_unavailable_failure(), vars=self.get_vars())
         self._routingServer2.start(script=self.router_script(), vars=self.get_vars())
@@ -1786,7 +1802,7 @@ class Routing(TestkitTestCase):
                 return [self._routingServer2.address]
             self.fail("unexpected")
 
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent, resolver)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent, resolver)
         self._routingServer1.start(script=self.router_script_with_one_reader_and_exit(), vars=self.get_vars())
         self._routingServer2.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_tx_script_with_exit(), vars=self.get_vars())
@@ -1821,7 +1837,7 @@ class Routing(TestkitTestCase):
             self.assertEqual(self._routingServer1.address, address)
             return [self._routingServer1.address, self._routingServer3.address]
 
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent, resolver)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent, resolver)
         self._routingServer1.start(script=self.router_script_with_another_router_and_non_existent_reader(),
                                    vars=self.get_vars())
         self._routingServer2.start(script=self.router_script_with_empty_response(), vars=self.get_vars())
@@ -1855,7 +1871,7 @@ class Routing(TestkitTestCase):
         if get_driver_name() in ['python', 'javascript', 'go', 'dotnet']:
             self.skipTest("supportsMultiDb not implemented in backend")
 
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
 
         supports_multi_db = driver.supportsMultiDB()
@@ -1874,7 +1890,7 @@ class Routing(TestkitTestCase):
         def resolver(address):
             return [self._routingServer1.address, self._routingServer2.address]
 
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent, resolver)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent, resolver)
         self._routingServer1.start(script=self.router_script_with_empty_response(), vars=self.get_vars())
         self._routingServer2.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_script(), vars=self.get_vars())
@@ -1897,7 +1913,7 @@ class Routing(TestkitTestCase):
         if get_driver_name() in ['python', 'javascript', 'go', 'dotnet']:
             self.skipTest("add code support")
 
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_db_not_found_failure(), vars=self.get_vars())
 
         session = driver.session('r', database=self.get_db())
@@ -1922,7 +1938,7 @@ class Routing(TestkitTestCase):
         if get_driver_name() in ['python', 'javascript', 'go']:
             self.skipTest("requires investigation")
 
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_unreachable_db_and_adb_db(), vars=self.get_vars())
         self._readServer1.start(script=self.read_script(), vars=self.get_vars())
 
@@ -1954,7 +1970,7 @@ class Routing(TestkitTestCase):
         # TODO remove this block once all languages work
         if get_driver_name() in ['dotnet', 'go', 'javascript']:
             self.skipTest("needs ROUTE bookmark list support")
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script(), vars=self.get_vars())
         self._readServer1.start(script=self.read_script_with_bookmarks(), vars=self.get_vars())
 
@@ -2015,7 +2031,7 @@ class Routing(TestkitTestCase):
             domain_name_resolver_call_num += 1
             return [resolved_domain_name_address]
 
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent, resolverFn=resolver,
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent, resolverFn=resolver,
                         domainNameResolverFn=domainNameResolver, connectionTimeoutMs=1000)
         self._routingServer1.start(script=self.router_script_with_unknown_failure(), vars=self.get_vars())
         # _routingServer2 is deliberately turned off
@@ -2052,7 +2068,7 @@ class Routing(TestkitTestCase):
             nonlocal router_ip_address
             return [router_ip_address]
 
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent,
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent,
                         domainNameResolverFn=domain_name_resolver)
         self._routingServer1.start(script=self.router_script_with_one_reader_and_exit(), vars=self.get_vars())
 
@@ -2139,7 +2155,7 @@ class RoutingV4(Routing):
         !: AUTO RESET
         !: AUTO HELLO
         !: AUTO GOODBYE
-        
+
         C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {#ROUTINGMODE# "db": "system"}
            PULL {"n": -1}
         S: SUCCESS {"fields": ["ttl", "servers"]}
@@ -2238,7 +2254,7 @@ class RoutingV4(Routing):
         return """
         !: BOLT #VERSION#
         !: AUTO RESET
-        
+
         !: AUTO GOODBYE
         C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": {"address": "#HOST#:9000"} #EXTRA_HELLO_PROPS# }
         S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
@@ -2263,7 +2279,7 @@ class RoutingV4(Routing):
         !: BOLT #VERSION#
         !: AUTO RESET
         !: AUTO GOODBYE
-        
+
         C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS# }
         S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
         C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {#ROUTINGMODE# "db": "system"}
@@ -2360,7 +2376,7 @@ class RoutingV4(Routing):
         !: AUTO RESET
         !: AUTO HELLO
         !: AUTO GOODBYE
-        
+
         C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {#ROUTINGMODE# "db": "system", 'bookmarks': ['sys:1234', 'foo:5678']}
         C: PULL {"n": -1}
         S: SUCCESS {"fields": ["ttl", "servers"]}
@@ -2368,8 +2384,9 @@ class RoutingV4(Routing):
         S: SUCCESS {"type": "r", "bookmark": "sys:2234"}
         """
 
-    def get_vars(self):
-        host = self._routingServer1.host
+    def get_vars(self, host=None):
+        if host is None:
+            host = self._routingServer1.host
         v = {
             "#VERSION#": 4.1,
             "#HOST#": host,
@@ -2396,7 +2413,7 @@ class RoutingV4(Routing):
         pass
 
     def test_should_pass_system_bookmark_when_getting_rt_for_multi_db(self):
-        driver = Driver(self._backend, self._uri, self._auth, self._userAgent)
+        driver = Driver(self._backend, self._uri_with_context, self._auth, self._userAgent)
         self._routingServer1.start(script=self.router_script_with_bookmarks(), vars=self.get_vars())
         self._readServer1.start(script=self.read_script_with_bookmarks(), vars=self.get_vars())
 
@@ -2485,7 +2502,7 @@ class RoutingV3(Routing):
         !: AUTO RESET
         !: AUTO HELLO
         !: AUTO GOODBYE
-        
+
         C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": {"address": "#HOST#:9000"}} {}
            PULL_ALL
         S: SUCCESS {"fields": ["ttl", "servers"]}
@@ -2607,7 +2624,7 @@ class RoutingV3(Routing):
         !: BOLT #VERSION#
         !: AUTO RESET
         !: AUTO GOODBYE
-        
+
         C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007" #EXTRA_HELLO_PROPS# #EXTR_HELLO_ROUTING_PROPS#}
         S: SUCCESS {"server": "Neo4j/3.5.0", "connection_id": "bolt-123456789"}
         C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": #ROUTINGCTX#} {#ROUTINGMODE#}
@@ -2970,8 +2987,9 @@ class RoutingV3(Routing):
         S: IGNORED
         """
 
-    def get_vars(self):
-        host = self._routingServer1.host
+    def get_vars(self, host=None):
+        if host is None:
+            host = self._routingServer1.host
         v = {
             "#VERSION#": 3,
             "#HOST#": host,
@@ -3008,6 +3026,7 @@ class RoutingV3(Routing):
 
     def test_should_send_system_bookmark_with_route(self):
         pass
+
 
 class NoRouting(TestkitTestCase):
     def setUp(self):


### PR DESCRIPTION
The java driver uses separate connections for routers and readers/writers when readers/writers are addressed by domain names in routing table. However, it will aim to use the same connection if IP addresses are used and there is no ambiguity involved. Since the purpose of these tests in not to test DNS resolution, it is suggested to switch them to IP-based addressing.