### PR TITLE
Improve TestRoutingConnectionRecvTimeout flexibility

### DIFF
--- a/tests/stub/configuration_hints/scripts/1_second_exceeds.script
+++ b/tests/stub/configuration_hints/scripts/1_second_exceeds.script
@@ -3,7 +3,7 @@
 !: ALLOW RESTART
 
 C: HELLO "*"
-S: SUCCESS {"server": "Neo4j/4.3.1", "hints": {"connection.recv_timeout_seconds": 1}, "connection_id": "bolt-0"}
+S: SUCCESS {"server": "Neo4j/4.3.1", "hints": {"connection.recv_timeout_seconds": 1}, "connection_id": "bolt-3"}
 {{
     C: RUN "timeout" "*" "*"
     S: <SLEEP> 2

--- a/tests/stub/configuration_hints/scripts/1_second_exceeds_tx.script
+++ b/tests/stub/configuration_hints/scripts/1_second_exceeds_tx.script
@@ -3,7 +3,7 @@
 !: ALLOW RESTART
 
 C: HELLO "*"
-S: SUCCESS {"server": "Neo4j/4.3.1", "hints": {"connection.recv_timeout_seconds": 1}, "connection_id": "bolt-0"}
+S: SUCCESS {"server": "Neo4j/4.3.1", "hints": {"connection.recv_timeout_seconds": 1}, "connection_id": "bolt-2"}
 C: BEGIN {}
 S: SUCCESS {}
 {{

--- a/tests/stub/configuration_hints/scripts/1_second_exceeds_tx_retry.script
+++ b/tests/stub/configuration_hints/scripts/1_second_exceeds_tx_retry.script
@@ -3,7 +3,7 @@
 !: AUTO GOODBYE
 
 C: HELLO "*"
-S: SUCCESS {"server": "Neo4j/4.3.1", "hints": {"connection.recv_timeout_seconds": 1}, "connection_id": "bolt-0"}
+S: SUCCESS {"server": "Neo4j/4.3.1", "hints": {"connection.recv_timeout_seconds": 1}, "connection_id": "bolt-1"}
 C: BEGIN {}
 S: SUCCESS {}
 {{

--- a/tests/stub/configuration_hints/scripts/2_seconds_in_time.script
+++ b/tests/stub/configuration_hints/scripts/2_seconds_in_time.script
@@ -2,7 +2,7 @@
 !: AUTO GOODBYE
 
 C: HELLO "*"
-S: SUCCESS {"server": "Neo4j/4.3.1", "hints": {"connection.recv_timeout_seconds": 2}, "connection_id": "bolt-0"}
+S: SUCCESS {"server": "Neo4j/4.3.1", "hints": {"connection.recv_timeout_seconds": 2}, "connection_id": "bolt-6"}
 C: RUN "*" {} {}
 S: <SLEEP> 1
    SUCCESS {"fields": ["n"]}

--- a/tests/stub/configuration_hints/scripts/2_seconds_in_time_tx.script
+++ b/tests/stub/configuration_hints/scripts/2_seconds_in_time_tx.script
@@ -2,7 +2,7 @@
 !: AUTO GOODBYE
 
 C: HELLO "*"
-S: SUCCESS {"server": "Neo4j/4.3.1", "hints": {"connection.recv_timeout_seconds": 2}, "connection_id": "bolt-0"}
+S: SUCCESS {"server": "Neo4j/4.3.1", "hints": {"connection.recv_timeout_seconds": 2}, "connection_id": "bolt-5"}
 C: BEGIN {}
 S: SUCCESS {}
 C: RUN "*" "*" "*"

--- a/tests/stub/configuration_hints/scripts/2_seconds_in_time_tx_retry.script
+++ b/tests/stub/configuration_hints/scripts/2_seconds_in_time_tx_retry.script
@@ -2,7 +2,7 @@
 !: AUTO GOODBYE
 
 C: HELLO "*"
-S: SUCCESS {"server": "Neo4j/4.3.1", "hints": {"connection.recv_timeout_seconds": 2}, "connection_id": "bolt-0"}
+S: SUCCESS {"server": "Neo4j/4.3.1", "hints": {"connection.recv_timeout_seconds": 2}, "connection_id": "bolt-4"}
 C: BEGIN {}
 S: SUCCESS {}
 C: RUN "*" "*" "*"

--- a/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
+++ b/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
@@ -215,7 +215,7 @@ class TestRoutingConnectionRecvTimeout(TestDirectConnectionRecvTimeout):
 
     def _assert_routing_table(self, timed_out, managed):
         if self.driver_supports_features(types.Feature.OPT_CONNECTION_REUSE):
-            self.assertEqual(self._router.count_responses("<HANGUP>"), 1)
+            self.assertEqual(self._router.count_responses("<HANGUP>"), 0)
 
         self._router.done()
         self._server.reset()

--- a/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
+++ b/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
@@ -174,7 +174,7 @@ class TestDirectConnectionRecvTimeout(TestkitTestCase):
 
 class TestRoutingConnectionRecvTimeout(TestDirectConnectionRecvTimeout):
     def setUp(self):
-        super().setUp()
+        TestkitTestCase.setUp(self)
         self._server = StubServer(9010)
         self._router = StubServer(9000)
         self._router.start(path=self.script_path("router.script"), vars={
@@ -190,8 +190,13 @@ class TestRoutingConnectionRecvTimeout(TestDirectConnectionRecvTimeout):
     def tearDown(self):
         # If test raised an exception this will make sure that the stub server
         # is killed and it's output is dumped for analysis.
+        self._server.reset()
         self._router.reset()
-        super().tearDown()
+        if self._session:
+            self._session.close()
+        if self._driver:
+            self._driver.close()
+        TestkitTestCase.tearDown(self)
 
     def _assert_is_timout_exception(self, e):
         if get_driver_name() in ["python"]:
@@ -209,7 +214,9 @@ class TestRoutingConnectionRecvTimeout(TestDirectConnectionRecvTimeout):
         self.assertEqual(rt.writers, [])
 
     def _assert_routing_table(self, timed_out, managed):
-        self.assertEqual(self._router.count_responses("<HANGUP>"), 0)
+        if self.driver_supports_features(types.Feature.OPT_CONNECTION_REUSE):
+            self.assertEqual(self._router.count_responses("<HANGUP>"), 1)
+
         self._router.done()
         self._server.reset()
         if timed_out:
@@ -218,7 +225,10 @@ class TestRoutingConnectionRecvTimeout(TestDirectConnectionRecvTimeout):
         else:
             self.assertEqual(self._server.count_responses("<ACCEPT>"), 1)
             self.assertEqual(self._router.count_requests("ROUTE"), 1)
-        self.assertEqual(self._router.count_responses("<ACCEPT>"), 1)
+
+        if self.driver_supports_features(types.Feature.OPT_CONNECTION_REUSE):
+            self.assertLessEqual(self._router.count_responses("<ACCEPT>"), 1)
+
         rt = self._driver.getRoutingTable()
         self.assertEqual(rt.routers, [
             get_dns_resolved_server_address(self._router)


### PR DESCRIPTION
Making the routing table information process less strict by allowing the client to disconnect and re-connect as it need. It's not the task of these tests verify this behaviour.

An improvement on the connection_id was also done to improve the test debugging.