### PR TITLE
Fix stub server not handling non-determinism right

### DIFF
--- a/boltstub/parsing.py
+++ b/boltstub/parsing.py
@@ -503,9 +503,12 @@ class AlternativeBlock(Block):
         for block in self.block_lists:
             block.assert_no_init()
 
+    def can_be_skipped(self):
+        if self.selection is None:
+            return any(b.can_be_skipped() for b in self.block_lists)
+        return self.block_lists[self.selection].can_be_skipped()
+
     def can_consume(self, channel) -> bool:
-        if self.done():
-            return False
         if self.selection is None:
             return any(b.can_consume(channel) for b in self.block_lists)
         return self.block_lists[self.selection].can_consume(channel)
@@ -530,8 +533,6 @@ class AlternativeBlock(Block):
             block.reset()
 
     def try_consume(self, channel) -> bool:
-        if self.done():
-            return False
         if self.selection is not None:
             return self.block_lists[self.selection].try_consume(channel)
         for i in range(len(self.block_lists)):
@@ -577,9 +578,10 @@ class ParallelBlock(Block):
     def done(self) -> bool:
         return all(b.done() for b in self.block_lists)
 
+    def can_be_skipped(self):
+        return all(b.can_be_skipped() for b in self.block_lists)
+
     def can_consume(self, channel) -> bool:
-        if self.done():
-            return False
         return any(b.can_consume(channel) for b in self.block_lists)
 
     def can_consume_after_reset(self, channel) -> bool:

--- a/tests/stub/shared.py
+++ b/tests/stub/shared.py
@@ -171,7 +171,8 @@ class StubServer:
         self._process.wait()
         if self._process.returncode > 0:
             self._dump()
-        self._read_pipes()
+        else:
+            self._read_pipes()
         self._clean_up()
 
     def _poll(self, timeout):
@@ -257,9 +258,8 @@ class StubServer:
         output."""
         if self._process:
             # briefly try to get a shutdown that will dump script mismatches
-            self._poll(1)
-            self._interrupt()
-            self._interrupt(.5)
+            self._interrupt(.3)
+            self._interrupt(0)
             self._kill()
 
     def count_requests_re(self, pattern):


### PR DESCRIPTION
Non-deterministic blocks inside alternative or parallel blocks could cause the
stub server to crash.