### PR TITLE
Add container deletion before creation

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -39,8 +39,10 @@ class Container:
         del _running[self.name]
 
 
-def create(image, name, command=None, mount_map=None, host_map=None, port_map=None,
-           env_map=None, working_folder=None, network=None, aliases=None):
+def create_or_replace(image, name, command=None, mount_map=None, host_map=None,
+                      port_map=None, env_map=None, working_folder=None,
+                      network=None, aliases=None):
+    subprocess.run(["docker", "rm", "-fv", name], check=True)
     cmd = ["docker", "create", "--name", name]
     if mount_map is not None:
         for k in mount_map:

--- a/driver.py
+++ b/driver.py
@@ -66,7 +66,7 @@ def start_container(testkit_path, branch_name, driver_name, driver_path,
     # Bootstrap the driver docker image by running a bootstrap script in
     # the image. The driver docker image only contains the tools needed to
     # build, not the built driver.
-    docker.create(
+    docker.create_or_replace(
         image, container_name,
         command=["python3", "/testkit/driver/bootstrap.py"],
         mount_map=mount_map,

--- a/runner.py
+++ b/runner.py
@@ -29,7 +29,7 @@ def start_container(testkit_path, branch_name, network, secondary_network):
     for varName in os.environ:
         if varName.startswith("TEST_"):
             env[varName] = os.environ[varName]
-    docker.create(
+    docker.create_or_replace(
         image, "runner",
         command=["python3", "/testkit/driver/bootstrap.py"],
         mount_map={testkit_path: "/testkit"},


### PR DESCRIPTION
This is just to make sure the build does not fail if there is such container already (possibly from a previous build).