### PR TITLE
Enabling testkit to build the driver and run only one test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ To run integration tests you need to:
     export TEST_NEO4J_HOST=localhost
     python3 -m unittest tests.neo4j.datatypes.TestDataTypes.testShouldEchoBack
     ```
+  
+  * Alternatively, It's possible to use the option `--tests RUN_SELECTED_TESTS` to build the driver backend and run the tested in the `TEST_SELECTOR` environment variable. It's specialy useful during the development of new tests when it's used in combination with `run_all.py` enabling to run one specific test against all known drivers.
 
 Running stub tests locally is simpler than running the integration tests:
   * Start the drivers testkit backend, see above.
@@ -138,4 +140,3 @@ Environment variables:
     Username used to connect, defaults to neo4j
   * TEST_NEO4J_PASS
     Password used to connect
-

--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ test_flags = {
     "UNIT_TESTS": True,
     "INTEGRATION_TESTS": True,
     "STUB_TESTS": True,
+    "RUN_SELECTED_TESTS": False,
     "STRESS_TESTS": True,
     "TLS_TESTS": True
 }
@@ -116,12 +117,9 @@ def initialise_configurations():
 
 
 def set_test_flags(requested_list):
-    if not requested_list:
-        requested_list = test_flags
-
-    for item in test_flags:
-        if item not in requested_list:
-            test_flags[item] = False
+    if requested_list:
+        for item in test_flags:
+            test_flags[item] = item in requested_list
 
     print("Tests that will be run:")
     for item in test_flags:
@@ -247,6 +245,12 @@ def main(settings, configurations):
 
     if test_flags["STUB_TESTS"]:
         run_fail_wrapper(runner_container.run_stub_tests)
+
+    if test_flags["RUN_SELECTED_TESTS"]:
+        run_fail_wrapper(
+            runner_container.run_selected_tests,
+            os.environ.get("TEST_SELECTOR")
+        )
 
     if test_flags["TLS_TESTS"]:
         run_fail_wrapper(runner_container.run_tls_tests)

--- a/runner.py
+++ b/runner.py
@@ -72,3 +72,6 @@ class Container:
         self._container.exec([
             "python3", "-m", "tests.neo4j.suites", suite],
             env_map=self._env)
+
+    def run_selected_tests(self, testpattern):
+        self._container.exec(["python3", "-m", "unittest", "-v", testpattern])


### PR DESCRIPTION
This option is especially useful during the development of new tests when it's used in combination with `run_all.py` enabling to run one specific test against all known drivers.