### PR TITLE
Fixing few bits for JS driver be complaint with Testkit

### DIFF
--- a/tests/stub/authorization/scripts/v4x0/reader_return_1_failure_return_2_and_3_succeed.script
+++ b/tests/stub/authorization/scripts/v4x0/reader_return_1_failure_return_2_and_3_succeed.script
@@ -18,8 +18,10 @@ A: HELLO {"{}": "*"}
             S: RECORD [1]
                SUCCESS {"type": "r", "has_more": true}
         +}
-        C: DISCARD {"n": -1}
-        S: SUCCESS {}
+        {*
+            C: DISCARD {"n": -1}
+            S: SUCCESS {}
+        *}
     ----
         C: RUN "RETURN 3 as n" {} {"mode": "r"}
            PULL {"n": "*"}

--- a/tests/stub/authorization/scripts/v4x0/reader_return_1_failure_return_2_and_3_succeed.script
+++ b/tests/stub/authorization/scripts/v4x0/reader_return_1_failure_return_2_and_3_succeed.script
@@ -18,10 +18,10 @@ A: HELLO {"{}": "*"}
             S: RECORD [1]
                SUCCESS {"type": "r", "has_more": true}
         +}
-        {*
+        {?
             C: DISCARD {"n": -1}
             S: SUCCESS {}
-        *}
+        ?}
     ----
         C: RUN "RETURN 3 as n" {} {"mode": "r"}
            PULL {"n": "*"}


### PR DESCRIPTION
List of adjustments

* Fixes script missmatch in `test_should_be_able_to_use_current_sessions_after_AuthorizationExpired` by make `reader_return_1_failure_return_2_and_3_succeed.script` accept as `DISCARD` or `RESET` at the end of the result consuption with session.close(). The JS driver was already finish the consumption at that point.