### PR TITLE
Set the correct scheme to connect to the neo4j server

### DIFF
--- a/main.py
+++ b/main.py
@@ -366,7 +366,8 @@ def main(settings, configurations):
                 print("Running test suite %s" % suite)
                 run_fail_wrapper(
                     runner_container.run_neo4j_tests,
-                    suite, hostname, neo4j.username, neo4j.password
+                    suite, hostname, neo4j.username, neo4j.password,
+                    neo4j_config.scheme
                 )
             else:
                 print("No test suite specified for %s" % server_name)
@@ -400,7 +401,8 @@ def main(settings, configurations):
         if is_neo4j_test_selected_to_run():
             run_fail_wrapper(
                 runner_container.run_selected_neo4j_tests,
-                get_selected_tests(), hostname, neo4j.username, neo4j.password
+                get_selected_tests(), hostname, neo4j.username, neo4j.password,
+                neo4j_config.scheme
             )
 
         # Check that all connections to Neo4j has been closed.

--- a/runner.py
+++ b/runner.py
@@ -66,12 +66,13 @@ class Container:
         self._container.exec(
                 ["python3", "-m", "tests.tls.suites"])
 
-    def run_neo4j_tests(self, suite, hostname, username, password):
+    def run_neo4j_tests(self, suite, hostname, username, password, scheme):
         self._env.update({
             # Hostname of Docker container running db
             "TEST_NEO4J_HOST": hostname,
             "TEST_NEO4J_USER": username,
             "TEST_NEO4J_PASS": password,
+            "TEST_NEO4J_SCHEME": scheme
         })
         self._container.exec([
             "python3", "-m", "tests.neo4j.suites", suite],
@@ -87,12 +88,13 @@ class Container:
         self._container.exec(["python3", "-m", "unittest", "-v", testpattern])
 
     def run_selected_neo4j_tests(
-            self, testpattern, hostname, username, password):
+            self, testpattern, hostname, username, password, scheme):
         self._env.update({
             # Hostname of Docker container running db
             "TEST_NEO4J_HOST": hostname,
             "TEST_NEO4J_USER": username,
             "TEST_NEO4J_PASS": password,
+            "TEST_NEO4J_SCHEME": scheme
         })
         self._container.exec([
             "python3", "-m", "unittest", "-v", testpattern],

--- a/tests/neo4j/shared.py
+++ b/tests/neo4j/shared.py
@@ -14,6 +14,7 @@ from nutkit.protocol import AuthorizationToken
 env_neo4j_host = "TEST_NEO4J_HOST"
 env_neo4j_user = "TEST_NEO4J_USER"
 env_neo4j_pass = "TEST_NEO4J_PASS"
+env_neo4j_sheme = "TEST_NEO4J_SCHEME"
 
 
 def get_authorization():
@@ -32,10 +33,15 @@ def get_neo4j_host_and_port():
     return (host, port)
 
 
+def get_neo4j_scheme():
+    scheme = os.environ.get(env_neo4j_sheme, "bolt")
+    return scheme
+
+
 def get_driver(backend):
     """ Returns default driver for tests that do not test this aspect
     """
+    scheme = get_neo4j_scheme()
     host, port = get_neo4j_host_and_port()
-    scheme = "bolt://%s:%d" % (host, port)
-    return Driver(backend, scheme, get_authorization())
-
+    uri = "%s://%s:%d" % (scheme, host, port)
+    return Driver(backend, uri, get_authorization())


### PR DESCRIPTION
The driver was always using the `bolt` as scheme for the `uri` during the testkit/neo4j tests. This behaviour can lead to error, especially during the tests which performs writes.