### PR TITLE
Fix one test and new message

### DIFF
--- a/tests/shared.py
+++ b/tests/shared.py
@@ -69,7 +69,11 @@ class MemoizedSupplier:
 
 @MemoizedSupplier
 def get_driver_features(backend):
-
+    # TODO: remove this as soon as java supports GetFeatures
+    if get_driver_name() in ["java"]:
+        # JAVA backend closes connection of receiving unknown message
+        warnings.warn("GetFeatures message not implemented in backend")
+        return ()
     try:
         response = backend.sendAndReceive(protocol.GetFeatures())
         if not isinstance(response, protocol.FeatureList):

--- a/tests/stub/authorization.py
+++ b/tests/stub/authorization.py
@@ -238,7 +238,8 @@ class AuthorizationTests(BaseAuthorizationTests):
 
         session = driver.session('r', database=self.get_db())
         try:
-            session.run("RETURN 1 as n")
+            res = session.run("RETURN 1 as n")
+            res.next()
         except types.DriverError as e:
             self.assert_is_authorization_error(error=e)
         session.close()


### PR DESCRIPTION
* Fix a tests that was broken for JS
* `GetFeatures` message would cause the Java driver to fail the first test because it closes the connection on receiving an unknown message.