### PR TITLE
Migrate tests from Java Driver to Testkit

### DIFF
--- a/main.py
+++ b/main.py
@@ -106,14 +106,14 @@ def initialise_configurations():
 
         configurations.append(neo4j.Config(
             name="4.3-tc-enterprise",
-            image="neo4j:4.3.0-drop03.0-enterprise",
+            image="neo4j:4.3.4-enterprise",
             version="4.3",
             edition="enterprise",
             cluster=False,
             suite="4.3",
             scheme="neo4j",
             download=teamcity.DockerImage(
-                "neo4j-enterprise-4.3.0-drop03.0-docker-loadable.tar"),
+                "neo4j-enterprise-4.3.4-docker-loadable.tar"),
             stress_test_duration=0))
     return configurations
 

--- a/main.py
+++ b/main.py
@@ -94,14 +94,14 @@ def initialise_configurations():
     if in_teamcity:
         configurations.append(neo4j.Config(
             name="4.2-tc-enterprise",
-            image="neo4j:4.2.3-enterprise",
+            image="neo4j:4.2.10-enterprise",
             version="4.2",
             edition="enterprise",
             cluster=False,
             suite="4.2",
             scheme="neo4j",
             download=teamcity.DockerImage(
-                "neo4j-enterprise-4.2.4-docker-loadable.tar"),
+                "neo4j-enterprise-4.2.10-docker-loadable.tar"),
             stress_test_duration=0))
 
         configurations.append(neo4j.Config(

--- a/nutkit/frontend/result.py
+++ b/nutkit/frontend/result.py
@@ -18,6 +18,12 @@ class Result:
         req = protocol.ResultConsume(self._result.id)
         return self._backend.sendAndReceive(req)
 
+    def list(self):
+        """ Retrieves the entire result stream.
+        """
+        req = protocol.ResultList(self._result.id)
+        return self._backend.sendAndReceive(req)
+
     def keys(self):
         return self._result.keys
 

--- a/nutkit/protocol/feature.py
+++ b/nutkit/protocol/feature.py
@@ -55,3 +55,6 @@ class Feature(Enum):
     # Temporary driver feature that will be removed when all official driver
     # backends have implemented it.
     TMP_DRIVER_MAX_TX_RETRY_TIME = "Temporary:DriverMaxTxRetryTime"
+    # Temporary driver feature that will be removed when all official driver
+    # backends have implemented it.
+    TMP_RESULT_LIST = "Temporary:ResultList"

--- a/nutkit/protocol/requests.py
+++ b/nutkit/protocol/requests.py
@@ -274,6 +274,15 @@ class ResultConsume:
         self.resultId = resultId
 
 
+class ResultList:
+    """ Request to retrieve the entire result stream of records. Backend should
+    respond with RecordList or an Error if an error occurred.
+    """
+
+    def __init__(self, resultId):
+        self.resultId = resultId
+
+
 class RetryablePositive:
     """ Request to commit the retryable transaction.
     Backend responds with either a RetryableTry response (if it failed to

--- a/nutkit/protocol/responses.py
+++ b/nutkit/protocol/responses.py
@@ -172,6 +172,18 @@ class NullRecord:
         return isinstance(other, NullRecord)
 
 
+class RecordList:
+    """ Represents list of records returned from ResultList request."""
+
+    def __init__(self, records=None):
+        record_list = []
+        if records is not None:
+            for record in records:
+                record_list.append(Record(values=record['values']))
+
+        self.records = record_list
+
+
 class Summary:
     """ Represents summary returned from a ResultConsume request.
     """

--- a/tests/stub/routing/scripts/v4x1_no_routing/writer_with_custom_fetch_size.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/writer_with_custom_fetch_size.script
@@ -3,18 +3,32 @@
 C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "#USER_AGENT#" #ROUTING# #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 *: RESET
-C: RUN "RETURN 1 as n" {} {"db": "adb"}
-S: SUCCESS {"fields": ["n"]}
-C: PULL {"n": 2}
-S: RECORD [1]
-   RECORD [3]
-   SUCCESS {"has_more": true}
-C: PULL {"n": 2}
-S: RECORD [5]
-   RECORD [7]
-   SUCCESS {"has_more": true}
-C: PULL {"n": 2}
-S: RECORD [9]
-   SUCCESS {}
+{{
+    C: RUN "RETURN 1 as n" {} {"db": "adb"}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL {"n": 2}
+    S: RECORD [1]
+       RECORD [3]
+       SUCCESS {"has_more": true}
+    C: PULL {"n": 2}
+    S: RECORD [5]
+       RECORD [7]
+       SUCCESS {"has_more": true}
+    C: PULL {"n": 2}
+    S: RECORD [9]
+       SUCCESS {}
+----
+    C: RUN "RETURN 5 as n" {} {"db": "adb"}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL {"n": 2}
+    S: RECORD [1]
+       RECORD [3]
+       SUCCESS {"has_more": true}
+    C: PULL {"n": -1}
+    S: RECORD [5]
+       RECORD [7]
+       RECORD [9]
+       SUCCESS {}
+}}
 *: RESET
 ?: GOODBYE

--- a/tests/stub/routing/test_no_routing_v3.py
+++ b/tests/stub/routing/test_no_routing_v3.py
@@ -24,6 +24,10 @@ class NoRoutingV3(NoRoutingV4x1):
             self):
         pass
 
+    def test_should_pull_custom_size_and_then_all_using_session_configuration(
+            self):
+        pass
+
     def test_should_read_successfully_with_database_name_using_session_run(
             self):
         pass


### PR DESCRIPTION
New features:
- `Temporary:ResultList`

Migrated tests:
- shouldHandleLeaderSwitchAndRetryWhenWritingInTxFunctionAsync -> test_should_write_successfully_on_leader_switch_using_tx_function (existing test, bolt bump to 4.1)
- shouldOnlyPullRecordsWhenNeededAsyncSession -> test_should_accept_custom_fetch_size_using_session_configuration (existing test, bolt bump to 4.1)
- shouldPullAllRecordsOnListAsyncWhenOverWatermark -> test_should_pull_custom_size_and_then_all_using_session_configuration