### PR TITLE
Auto line arguments

### DIFF
--- a/boltstub/parsing.py
+++ b/boltstub/parsing.py
@@ -300,21 +300,9 @@ class ClientLine(Line):
 
 
 class AutoLine(ClientLine):
-    allow_jolt_wildcard = False
-
-    def __new__(cls, *args, **kwargs):
-        obj = super(AutoLine, cls).__new__(cls, *args, **kwargs)
-        obj.parsed = cls.parse_line(obj)
-        if obj.parsed[1]:
-            raise LineError(obj, "Auto-Line does not allow for fields.")
-        return obj
-
     def canonical(self):
-        return " ".join(("A:", self.parsed[0]))
-
-    def match(self, msg):
-        tag, fields = self.parsed
-        return tag == msg.name
+        return " ".join(("A:", self.parsed[0],
+                         *map(json.dumps, self.parsed[1])))
 
 
 class ServerLine(Line):
@@ -518,10 +506,10 @@ class ClientBlock(Block):
 class AutoBlock(ClientBlock):
     def __init__(self, line: AutoLine, line_number: int):
         # AutoBlocks always have exactly one line. E.g., this syntax is invalid
-        #   A: HELLO
+        #   A: HELLO "*"
         #      RESET
         # Instead, it must be
-        #   A: HELLO
+        #   A: HELLO "*"
         #   A: RESET
         # This is to avoid ambiguity when it comes to `?:`, `*:`, and `+:`
         # macros.

--- a/boltstub/parsing.py
+++ b/boltstub/parsing.py
@@ -1143,10 +1143,10 @@ class ScriptTransformer(lark.Transformer):
             if isinstance(child, lark.Token):
                 continue
             if (blocks
-                    and ((isinstance(child, ClientBlock)
-                          and isinstance(blocks[-1], ClientBlock))
-                         or (isinstance(child, ServerBlock)
-                             and isinstance(blocks[-1], ServerBlock)))):
+                    and ((child.__class__ == ClientBlock
+                          and blocks[-1].__class__ == ClientBlock)
+                         or (child.__class__ == ServerBlock
+                             and blocks[-1].__class__ == ServerBlock))):
                 blocks[-1].lines.extend(child.lines)
             else:
                 blocks.append(child)
@@ -1156,19 +1156,19 @@ class ScriptTransformer(lark.Transformer):
     @lark.v_args(tree=True)
     def client_block(self, tree):
         return ClientBlock(
-            [child for child in tree.children if isinstance(child, ClientLine)],
+            [child for child in tree.children if child.__class__ == ClientLine],
             tree.line
         )
 
     @lark.v_args(tree=True)
     def auto_block(self, tree):
         assert len(tree.children) == 1
-        assert isinstance(tree.children[0], AutoLine)
+        assert tree.children[0].__class__ == AutoLine
         return AutoBlock(tree.children[0], tree.line)
 
     def _wrapped_auto_block(self, wrapper, tree):
         assert len(tree.children) == 1
-        assert isinstance(tree.children[0], AutoLine)
+        assert tree.children[0].__class__ == AutoLine
         return wrapper(
             BlockList(
                 [AutoBlock(tree.children[0], tree.line)],
@@ -1192,7 +1192,7 @@ class ScriptTransformer(lark.Transformer):
     @lark.v_args(tree=True)
     def server_block(self, tree):
         return ServerBlock(
-            [child for child in tree.children if isinstance(child, ServerLine)],
+            [child for child in tree.children if child.__class__ == ServerLine],
             tree.line
         )
 

--- a/boltstub/tests/test_parsing.py
+++ b/boltstub/tests/test_parsing.py
@@ -1,4 +1,6 @@
 from collections import defaultdict
+import itertools
+
 import lark
 import pytest
 import re
@@ -238,12 +240,15 @@ def test_auto_line_takes_no_fields(auto_marker, fields, unverified_script):
         parsing.parse(script)
 
 
+@pytest.mark.parametrize("order", itertools.permutations(range(3), 3))
 @pytest.mark.parametrize("extra_ws", whitespace_generator(7, {0, 6}, {1, 3, 5}))
-def test_simple_dialogue(extra_ws, unverified_script):
-    script = "%sC:%sMSG1%sS:%sMSG2%sA:%sMSG3%s" % extra_ws
+def test_simple_dialogue(order, extra_ws, unverified_script):
+    lines = ["C:%sMSG1", "S:%sMSG2", "A:%sMSG3"]
+    script = "%s" + "%s".join(lines[i] for i in order) + "%s"
+    script = script % extra_ws
     script = parsing.parse(script)
     assert_dialogue_blocks_block_list(script.block_list,
-                                      ["C: MSG1", "S: MSG2", "A: MSG3"])
+                                      [lines[i] % " " for i in order])
 
 
 @pytest.mark.parametrize(("auto_marker", "wrapper_block_class"), (


### PR DESCRIPTION
Contains a bug fix where auto lines are not correctly parsed.

Plus:
Currently, there are no bolt messages with a variable number of fields. Hence,
the fact that auto lines (e.g. `A: HELLO`) accept any number, type, and value
as message fields has no benefit but the drawback of allowing the driver to send
protocol violating messages without having the StubServer complain about it.

Note: it is still possible to accept any type and value (`A: HELLO "*"`) but the
number of expected fields has to be fixed (one in the previous example, or
`A: HELLO "*" "*"` for two, etc.).