### PR TITLE
Do not expect null routing key from Go driver

### DIFF
--- a/tests/stub/disconnects/test_disconnects.py
+++ b/tests/stub/disconnects/test_disconnects.py
@@ -288,7 +288,7 @@ class TestDisconnects(TestkitTestCase):
             return ', "realm": "", "ticket": ""'
         elif self._driverName == "java":
             return ', "realm": "", "routing": null'
-        elif self._driverName in ("dotnet", "go"):
+        elif self._driverName == "dotnet":
             return ', "routing": null'
         else:
             return ""


### PR DESCRIPTION
After neo4j/neo4j-go-driver/pull/250 is merged, the driver will
not send it