### PR TITLE
Migrate tests from Java Driver to Testkit

### DIFF
--- a/nutkit/frontend/driver.py
+++ b/nutkit/frontend/driver.py
@@ -4,8 +4,8 @@ from .. import protocol
 
 class Driver:
     def __init__(self, backend, uri, authToken, userAgent=None, resolverFn=None,
-                 domainNameResolverFn=None,
-                 connectionTimeoutMs=None, fetchSize=None):
+                 domainNameResolverFn=None, connectionTimeoutMs=None,
+                 fetchSize=None, maxTxRetryTimeMs=None):
         self._backend = backend
         self._resolverFn = resolverFn
         self._domainNameResolverFn = domainNameResolverFn
@@ -14,7 +14,7 @@ class Driver:
             resolverRegistered=resolverFn is not None,
             domainNameResolverRegistered=domainNameResolverFn is not None,
             connectionTimeoutMs=connectionTimeoutMs,
-            fetchSize=fetchSize)
+            fetchSize=fetchSize, maxTxRetryTimeMs=maxTxRetryTimeMs)
         res = backend.sendAndReceive(req)
         if not isinstance(res, protocol.Driver):
             raise Exception("Should be Driver but was %s" % res)

--- a/nutkit/protocol/feature.py
+++ b/nutkit/protocol/feature.py
@@ -52,3 +52,6 @@ class Feature(Enum):
     # Temporary driver feature. There is a pending decision on whether it should
     # be supported in all drivers or be removed from all of them.
     TMP_DRIVER_FETCH_SIZE = "Temporary:DriverFetchSize"
+    # Temporary driver feature that will be removed when all official driver
+    # backends have implemented it.
+    TMP_DRIVER_MAX_TX_RETRY_TIME = "Temporary:DriverMaxTxRetryTime"

