### PR TITLE
Fix server address checks in summary when run inside docker

### DIFF
--- a/tests/stub/routing/test_no_routing.py
+++ b/tests/stub/routing/test_no_routing.py
@@ -4,7 +4,10 @@ from tests.shared import (
     get_driver_name,
     TestkitTestCase,
 )
-from tests.stub.shared import StubServer
+from tests.stub.shared import (
+    get_dns_resolved_server_address,
+    StubServer,
+)
 from ._routing import get_extra_hello_props
 
 
@@ -51,5 +54,6 @@ class NoRouting(TestkitTestCase):
         session.close()
         driver.close()
 
-        self.assertEqual(summary.server_info.address, self._server.address)
+        self.assertEqual(summary.server_info.address,
+                         get_dns_resolved_server_address(self._server))
         self._server.done()

--- a/tests/stub/routing/test_routing_v4x3.py
+++ b/tests/stub/routing/test_routing_v4x3.py
@@ -3,7 +3,10 @@ from collections import defaultdict
 from nutkit.frontend import Driver
 import nutkit.protocol as types
 from tests.shared import get_driver_name
-from tests.stub.shared import get_ip_addresses, StubServerScriptNotFinished
+from tests.stub.shared import (
+    get_dns_resolved_server_address,
+    get_ip_addresses,
+)
 from ._routing import RoutingBase
 
 
@@ -71,7 +74,8 @@ class RoutingV4x3(RoutingBase):
 
         self._routingServer1.done()
         self._readServer1.done()
-        self.assertEqual(summary.server_info.address, self._readServer1.address)
+        self.assertEqual(summary.server_info.address,
+                         get_dns_resolved_server_address(self._readServer1))
         self.assertEqual([1], sequence)
 
     def test_should_read_successfully_from_reader_using_session_run_with_default_db_driver(self):
@@ -89,7 +93,8 @@ class RoutingV4x3(RoutingBase):
 
         self._routingServer1.done()
         self._readServer1.done()
-        self.assertEqual(summary.server_info.address, self._readServer1.address)
+        self.assertEqual(summary.server_info.address,
+                         get_dns_resolved_server_address(self._readServer1))
         self.assertEqual([1], sequence)
 
     # Same test as for session.run but for transaction run.
@@ -110,7 +115,8 @@ class RoutingV4x3(RoutingBase):
 
         self._routingServer1.done()
         self._readServer1.done()
-        self.assertEqual(summary.server_info.address, self._readServer1.address)
+        self.assertEqual(summary.server_info.address,
+                         get_dns_resolved_server_address(self._readServer1))
         self.assertEqual([1], sequence)
 
     def test_should_send_system_bookmark_with_route(self):
@@ -169,7 +175,7 @@ class RoutingV4x3(RoutingBase):
         self.assertEqual([[1]], sequences)
         self.assertEqual(len(summaries), 1)
         self.assertEqual(summaries[0].server_info.address,
-                         self._readServer1.address)
+                         get_dns_resolved_server_address(self._readServer1))
 
     def test_should_fail_when_reading_from_unexpectedly_interrupting_reader_using_session_run(self):
         # TODO remove this block once all languages wor
@@ -255,7 +261,8 @@ class RoutingV4x3(RoutingBase):
 
         self._routingServer1.done()
         self._writeServer1.done()
-        assert summary.server_info.address == self._writeServer1.address
+        assert (summary.server_info.address
+                == get_dns_resolved_server_address(self._writeServer1))
 
     # Checks that write server is used
     def test_should_write_successfully_on_writer_using_tx_run(self):
@@ -275,7 +282,8 @@ class RoutingV4x3(RoutingBase):
 
         self._routingServer1.done()
         self._writeServer1.done()
-        assert summary.server_info.address == self._writeServer1.address
+        assert (summary.server_info.address
+                == get_dns_resolved_server_address(self._writeServer1))
 
     def test_should_write_successfully_on_writer_using_tx_function(self):
         # TODO remove this block once all languages work
