### PR TITLE
Migrate tests from java driver

### DIFF
--- a/nutkit/frontend/driver.py
+++ b/nutkit/frontend/driver.py
@@ -3,14 +3,18 @@ from .. import protocol
 
 
 class Driver:
-    def __init__(self, backend, uri, authToken, userAgent=None, resolverFn=None, domainNameResolverFn=None,
-                 connectionTimeoutMs=None):
+    def __init__(self, backend, uri, authToken, userAgent=None, resolverFn=None,
+                 domainNameResolverFn=None,
+                 connectionTimeoutMs=None, fetchSize=None):
         self._backend = backend
         self._resolverFn = resolverFn
         self._domainNameResolverFn = domainNameResolverFn
-        req = protocol.NewDriver(uri, authToken, userAgent=userAgent, resolverRegistered=resolverFn is not None,
-                                 domainNameResolverRegistered=domainNameResolverFn is not None,
-                                 connectionTimeoutMs=connectionTimeoutMs)
+        req = protocol.NewDriver(
+            uri, authToken, userAgent=userAgent,
+            resolverRegistered=resolverFn is not None,
+            domainNameResolverRegistered=domainNameResolverFn is not None,
+            connectionTimeoutMs=connectionTimeoutMs,
+            fetchSize=fetchSize)
         res = backend.sendAndReceive(req)
         if not isinstance(res, protocol.Driver):
             raise Exception("Should be Driver but was %s" % res)

--- a/nutkit/frontend/transaction.py
+++ b/nutkit/frontend/transaction.py
@@ -25,3 +25,9 @@ class Transaction:
         res = self._backend.sendAndReceive(req)
         if not isinstance(res, protocol.Transaction):
             raise Exception("Should be transaction but was: %s" % res)
+
+    def close(self):
+        req = protocol.TransactionClose(self._id)
+        res = self._backend.sendAndReceive(req)
+        if not isinstance(res, protocol.Transaction):
+            raise Exception("Should be transaction but was: %s" % res)

--- a/nutkit/protocol/feature.py
+++ b/nutkit/protocol/feature.py
@@ -48,6 +48,7 @@ class Feature(Enum):
     # Temporary driver feature that will be removed when all official driver
     # backends have implemented the TransactionClose request
     TMP_TRANSACTION_CLOSE = "Temporary:TransactionClose"
-    # Temporary driver feature that will be removed when all official driver
-    # backends have implemented fetch size configuration on driver creation
+    # TODO Update this one the decision has been made.
+    # Temporary driver feature. There is a pending decision on whether it should
+    # be supported in all drivers or be removed from all of them.
     TMP_DRIVER_FETCH_SIZE = "Temporary:DriverFetchSize"

--- a/nutkit/protocol/feature.py
+++ b/nutkit/protocol/feature.py
@@ -48,7 +48,7 @@ class Feature(Enum):
     # Temporary driver feature that will be removed when all official driver
     # backends have implemented the TransactionClose request
     TMP_TRANSACTION_CLOSE = "Temporary:TransactionClose"
-    # TODO Update this one the decision has been made.
+    # TODO Update this once the decision has been made.
     # Temporary driver feature. There is a pending decision on whether it should
     # be supported in all drivers or be removed from all of them.
     TMP_DRIVER_FETCH_SIZE = "Temporary:DriverFetchSize"

--- a/nutkit/protocol/feature.py
+++ b/nutkit/protocol/feature.py
@@ -45,3 +45,9 @@ class Feature(Enum):
     # Temporary driver feature that will be removed when all official driver
     # backends have implemented path and relationship types
     TMP_CYPHER_PATH_AND_RELATIONSHIP = "Temporary:CypherPathAndRelationship"
+    # Temporary driver feature that will be removed when all official driver
+    # backends have implemented the TransactionClose request
+    TMP_TRANSACTION_CLOSE = "Temporary:TransactionClose"
+    # Temporary driver feature that will be removed when all official driver
+    # backends have implemented fetch size configuration on driver creation
+    TMP_DRIVER_FETCH_SIZE = "Temporary:DriverFetchSize"

