### PR TITLE
Adding explicit auto lines to stubscript

### DIFF
--- a/boltstub/channel.py
+++ b/boltstub/channel.py
@@ -104,12 +104,15 @@ class Channel:
             self._buffered_msg = self._consume()
         return self._buffered_msg
 
+    def auto_respond(self, msg):
+        self.log("AUTO response:")
+        self.send_struct(self.bolt_protocol.get_auto_response(msg))
+
     def try_auto_consume(self, whitelist: Iterable[str]):
         next_msg = self.peek()
         if next_msg.name in whitelist:
             self._buffered_msg = None  # consume the message for real
             self.log("C: %s", next_msg)
-            self.log("AUTO response:")
-            self.send_struct(self.bolt_protocol.get_auto_response(next_msg))
+            self.auto_respond(next_msg)
             return True
         return False

--- a/boltstub/grammar.lark
+++ b/boltstub/grammar.lark
@@ -6,6 +6,10 @@ start : [NLS] (bang_line NLS)* block_list [NLS]
 block_list : block (NLS block)*
 
 ?block : client_block
+       | auto_block
+       | auto_optional_block
+       | auto_loop0_block
+       | auto_loop1_block
        | server_block
        | alternative_block
        | parallel_block
@@ -18,6 +22,7 @@ parallel_block : PAR_START_L NLS (block_list NLS PAR_SEP_L NLS)+ block_list NLS 
 optional_block : OPT_START_L NLS block_list NLS OPT_END_L
 repeat_0_block : LOOP0_START_L NLS block_list NLS LOOP0_END_L
 repeat_1_block : LOOP1_START_L NLS block_list NLS LOOP1_END_L
+
 
 ALT_START_L : "{{"
 ALT_SEP_L : "----"
@@ -32,22 +37,47 @@ LOOP0_END_L : "*}"
 LOOP1_START_L : "{+"
 LOOP1_END_L : "+}"
 
+
 bang_line : BANG_MARKER WS* LINE
 client_block : explicit_client_line (NLS implicit_client_line)*
 explicit_client_line : CLIENT_MARKER WS* LINE  -> client_line
 implicit_client_line.-1: WS* LINE              -> client_line
+
+auto_block : explicit_auto_line (NLS implicit_auto_line)*
+explicit_auto_line : AUTO_MARKER WS* LINE    -> auto_line
+implicit_auto_line.-1: WS* LINE              -> auto_line
+
+auto_optional_block : explicit_auto_optional_line (NLS implicit_auto_optional_line)*
+explicit_auto_optional_line : AUTO_OPTIONAL_MARKER WS* LINE  -> auto_line
+implicit_auto_optional_line.-1: WS* LINE                     -> auto_line
+
+auto_loop0_block : explicit_auto_loop0_line (NLS implicit_auto_loop0_line)*
+explicit_auto_loop0_line : AUTO_LOOP0_MARKER WS* LINE  -> auto_line
+implicit_auto_loop0_line.-1: WS* LINE                  -> auto_line
+
+auto_loop1_block : explicit_auto_loop1_line (NLS implicit_auto_loop1_line)*
+explicit_auto_loop1_line : AUTO_LOOP1_MARKER WS* LINE  -> auto_line
+implicit_auto_loop1_line.-1: WS* LINE                  -> auto_line
+
 server_block : explicit_server_line (NLS implicit_server_line)*
 explicit_server_line : SERVER_MARKER WS* LINE  -> server_line
 implicit_server_line.-1: WS* LINE              -> server_line
 
+
 WS : /[ \t\f\r]/+
 COMMENT: /^/m WS* /#[^\n]*/m [NLS]
 // this is ugly but needed to avoid unprocessable amounts of ambiguity in the grammar
