### PR TITLE
Fix docker complaining about relative paths

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -63,7 +63,8 @@ def create_or_replace(image, name, command=None, mount_map=None, host_map=None,
     cmd = ["docker", "create", "--name", name]
     if mount_map is not None:
         for k in mount_map:
-            cmd.extend(["-v", "%s:%s" % (k, mount_map[k])])
+            src, dst = os.path.abspath(k), os.path.abspath(mount_map[k])
+            cmd.extend(["-v", "%s:%s" % (src, dst)])
     if host_map is not None:
         for k in host_map:
             cmd.extend(["--add-host", "%s:%s" % (k, host_map[k])])


### PR DESCRIPTION
Specifying a relative path (e.g., `TEST_DRIVER_REPO=../neo4j-python-driver`) would cause docker to complain:  
`Error response from daemon: create ../neo4j-python-driver: "../neo4j-python-driver" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path
`