@@ -302,7 +310,8 @@ class RoutingV4x3(RoutingBase):
         self._routingServer1.done()
         self._writeServer1.done()
         self.assertIsNotNone(res)
-        assert summary.server_info.address == self._writeServer1.address
+        assert (summary.server_info.address
+                == get_dns_resolved_server_address(self._writeServer1))
 
     def test_should_write_successfully_on_leader_switch_using_tx_function(self):
         # TODO remove this block once all languages work

--- a/tests/stub/shared.py
+++ b/tests/stub/shared.py
@@ -12,6 +12,7 @@ from queue import (
 )
 import re
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
@@ -382,3 +383,20 @@ def get_ip_addresses(exclude_loopback=True):
             ips.append(address)
 
     return ips
+
+
+def dns_resolve(addr):
+    return socket.gethostbyname_ex(addr)[2]
+
+
+def dns_resolve_single(addr):
+    ips = dns_resolve(addr)
+    if len(ips) != 1:
+        raise ValueError("%s resolved to %i instead of 1 IP addresses"
+                         % (addr, len(ips)))
+    return ips[0]
+
+
+def get_dns_resolved_server_address(server):
+    print(server.host, server.port)
+    return "%s:%i" % (dns_resolve_single(server.host), server.port)

--- a/tests/stub/shared.py
+++ b/tests/stub/shared.py
@@ -385,15 +385,16 @@ def get_ip_addresses(exclude_loopback=True):
     return ips
 
 
-def dns_resolve(addr):
-    return socket.gethostbyname_ex(addr)[2]
+def dns_resolve(host_name):
+    _, _, ip_addresses = socket.gethostbyname_ex(host_name)
+    return ip_addresses
 
 
-def dns_resolve_single(addr):
-    ips = dns_resolve(addr)
+def dns_resolve_single(host_name):
+    ips = dns_resolve(host_name)
     if len(ips) != 1:
-        raise ValueError("%s resolved to %i instead of 1 IP addresses"
-                         % (addr, len(ips)))
+        raise ValueError("%s resolved to %i instead of 1 IP address"
+                         % (host_name, len(ips)))
     return ips[0]
 
 

--- a/tests/stub/versions/test_versions.py
+++ b/tests/stub/versions/test_versions.py
@@ -9,7 +9,10 @@ from tests.shared import (
     get_driver_name,
     TestkitTestCase,
 )
-from tests.stub.shared import StubServer
+from tests.stub.shared import (
+    get_dns_resolved_server_address,
+    StubServer,
+)
 
 
 class TestProtocolVersions(TestkitTestCase):
@@ -78,8 +81,10 @@ class TestProtocolVersions(TestkitTestCase):
                         self.assertEqual(summary.server_info.agent,
                                          vars_["#SERVER_AGENT#"])
                     if check_server_address:
-                        self.assertEqual(summary.server_info.address,
-                                         self._server.address)
+                        self.assertEqual(
+                            summary.server_info.address,
+                            get_dns_resolved_server_address(self._server)
+                        )
                 else:
                     # Otherwise the script will not fail when the protocol is
                     # not present (on backends where run is lazily evaluated)
@@ -161,8 +166,10 @@ class TestProtocolVersions(TestkitTestCase):
         ) as session:
             result = session.run("RETURN 1 AS n")
             summary = result.consume()
-            self.assertEqual(summary.server_info.address, self._server.address)
+            self.assertEqual(summary.server_info.address,
+                             get_dns_resolved_server_address(self._server))
         # result should cache summary and still be valid after the session's and
         # the driver's life-time
         summary = result.consume()
-        self.assertEqual(summary.server_info.address, self._server.address)
+        self.assertEqual(summary.server_info.address,
+                         get_dns_resolved_server_address(self._server))


### PR DESCRIPTION
Inside docker, the server addresses will look like "runner:1234". We expect the driver to return the resolved IP address in the summary.