--- a/nutkit/protocol/requests.py
+++ b/nutkit/protocol/requests.py
@@ -39,8 +39,9 @@ class NewDriver:
     Backend should respond with a Driver response or an Error response.
     """
 
-    def __init__(self, uri, authToken, userAgent=None, resolverRegistered=False, domainNameResolverRegistered=False,
-                 connectionTimeoutMs=None):
+    def __init__(self, uri, authToken, userAgent=None, resolverRegistered=False,
+                 domainNameResolverRegistered=False,
+                 connectionTimeoutMs=None, fetchSize=None):
         # Neo4j URI to connect to
         self.uri = uri
         # Authorization token used by driver when connecting to Neo4j
@@ -50,6 +51,8 @@ class NewDriver:
         self.resolverRegistered = resolverRegistered
         self.domainNameResolverRegistered = domainNameResolverRegistered
         self.connectionTimeoutMs = connectionTimeoutMs
+        if fetchSize is not None:
+            self.fetchSize = fetchSize
 
 
 class AuthorizationToken:
@@ -225,6 +228,16 @@ class TransactionCommit:
 class TransactionRollback:
     """ Request to run a query in a specified transaction.
     Backend should respond with a Result response or an Error response.
+    """
+
+    def __init__(self, txId):
+        self.txId = txId
+
+
+class TransactionClose:
+    """ Request to close the transaction instance on the backend.
+    Backend should respond with a transaction response representing the closed
+    transaction or an error response.
     """
 
     def __init__(self, txId):

--- a/nutkit/protocol/requests.py
+++ b/nutkit/protocol/requests.py
@@ -51,6 +51,10 @@ class NewDriver:
         self.resolverRegistered = resolverRegistered
         self.domainNameResolverRegistered = domainNameResolverRegistered
         self.connectionTimeoutMs = connectionTimeoutMs
+        # TODO: remove assertion and condition as soon as all drivers support
+        #       driver-scoped fetch-size config
+        from .feature import Feature
+        assert hasattr(Feature, "TMP_DRIVER_FETCH_SIZE")
         if fetchSize is not None:
             self.fetchSize = fetchSize
 

--- a/tests/neo4j/test_direct_driver.py
+++ b/tests/neo4j/test_direct_driver.py
@@ -122,10 +122,6 @@ class TestDirectDriver(TestkitTestCase):
             return
         self.assertEqual(exc.code,
                          "Neo.ClientError.Database.DatabaseNotFound")
-        # TODO remove this block once all languages work
-        if get_driver_name() in ["java"]:
-            # does not set exception message
-            return
         self.assertIn("test-database", exc.msg)
         self.assertIn("exist", exc.msg)
         if get_driver_name() in ["python"]:

--- a/tests/stub/routing/scripts/v3_no_routing/writer_yielding_error_on_rollback.script
+++ b/tests/stub/routing/scripts/v3_no_routing/writer_yielding_error_on_rollback.script
@@ -6,9 +6,9 @@ S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 C: BEGIN {}
 S: SUCCESS {}
 C: RUN "RETURN 1 as n" {} {}
-   PULL_ALL
 S: SUCCESS {"fields": ["n"]}
-   RECORD [1]
+C: PULL_ALL
+S: RECORD [1]
    SUCCESS {"type": "r"}
 C: ROLLBACK
 S: FAILURE {"code": "Neo.TransientError.General.DatabaseUnavailable", "message": "Unable to rollback"}

--- a/tests/stub/routing/scripts/v3_no_routing/writer_yielding_error_on_rollback.script
+++ b/tests/stub/routing/scripts/v3_no_routing/writer_yielding_error_on_rollback.script
@@ -1,0 +1,20 @@
+!: BOLT #VERSION#
+!: AUTO GOODBYE
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "#USER_AGENT#" #ROUTING# #EXTRA_HELLO_PROPS#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+C: BEGIN {}
+S: SUCCESS {}
+C: RUN "RETURN 1 as n" {} {}
+   PULL_ALL
+S: SUCCESS {"fields": ["n"]}
+   RECORD [1]
+   SUCCESS {"type": "r"}
+C: ROLLBACK
+S: FAILURE {"code": "Neo.TransientError.General.DatabaseUnavailable", "message": "Unable to rollback"}
+C: RESET
+S: SUCCESS {}
+{?
+    C: RESET
+    S: SUCCESS {}
+?}

--- a/tests/stub/routing/scripts/v4x1_no_routing/writer_with_custom_fetch_size.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/writer_with_custom_fetch_size.script
@@ -3,6 +3,11 @@
 
 C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "#USER_AGENT#" #ROUTING# #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+# Added this block for GO
+{?
+    C: RESET
+    S: SUCCESS {}
+?}
 C: RUN "RETURN 1 as n" {} {"db": "adb"}
 S: SUCCESS {"fields": ["n"]}
 C: PULL {"n": 2}

--- a/tests/stub/routing/scripts/v4x1_no_routing/writer_with_custom_fetch_size.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/writer_with_custom_fetch_size.script
@@ -1,0 +1,20 @@
+!: BOLT #VERSION#
+!: AUTO GOODBYE
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "#USER_AGENT#" #ROUTING# #EXTRA_HELLO_PROPS#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+C: RUN "RETURN 1 as n" {} {"db": "adb"}
+   PULL {"n": 2}
+S: SUCCESS {"fields": ["n"]}
+   RECORD [1]
+   RECORD [5]
+   SUCCESS {"has_more": true}
+C: PULL {"n": 2}
+S: RECORD [7]
+   SUCCESS {}
+C: RESET
+S: SUCCESS {}
+{?
+    C: RESET
+    S: SUCCESS {}
+?}

--- a/tests/stub/routing/scripts/v4x1_no_routing/writer_with_custom_fetch_size.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/writer_with_custom_fetch_size.script
@@ -4,9 +4,9 @@
 C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "#USER_AGENT#" #ROUTING# #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 C: RUN "RETURN 1 as n" {} {"db": "adb"}
-   PULL {"n": 2}
 S: SUCCESS {"fields": ["n"]}
-   RECORD [1]
+C: PULL {"n": 2}
+S: RECORD [1]
    RECORD [5]
    SUCCESS {"has_more": true}
 C: PULL {"n": 2}

--- a/tests/stub/routing/scripts/v4x1_no_routing/writer_yielding_error_on_rollback.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/writer_yielding_error_on_rollback.script
@@ -1,0 +1,20 @@
+!: BOLT #VERSION#
+!: AUTO GOODBYE
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "#USER_AGENT#" #ROUTING# #EXTRA_HELLO_PROPS#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+C: BEGIN {"db": "adb"}
+S: SUCCESS {}
+C: RUN "RETURN 1 as n" {} {}
+   PULL {"n": 1000}
+S: SUCCESS {"fields": ["n"]}
+   RECORD [1]
+   SUCCESS {"type": "r"}
+C: ROLLBACK
+S: FAILURE {"code": "Neo.TransientError.General.DatabaseUnavailable", "message": "Unable to rollback"}
+C: RESET
+S: SUCCESS {}
+{?
+    C: RESET
+    S: SUCCESS {}
+?}

--- a/tests/stub/routing/scripts/v4x1_no_routing/writer_yielding_error_on_rollback.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/writer_yielding_error_on_rollback.script
@@ -6,9 +6,9 @@ S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 C: BEGIN {"db": "adb"}
 S: SUCCESS {}
 C: RUN "RETURN 1 as n" {} {}
-   PULL {"n": 1000}
 S: SUCCESS {"fields": ["n"]}
-   RECORD [1]
+C: PULL {"n": 1000}
+S: RECORD [1]
    SUCCESS {"type": "r"}
 C: ROLLBACK
 S: FAILURE {"code": "Neo.TransientError.General.DatabaseUnavailable", "message": "Unable to rollback"}

--- a/tests/stub/routing/test_no_routing_v3.py
+++ b/tests/stub/routing/test_no_routing_v3.py
@@ -19,3 +19,7 @@ class NoRoutingV3(NoRoutingV4x1):
             "#USER_AGENT#": '007',
             "#ROUTING#": ''
         }
+
+    def test_should_accept_custom_fetch_size_using_session_configuration(
+            self):
+        pass

--- a/tests/stub/routing/test_no_routing_v4x1.py
+++ b/tests/stub/routing/test_no_routing_v4x1.py
@@ -3,7 +3,8 @@ from nutkit.frontend import Driver
 from tests.shared import (
     get_dns_resolved_server_address,
     get_driver_name,
-    TestkitTestCase, driver_feature,
+    TestkitTestCase,
+    driver_feature,
 )
 from tests.stub.shared import StubServer
 from ._routing import get_extra_hello_props
@@ -161,7 +162,6 @@ class NoRoutingV4x1(TestkitTestCase):
         session.close()
         driver.close()
 
-        self.assertIsNotNone(exc)
         self._assert_is_transient_exception(exc.exception)
         self.assertEqual(summary.server_info.address,
                          get_dns_resolved_server_address(self._server))
@@ -191,7 +191,6 @@ class NoRoutingV4x1(TestkitTestCase):
         session.close()
         driver.close()
 
-        self.assertIsNotNone(exc)
         self._assert_is_transient_exception(exc.exception)
         self.assertEqual(summary.server_info.address,
                          get_dns_resolved_server_address(self._server))
@@ -220,7 +219,6 @@ class NoRoutingV4x1(TestkitTestCase):
 
         driver.close()
 
-        self.assertIsNotNone(exc)
         self._assert_is_transient_exception(exc.exception)
         self.assertEqual(summary.server_info.address,
                          get_dns_resolved_server_address(self._server))

--- a/tests/stub/routing/test_no_routing_v4x1.py
+++ b/tests/stub/routing/test_no_routing_v4x1.py
@@ -142,7 +142,7 @@ class NoRoutingV4x1(TestkitTestCase):
     def test_should_error_on_rollback_failure_using_tx_rollback(self):
         # TODO There is a pending unification task to fix this.
         # Once fixed, this block should be removed.
-        if get_driver_name() in ["go"]:
+        if get_driver_name() in ["javascript", "go"]:
             self.skipTest("There is a pending unification task to fix this.")
         uri = "bolt://%s" % self._server.address
         self._server.start(
@@ -173,10 +173,6 @@ class NoRoutingV4x1(TestkitTestCase):
 
     @driver_feature(types.Feature.TMP_TRANSACTION_CLOSE)
     def test_should_error_on_rollback_failure_using_tx_close(self):
-        # TODO There is a pending unification task to fix this.
-        # Once fixed, this block should be removed.
-        if get_driver_name() in ["go"]:
-            self.skipTest("There is a pending unification task to fix this.")
         uri = "bolt://%s" % self._server.address
         self._server.start(
             path=self.script_path(self.version_dir,

--- a/tests/stub/routing/test_no_routing_v4x1.py
+++ b/tests/stub/routing/test_no_routing_v4x1.py
@@ -281,6 +281,6 @@ class NoRoutingV4x1(TestkitTestCase):
         if get_driver_name() in ["java"]:
             self.assertEqual("org.neo4j.driver.exceptions.TransientException",
                              e.errorType)
-        self.assertEqual("Neo.TransientError.General.DatabaseUnavailable",
-                         e.code)
-        self.assertEqual("Unable to rollback", e.msg)
+            self.assertEqual("Neo.TransientError.General.DatabaseUnavailable",
+                             e.code)
+            self.assertEqual("Unable to rollback", e.msg)

--- a/tests/stub/routing/test_no_routing_v4x1.py
+++ b/tests/stub/routing/test_no_routing_v4x1.py
@@ -140,6 +140,10 @@ class NoRoutingV4x1(TestkitTestCase):
         self._server.done()
 
     def test_should_error_on_rollback_failure_using_tx_rollback(self):
+        # TODO There is a pending unification task to fix this.
+        # Once fixed, this block should be removed.
+        if get_driver_name() in ["go"]:
+            self.skipTest("There is a pending unification task to fix this.")
         uri = "bolt://%s" % self._server.address
         self._server.start(
             path=self.script_path(self.version_dir,
@@ -169,6 +173,10 @@ class NoRoutingV4x1(TestkitTestCase):
 
     @driver_feature(types.Feature.TMP_TRANSACTION_CLOSE)
     def test_should_error_on_rollback_failure_using_tx_close(self):
+        # TODO There is a pending unification task to fix this.
+        # Once fixed, this block should be removed.
+        if get_driver_name() in ["go"]:
+            self.skipTest("There is a pending unification task to fix this.")
         uri = "bolt://%s" % self._server.address
         self._server.start(
             path=self.script_path(self.version_dir,
@@ -198,6 +206,10 @@ class NoRoutingV4x1(TestkitTestCase):
 
     def test_should_error_on_rollback_failure_using_session_close(
             self):
+        # TODO There is a pending unification task to fix this.
+        # Once fixed, this block should be removed.
+        if get_driver_name() in ["javascript", "go"]:
+            self.skipTest("There is a pending unification task to fix this.")
         uri = "bolt://%s" % self._server.address
         self._server.start(
             path=self.script_path(self.version_dir,
@@ -279,6 +291,6 @@ class NoRoutingV4x1(TestkitTestCase):
         if get_driver_name() in ["java"]:
             self.assertEqual("org.neo4j.driver.exceptions.TransientException",
                              e.errorType)
-            self.assertEqual("Neo.TransientError.General.DatabaseUnavailable",
-                             e.code)
-            self.assertEqual("Unable to rollback", e.msg)
+        self.assertEqual("Unable to rollback", e.msg)
+        self.assertEqual("Neo.TransientError.General.DatabaseUnavailable",
+                         e.code)

--- a/tests/stub/routing/test_no_routing_v4x1.py
+++ b/tests/stub/routing/test_no_routing_v4x1.py
@@ -206,6 +206,9 @@ class NoRoutingV4x1(TestkitTestCase):
         # Once fixed, this block should be removed.
         if get_driver_name() in ["javascript", "go"]:
             self.skipTest("There is a pending unification task to fix this.")
+        # TODO This needs investigation
+        if get_driver_name() in ["dotnet"]:
+            self.skipTest("Throws client exception instead.")
         uri = "bolt://%s" % self._server.address
         self._server.start(
             path=self.script_path(self.version_dir,


### PR DESCRIPTION
This updated also includes:
- TransactionClose request support (`Temporary:TransactionClose` feature)
- Driver fetch size configuration (`Temporary:DriverFetchSize` feature)

Migrated tests:
- shouldThrowRollbackErrorWhenTransactionRollback -> test_should_error_on_rollback_failure_using_tx_rollback
- shouldThrowRollbackErrorWhenTransactionClose -> test_should_error_on_rollback_failure_using_tx_close
- shouldPropagateTransactionRollbackErrorWhenSessionClosed -> test_should_error_on_rollback_failure_using_session_close
- shouldStreamingRecordsInBatches -> test_should_accept_custom_fetch_size_using_driver_configuration (protocol bump from 4 to 4.1)
- shouldChangeFetchSize -> test_should_accept_custom_fetch_size_using_session_configuration (protocol bump from 4 to 4.1)