### PR TITLE
Migrate tests from Java Driver to Testkit

### DIFF
--- a/tests/stub/routing/scripts/v4x1_no_routing/reader_tx_yielding_multiple_records.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/reader_tx_yielding_multiple_records.script
@@ -2,9 +2,9 @@
 
 C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "#USER_AGENT#" #ROUTING# #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
 C: BEGIN {"mode": "r", "db": "adb"}
 S: SUCCESS {}
-*: RESET
 C: RUN "RETURN 1 as n" {} {}
 S: SUCCESS {"fields": ["n"]}
 C: PULL { "n": 1000 }

--- a/tests/stub/routing/scripts/v4x1_no_routing/reader_tx_yielding_multiple_records.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/reader_tx_yielding_multiple_records.script
@@ -4,6 +4,7 @@ C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent":
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 C: BEGIN {"mode": "r", "db": "adb"}
 S: SUCCESS {}
+*: RESET
 C: RUN "RETURN 1 as n" {} {}
 S: SUCCESS {"fields": ["n"]}
 C: PULL { "n": 1000 }

--- a/tests/stub/routing/scripts/v4x1_no_routing/reader_tx_yielding_multiple_records.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/reader_tx_yielding_multiple_records.script
@@ -2,19 +2,16 @@
 
 C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "#USER_AGENT#" #ROUTING# #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
-*: RESET
-C: RUN "RETURN 1 as n" {} {"db": "adb"}
+C: BEGIN {"mode": "r", "db": "adb"}
+S: SUCCESS {}
+C: RUN "RETURN 1 as n" {} {}
 S: SUCCESS {"fields": ["n"]}
-C: PULL {"n": 2}
+C: PULL { "n": 1000 }
 S: RECORD [1]
-   RECORD [3]
-   SUCCESS {"has_more": true}
-C: PULL {"n": 2}
-S: RECORD [5]
+   RECORD [5]
    RECORD [7]
-   SUCCESS {"has_more": true}
-C: PULL {"n": 2}
-S: RECORD [9]
-   SUCCESS {}
+   SUCCESS {"type": "r"}
+C: COMMIT
+S: SUCCESS { "bookmark": "ABookmark" }
 *: RESET
 ?: GOODBYE

--- a/tests/stub/routing/scripts/v4x1_no_routing/reader_yielding_multiple_records.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/reader_yielding_multiple_records.script
@@ -2,19 +2,12 @@
 
 C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "#USER_AGENT#" #ROUTING# #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
-*: RESET
-C: RUN "RETURN 1 as n" {} {"db": "adb"}
+C: RUN "RETURN 1 as n" {} {"mode": "r", "db": "adb"}
 S: SUCCESS {"fields": ["n"]}
-C: PULL {"n": 2}
+C: PULL { "n": 1000 }
 S: RECORD [1]
-   RECORD [3]
-   SUCCESS {"has_more": true}
-C: PULL {"n": 2}
-S: RECORD [5]
+   RECORD [5]
    RECORD [7]
-   SUCCESS {"has_more": true}
-C: PULL {"n": 2}
-S: RECORD [9]
-   SUCCESS {}
+   SUCCESS {"type": "r"}
 *: RESET
 ?: GOODBYE

--- a/tests/stub/routing/scripts/v4x1_no_routing/reader_yielding_multiple_records.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/reader_yielding_multiple_records.script
@@ -2,6 +2,7 @@
 
 C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "#USER_AGENT#" #ROUTING# #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
 C: RUN "RETURN 1 as n" {} {"mode": "r", "db": "adb"}
 S: SUCCESS {"fields": ["n"]}
 C: PULL { "n": 1000 }

--- a/tests/stub/routing/test_no_routing_v3.py
+++ b/tests/stub/routing/test_no_routing_v3.py
@@ -24,5 +24,13 @@ class NoRoutingV3(NoRoutingV4x1):
             self):
         pass
 
+    def test_should_read_successfully_with_database_name_using_session_run(
+            self):
+        pass
+
+    def test_should_read_successfully_with_database_name_using_tx_function(
+            self):
+        pass
+
     def _assert_supports_multi_db(self, supports_multi_db):
         self.assertFalse(supports_multi_db)

