### PR TITLE
Fix for test_disconnect_on_tx_begin

### DIFF
--- a/tests/stub/disconnects/test_disconnects.py
+++ b/tests/stub/disconnects/test_disconnects.py
@@ -177,7 +177,7 @@ class TestDisconnects(TestkitTestCase):
         expected_step = "after begin"
         if self._driverName in ["python", "go"]:
             expected_step = "after run"
-        elif self._driverName in ["javascript", "dotnet"]:
+        elif self._driverName in ["javascript"]:
             expected_step = "after first next"
         self.assertEqual(step, expected_step)
 

--- a/tests/stub/routing/test_no_routing_v4x1.py
+++ b/tests/stub/routing/test_no_routing_v4x1.py
@@ -206,9 +206,7 @@ class NoRoutingV4x1(TestkitTestCase):
         # Once fixed, this block should be removed.
         if get_driver_name() in ["javascript", "go"]:
             self.skipTest("There is a pending unification task to fix this.")
-        # TODO This needs investigation
-        if get_driver_name() in ["dotnet"]:
-            self.skipTest("Throws client exception instead.")
+        
         uri = "bolt://%s" % self._server.address
         self._server.start(
             path=self.script_path(self.version_dir,


### PR DESCRIPTION
The behaviour of the driver now matches the Java driver after the implementation of the ReAuthorization changes for LDAP.