--- a/nutkit/protocol/requests.py
+++ b/nutkit/protocol/requests.py
@@ -40,8 +40,8 @@ class NewDriver:
     """
 
     def __init__(self, uri, authToken, userAgent=None, resolverRegistered=False,
-                 domainNameResolverRegistered=False,
-                 connectionTimeoutMs=None, fetchSize=None):
+                 domainNameResolverRegistered=False, connectionTimeoutMs=None,
+                 fetchSize=None, maxTxRetryTimeMs=None):
         # Neo4j URI to connect to
         self.uri = uri
         # Authorization token used by driver when connecting to Neo4j
@@ -57,6 +57,11 @@ class NewDriver:
         assert hasattr(Feature, "TMP_DRIVER_FETCH_SIZE")
         if fetchSize is not None:
             self.fetchSize = fetchSize
+        # TODO: remove assertion and condition as soon as all drivers support
+        #       driver-scoped fetch-size config
+        assert hasattr(Feature, "TMP_DRIVER_MAX_TX_RETRY_TIME")
+        if maxTxRetryTimeMs is not None:
+            self.maxTxRetryTimeMs = maxTxRetryTimeMs
 
 
 class AuthorizationToken:

--- a/tests/stub/routing/test_routing_v4x3.py
+++ b/tests/stub/routing/test_routing_v4x3.py
@@ -6,6 +6,7 @@ from tests.shared import (
     get_dns_resolved_server_address,
     get_driver_name,
     get_ip_addresses,
+    driver_feature
 )
 from ._routing import RoutingBase
 
@@ -244,6 +245,84 @@ class RoutingV4x3(RoutingBase):
         self._routingServer1.done()
         self._readServer1.done()
         self.assertTrue(failed)
+
+    @driver_feature(types.Feature.TMP_DRIVER_MAX_TX_RETRY_TIME)
+    def test_should_fail_when_reading_from_unexpectedly_interrupting_readers_using_tx_function(
+            self):
+        driver = Driver(self._backend, self._uri_with_context, self._auth,
+                        self._userAgent, maxTxRetryTimeMs=5000)
+        self.start_server(self._routingServer1,
+                          "router_adb_multi_no_bookmarks.script")
+        self.start_server(
+            self._readServer1,
+            "reader_tx_with_unexpected_interruption.script"
+        )
+        self.start_server(
+            self._readServer2,
+            "reader_tx_with_unexpected_interruption.script"
+        )
+
+        session = driver.session('r', database=self.adb)
+
+        def work(tx):
+            # drivers doing eager loading will fail here
+            tx.run("RETURN 1 as n")
+            # else they should fail here
+            tx.commit()
+
+        with self.assertRaises(types.DriverError) as exc:
+            session.readTransaction(work)
+
+        session.close()
+        driver.close()
+
+        if get_driver_name() in ['java']:
+            self.assertEqual(
+                'org.neo4j.driver.exceptions.SessionExpiredException',
+                exc.exception.errorType
+            )
+        self._routingServer1.done()
+        self._readServer1.done()
+        self._readServer2.done()
+
+    @driver_feature(types.Feature.TMP_DRIVER_MAX_TX_RETRY_TIME)
+    def test_should_fail_when_writing_to_unexpectedly_interrupting_writers_using_tx_function(
+            self):
+        driver = Driver(self._backend, self._uri_with_context, self._auth,
+                        self._userAgent, maxTxRetryTimeMs=5000)
+        self.start_server(self._routingServer1,
+                          "router_adb_multi_no_bookmarks.script")
+        self.start_server(
+            self._writeServer1,
+            "writer_tx_with_unexpected_interruption.script"
+        )
+        self.start_server(
+            self._writeServer2,
+            "writer_tx_with_unexpected_interruption.script"
+        )
+
+        session = driver.session('w', database=self.adb)
+
+        def work(tx):
+            # drivers doing eager loading will fail here
+            tx.run("RETURN 1 as n")
+            # else they should fail here
+            tx.commit()
+
+        with self.assertRaises(types.DriverError) as exc:
+            session.writeTransaction(work)
+
+        session.close()
+        driver.close()
+
+        if get_driver_name() in ['java']:
+            self.assertEqual(
+                'org.neo4j.driver.exceptions.SessionExpiredException',
+                exc.exception.errorType
+            )
+        self._routingServer1.done()
+        self._writeServer1.done()
+        self._writeServer2.done()
 
     # Checks that write server is used
     def test_should_write_successfully_on_writer_using_session_run(self):
@@ -1911,3 +1990,39 @@ class RoutingV4x3(RoutingBase):
         self.assertEqual(self.server_agent, agent)
         self._routingServer1.done()
         self._readServer1.done()
+
+    def test_should_fail_when_driver_closed_using_session_run(
+            self):
+        # TODO remove this block once fixed
+        if get_driver_name() in ["dotnet", "go", "javascript"]:
+            self.skipTest("Skipped because it needs investigation")
+        driver = Driver(self._backend, self._uri_with_context, self._auth,
+                        self._userAgent)
+        self.start_server(self._routingServer1, "router_adb.script")
+        self.start_server(self._readServer1, "reader.script")
+
+        session = driver.session('r', database=self.adb)
+        result = session.run("RETURN 1 as n")
+        sequence = self.collectRecords(result)
+        summary = result.consume()
+        session.close()
+        session = driver.session('r', database=self.adb)
+        driver.close()
+
+        failed_on_run = False
+        try:
+            session.run("RETURN 1 as n")
+        except types.DriverError as e:
+            if get_driver_name() in ['java']:
+                self.assertEqual(
+                    'java.lang.IllegalStateException',
+                    e.errorType
+                )
+            failed_on_run = True
+
+        self.assertTrue(failed_on_run)
+        self._routingServer1.done()
+        self._readServer1.done()
+        self.assertEqual(summary.server_info.address,
+                         get_dns_resolved_server_address(self._readServer1))
+        self.assertEqual([1], sequence)

--- a/tests/stub/versions/scripts/optional_hello.script
+++ b/tests/stub/versions/scripts/optional_hello.script
@@ -1,0 +1,16 @@
+!: BOLT #VERSION#
+
+{?
+    C: GOODBYE
+    S: SUCCESS
+?}
+C: HELLO {"{}": "*"}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+{*
+    C: RESET
+    S: SUCCESS
+*}
+{?
+    C: GOODBYE
+    S: SUCCESS
+?}

--- a/tests/stub/versions/test_versions.py
+++ b/tests/stub/versions/test_versions.py
@@ -112,8 +112,6 @@ class TestProtocolVersions(TestkitTestCase):
         self._run("4x2")
 
     def test_supports_bolt_4x3(self):
-        if get_driver_name() in ['java']:
-            self.skipTest("4.3 protocol not implemented")
         self._run("4x3")
 
     def test_supports_bolt_3x0(self):
@@ -177,3 +175,57 @@ class TestProtocolVersions(TestkitTestCase):
         summary = result.consume()
         self.assertEqual(summary.server_info.address,
                          get_dns_resolved_server_address(self._server))
+
+    def test_should_reject_server_using_verify_connectivity_bolt_3x0(self):
+        # TODO remove this block once fixed
+        if get_driver_name() in ["dotnet", "go", "javascript"]:
+            self.skipTest("Skipped because it needs investigation")
+        self._test_should_reject_server_using_verify_connectivity(version="3")
+
+    def test_should_reject_server_using_verify_connectivity_bolt_4x0(self):
+        # TODO remove this block once fixed
+        if get_driver_name() in ["java", "dotnet", "go", "javascript"]:
+            self.skipTest("Skipped because it needs investigation")
+        self._test_should_reject_server_using_verify_connectivity(version="4.0")
+
+    def test_should_reject_server_using_verify_connectivity_bolt_4x1(self):
+        # TODO remove this block once fixed
+        if get_driver_name() in ["java", "dotnet", "go", "javascript"]:
+            self.skipTest("Skipped because it needs investigation")
+        self._test_should_reject_server_using_verify_connectivity(version="4.1")
+
+    def test_should_reject_server_using_verify_connectivity_bolt_4x2(self):
+        # TODO remove this block once fixed
+        if get_driver_name() in ["java", "dotnet", "go", "javascript"]:
+            self.skipTest("Skipped because it needs investigation")
+        self._test_should_reject_server_using_verify_connectivity(version="4.2")
+
+    def test_should_reject_server_using_verify_connectivity_bolt_4x3(self):
+        # TODO remove this block once fixed
+        if get_driver_name() in ["java", "dotnet", "go", "javascript"]:
+            self.skipTest("Skipped because it needs investigation")
+        self._test_should_reject_server_using_verify_connectivity(version="4.3")
+
+    def _test_should_reject_server_using_verify_connectivity(self, version):
+        uri = "bolt://%s" % self._server.address
+        driver = Driver(self._backend, uri,
+                        types.AuthorizationToken(scheme="basic"))
+        script_path = self.script_path("optional_hello.script")
+        variables = {
+            "#VERSION#": version,
+            "#SERVER_AGENT#": "AgentSmith/0.0.1"
+        }
+        self._server.start(path=script_path, vars=variables)
+
+        with self.assertRaises(types.DriverError) as e:
+            driver.verifyConnectivity()
+
+        self._assert_is_untrusted_server_exception(e.exception)
+        self._server.done()
+        driver.close()
+
+    def _assert_is_untrusted_server_exception(self, e):
+        if get_driver_name() in ["java"]:
+            self.assertEqual(
+                "org.neo4j.driver.exceptions.UntrustedServerException",
+                e.errorType)


### PR DESCRIPTION
Cherry-pick: #226.

New features:
- `Temporary:DriverMaxTxRetryTime` - configures maximum transaction retry time.

Migrated tests:
- shouldRetryReadTransactionUntilFailure -> test_should_fail_when_reading_from_unexpectedly_interrupting_readers_using_tx_function
- shouldRetryWriteTransactionUntilFailure -> test_should_fail_when_writing_to_unexpectedly_interrupting_writers_using_tx_function
- useSessionAfterDriverIsClosed -> test_should_fail_when_driver_closed_using_session_run
- shouldRejectConnectionsToNonNeo4jServers -> test_should_reject_server_using_verify_connectivity_bolt_3x0

Enabled tests:
- test_supports_bolt_4x3