--- a/tests/stub/routing/test_no_routing_v4x1.py
+++ b/tests/stub/routing/test_no_routing_v4x1.py
@@ -258,8 +258,10 @@ class NoRoutingV4x1(TestkitTestCase):
         driver.close()
 
         self.assertEqual([types.Record(values=[types.CypherInt(1)]),
+                          types.Record(values=[types.CypherInt(3)]),
                           types.Record(values=[types.CypherInt(5)]),
-                          types.Record(values=[types.CypherInt(7)])], records)
+                          types.Record(values=[types.CypherInt(7)]),
+                          types.Record(values=[types.CypherInt(9)])], records)
         self._server.done()
 
     def test_should_accept_custom_fetch_size_using_session_configuration(
@@ -283,8 +285,10 @@ class NoRoutingV4x1(TestkitTestCase):
         driver.close()
 
         self.assertEqual([types.Record(values=[types.CypherInt(1)]),
+                          types.Record(values=[types.CypherInt(3)]),
                           types.Record(values=[types.CypherInt(5)]),
-                          types.Record(values=[types.CypherInt(7)])], records)
+                          types.Record(values=[types.CypherInt(7)]),
+                          types.Record(values=[types.CypherInt(9)])], records)
         self._server.done()
 
     @driver_feature(types.Feature.TMP_DRIVER_FETCH_SIZE)
@@ -447,6 +451,64 @@ class NoRoutingV4x1(TestkitTestCase):
 
         self._assert_is_transient_commit_exception(
             exc.exception, expected_msg="Database shut down.")
+        self._server.done()
+
+    def test_should_read_successfully_with_database_name_using_session_run(
+            self):
+        uri = "bolt://%s" % self._server.address
+        self._server.start(
+            path=self.script_path(
+                self.version_dir,
+                "reader_yielding_multiple_records.script"),
+            vars=self.get_vars()
+        )
+        driver = Driver(self._backend, uri,
+                        types.AuthorizationToken(scheme="basic", principal="p",
+                                                 credentials="c"),
+                        userAgent="007")
+
+        session = driver.session('r', database=self.adb)
+        res = session.run("RETURN 1 as n")
+        records = list(res)
+
+        session.close()
+        driver.close()
+
+        self.assertEqual([types.Record(values=[types.CypherInt(1)]),
+                          types.Record(values=[types.CypherInt(5)]),
+                          types.Record(values=[types.CypherInt(7)])], records)
+        self._server.done()
+
+    def test_should_read_successfully_with_database_name_using_tx_function(
+            self):
+        uri = "bolt://%s" % self._server.address
+        self._server.start(
+            path=self.script_path(
+                self.version_dir,
+                "reader_tx_yielding_multiple_records.script"),
+            vars=self.get_vars()
+        )
+        driver = Driver(self._backend, uri,
+                        types.AuthorizationToken(scheme="basic", principal="p",
+                                                 credentials="c"),
+                        userAgent="007")
+
+        session = driver.session('r', database=self.adb)
+        records = None
+
+        def work(tx):
+            nonlocal records
+            result = tx.run("RETURN 1 as n")
+            records = list(result)
+
+        session.readTransaction(work)
+
+        session.close()
+        driver.close()
+
+        self.assertEqual([types.Record(values=[types.CypherInt(1)]),
+                          types.Record(values=[types.CypherInt(5)]),
+                          types.Record(values=[types.CypherInt(7)])], records)
         self._server.done()
 
     def _assert_is_transient_rollback_exception(


### PR DESCRIPTION
Migrated tests:
- shouldAllowDatabaseNameInSessionRun -> test_should_support_database_name_using_session_run (Bolt bump from v4 to v4.1)
- shouldAllowDatabaseNameInBeginTransaction -> test_should_read_successfully_with_database_name_using_tx_function (Bolt bump from v4 to v4.1)
- shouldOnlyPullRecordsWhenNeededSimpleSession -> test_should_accept_custom_fetch_size_using_session_configuration (existing test)