### PR TITLE
Change to behaviour of test_disconnect_on_tx_begin

### DIFF
--- a/tests/stub/disconnects/test_disconnects.py
+++ b/tests/stub/disconnects/test_disconnects.py
@@ -177,7 +177,7 @@ class TestDisconnects(TestkitTestCase):
         expected_step = "after begin"
         if self._driverName in ["python", "go"]:
             expected_step = "after run"
-        elif self._driverName in ["javascript", "dotnet"]:
+        elif self._driverName in ["javascript"]:
             expected_step = "after first next"
         self.assertEqual(step, expected_step)
 


### PR DESCRIPTION
The behaviour of the driver now matches the Java driver after the implementation of the ReAuthorization changes for LDAP.