-LINE : /(?!\s*(!:|S:|C:|#|{{|----|\+\+\+\+|}}|{[?*+]|[?*+]\}))[^\n]+/
+LINE : /(?!\s*(!:|S:|C:|A:|\?:|\*:|\+:|#|{{|----|\+\+\+\+|}}|{[?*+]|[?*+]\}))[^\n]+/
+
 
 BANG_MARKER : "!:"
 CLIENT_MARKER : "C:"
+AUTO_MARKER : "A:"
+AUTO_OPTIONAL_MARKER : "?:"
+AUTO_LOOP0_MARKER : "*:"
+AUTO_LOOP1_MARKER : "+:"
 SERVER_MARKER : "S:"
+
 
 CR : /\r/
 LF : /\n/

--- a/boltstub/grammar.lark
+++ b/boltstub/grammar.lark
@@ -43,21 +43,17 @@ client_block : explicit_client_line (NLS implicit_client_line)*
 explicit_client_line : CLIENT_MARKER WS* LINE  -> client_line
 implicit_client_line.-1: WS* LINE              -> client_line
 
-auto_block : explicit_auto_line (NLS implicit_auto_line)*
+auto_block : explicit_auto_line
 explicit_auto_line : AUTO_MARKER WS* LINE    -> auto_line
-implicit_auto_line.-1: WS* LINE              -> auto_line
 
-auto_optional_block : explicit_auto_optional_line (NLS implicit_auto_optional_line)*
+auto_optional_block : explicit_auto_optional_line
 explicit_auto_optional_line : AUTO_OPTIONAL_MARKER WS* LINE  -> auto_line
-implicit_auto_optional_line.-1: WS* LINE                     -> auto_line
 
-auto_loop0_block : explicit_auto_loop0_line (NLS implicit_auto_loop0_line)*
+auto_loop0_block : explicit_auto_loop0_line
 explicit_auto_loop0_line : AUTO_LOOP0_MARKER WS* LINE  -> auto_line
-implicit_auto_loop0_line.-1: WS* LINE                  -> auto_line
 
-auto_loop1_block : explicit_auto_loop1_line (NLS implicit_auto_loop1_line)*
+auto_loop1_block : explicit_auto_loop1_line
 explicit_auto_loop1_line : AUTO_LOOP1_MARKER WS* LINE  -> auto_line
-implicit_auto_loop1_line.-1: WS* LINE                  -> auto_line
 
 server_block : explicit_server_line (NLS implicit_server_line)*
 explicit_server_line : SERVER_MARKER WS* LINE  -> server_line

--- a/boltstub/parsing.py
+++ b/boltstub/parsing.py
@@ -306,7 +306,7 @@ class AutoLine(ClientLine):
         obj = super(AutoLine, cls).__new__(cls, *args, **kwargs)
         obj.parsed = cls.parse_line(obj)
         if obj.parsed[1]:
-            raise LineError(obj, "Auto-Line does not fields.")
+            raise LineError(obj, "Auto-Line does not allow for fields.")
         return obj
 
     def canonical(self):

--- a/boltstub/tests/test_parsing.py
+++ b/boltstub/tests/test_parsing.py
@@ -246,24 +246,25 @@ def test_simple_dialogue(extra_ws, unverified_script):
                                       ["C: MSG1", "S: MSG2", "A: MSG3"])
 
 
-@pytest.mark.parametrize("auto_marker", ("A", "?", "+", "*"))
+@pytest.mark.parametrize(("auto_marker", "wrapper_block_class"), (
+    ("A", None),
+    ("?", parsing.OptionalBlock),
+    ("*", parsing.Repeat0Block),
+    ("+", parsing.Repeat1Block),
+))
 @pytest.mark.parametrize("extra_ws", whitespace_generator(3, {0, 2}, {1}))
-def test_auto_message_macros(extra_ws, auto_marker, unverified_script):
+def test_auto_message_macros(extra_ws, auto_marker, wrapper_block_class,
+                             unverified_script):
     script = "%%s%s:%%sMSG%%s" % auto_marker % extra_ws
     script = parsing.parse(script)
-    if auto_marker == "A":
+    if not wrapper_block_class:
         assert_dialogue_blocks_block_list(script.block_list, ["A: MSG"])
     else:
         block_list = script.block_list
         assert block_list.__class__ == parsing.BlockList
         assert len(block_list.blocks) == 1
         wrapper_block = block_list.blocks[0]
-        if auto_marker == "?":
-            assert wrapper_block.__class__ == parsing.OptionalBlock
-        elif auto_marker == "*":
-            assert wrapper_block.__class__ == parsing.Repeat0Block
-        elif auto_marker == "+":
-            assert wrapper_block.__class__ == parsing.Repeat1Block
+        assert wrapper_block.__class__ == wrapper_block_class
         assert wrapper_block.block_list.__class__ == parsing.BlockList
         assert len(wrapper_block.block_list.blocks) == 1
         inner_block = wrapper_block.block_list.blocks[0]

--- a/boltstub/tests/test_script_logic.py
+++ b/boltstub/tests/test_script_logic.py
@@ -8,6 +8,7 @@ from . import _common
 from ..bolt_protocol import TranslatedStructure
 from ..parsing import (
     ClientLine,
+    AutoLine,
     ServerLine,
     AlternativeBlock,
     BlockList,
@@ -15,6 +16,7 @@ from ..parsing import (
     OptionalBlock,
     ParallelBlock,
     ClientBlock,
+    AutoBlock,
     ServerBlock,
     Repeat0Block,
     Repeat1Block,
@@ -67,6 +69,10 @@ class MockChannel:
         prev_idx = self.index
         yield
         assert self.index == prev_idx + 1
+
+    def auto_respond(self, msg):
+        msg = TranslatedStructure("AUTO_REPLY", b"\x00", msg.name)
+        self.msg_buffer.append(msg)
 
 
 def channel_factory(msg_names):
@@ -664,7 +670,7 @@ class TestClientBlock:
 
     @pytest.fixture()
     def single_channel(self):
-        return channel_factory(["MSG1", "MSG2", "MSG3", "NOMATCH"])
+        return channel_factory(["MSG1", "NOMATCH"])
 
     @pytest.fixture()
     def multi_block(self):
@@ -692,6 +698,7 @@ class TestClientBlock:
         with single_channel.assert_consume():
             assert single_block.try_consume(single_channel)
         _assert_accepted_messages(single_block, [])
+        assert not single_channel.msg_buffer
         assert single_block.done()
         assert not single_block.can_consume(single_channel)
         assert not single_block.try_consume(single_channel)
@@ -711,6 +718,78 @@ class TestClientBlock:
             with multi_channel.assert_consume():
                 assert multi_block.try_consume(multi_channel)
         _assert_accepted_messages(multi_block, [])
+        assert not multi_block.msg_buffer
+        assert multi_block.done()
+        assert not multi_block.can_consume(multi_channel)
+        assert not multi_block.try_consume(multi_channel)
+
+
+class TestAutoBlock:
+    @pytest.fixture()
+    def single_block(self):
+        return AutoBlock([
+            AutoLine(1, "A: MSG1", "MSG1"),
+        ], 1)
+
+    @pytest.fixture()
+    def single_channel(self):
+        return channel_factory(["MSG1", "NOMATCH"])
+
+    @pytest.fixture()
+    def multi_block(self):
+        return AutoBlock([
+            AutoLine(1, "A: MSG1", "MSG1"),
+            AutoLine(2, "A: MSG2", "MSG2"),
+            AutoLine(3, "A: MSG3", "MSG3"),
+        ], 1)
+
+    @pytest.fixture()
+    def multi_channel(self):
+        return channel_factory(["MSG1", "MSG2", "MSG3", "NOMATCH"])
+
+    def test_single_block(self, single_block, single_channel):
+        assert single_block.can_consume(single_channel)
+        assert not single_block.done()
+        assert not single_channel.msg_buffer
+        assert single_block.can_consume(single_channel)
+        _assert_accepted_messages(single_block, ["MSG1"])
+        single_block.init(single_channel)
+        assert not single_block.done()
+        assert not single_channel.msg_buffer
+        _assert_accepted_messages(single_block, ["MSG1"])
+        assert single_block.can_consume(single_channel)
+        with single_channel.assert_consume():
+            assert single_block.try_consume(single_channel)
+        _assert_accepted_messages(single_block, [])
+        assert single_block.done()
+        assert len(single_channel.msg_buffer) == 1
+        msg = single_channel.msg_buffer[0]
+        assert isinstance(msg, TranslatedStructure)
+        assert msg.name == "AUTO_REPLY"
+        assert msg.fields == ["MSG1"]
+        assert not single_block.can_consume(single_channel)
+        assert not single_block.try_consume(single_channel)
+
+    def test_multi_block(self, multi_block, multi_channel):
+        assert multi_block.can_consume(multi_channel)
+        assert not multi_block.done()
+        assert not multi_channel.msg_buffer
+        _assert_accepted_messages(multi_block, ["MSG1"])
+        multi_block.init(multi_channel)
+        assert not multi_block.done()
+        assert not multi_channel.msg_buffer
+        for i in range(3):
+            _assert_accepted_messages(multi_block,
+                                      ["MSG1", "MSG2", "MSG3"][i:(i + 1)])
+            assert multi_block.can_consume(multi_channel)
+            with multi_channel.assert_consume():
+                assert multi_block.try_consume(multi_channel)
+        _assert_accepted_messages(multi_block, [])
+        assert len(multi_channel.msg_buffer) == 3
+        for i, msg in enumerate(multi_channel.msg_buffer):
+            assert isinstance(msg, TranslatedStructure)
+            assert msg.name == "AUTO_REPLY"
+            assert msg.fields == ["MSG%i" % (i + 1)]
         assert multi_block.done()
         assert not multi_block.can_consume(multi_channel)
         assert not multi_block.try_consume(multi_channel)

--- a/boltstub/tests/test_script_parts.py
+++ b/boltstub/tests/test_script_parts.py
@@ -317,7 +317,7 @@ class TestClientLine:
 class TestAutoLine:
     @pytest.mark.parametrize("auto_marker", ("A", "?", "+", "*"))
     def test_matches_tag_name(self, auto_marker):
-        line = AutoLine(10, "%: MSG" % auto_marker, "MSG")
+        line = AutoLine(10, "%s: MSG" % auto_marker, "MSG")
         msg = TranslatedStructure("MSG", b"\x00")
         assert line.match(msg)
 


### PR DESCRIPTION
`!: AUTO <SOME_COMMAND>` has the big drawback that it allows driver to send
the specified message at any given time. This can lead to tests passing that
actually shouldn't. The biggest pitfall is `!: AUTO GOODBYE` which more or less
renders `server.done()` useless as it allows the driver at any point in the
script to jump to the end by sending `GOODBYE` and making the server shut down
this way.
Therefore, I'm introducing a new line type: auto lines. They look like this

    A: RESET

This line will match the `RESET` message regardless of the fields attached to
the message (just like `!: AUTO` does and send the auto response (the same that
`!: AUTO` sends for each message).

Moreover, I introduce shorthand notation:

    ?: RESET

    *: RESET

    +: RESET

which will internally be expanded to

    {?
        A: RESET
    ?}

    {*
        A: RESET
    *}

    {+
        A: RESET
    +}

respectively.