### PR TITLE
Migrate tests from Java Driver to Testkit

### DIFF
--- a/main.py
+++ b/main.py
@@ -93,26 +93,26 @@ def initialise_configurations():
     if in_teamcity:
         configurations.append(neo4j.Config(
             name="4.2-tc-enterprise",
-            image="neo4j:4.2.3-enterprise",
+            image="neo4j:4.2.10-enterprise",
             version="4.2",
             edition="enterprise",
             cluster=False,
             suite="4.2",
             scheme="neo4j",
             download=teamcity.DockerImage(
-                "neo4j-enterprise-4.2.4-docker-loadable.tar"),
+                "neo4j-enterprise-4.2.10-docker-loadable.tar"),
             stress_test_duration=0))
 
         configurations.append(neo4j.Config(
             name="4.3-tc-enterprise",
-            image="neo4j:4.3.0-drop03.0-enterprise",
+            image="neo4j:4.3.4-enterprise",
             version="4.3",
             edition="enterprise",
             cluster=False,
             suite="4.3",
             scheme="neo4j",
             download=teamcity.DockerImage(
-                "neo4j-enterprise-4.3.0-drop03.0-docker-loadable.tar"),
+                "neo4j-enterprise-4.3.4-docker-loadable.tar"),
             stress_test_duration=0))
     return configurations
 

--- a/nutkit/frontend/result.py
+++ b/nutkit/frontend/result.py
@@ -18,6 +18,12 @@ class Result:
         req = protocol.ResultConsume(self._result.id)
         return self._backend.sendAndReceive(req)
 
+    def list(self):
+        """ Retrieves the entire result stream.
+        """
+        req = protocol.ResultList(self._result.id)
+        return self._backend.sendAndReceive(req)
+
     def keys(self):
         return self._result.keys
 

--- a/nutkit/protocol/feature.py
+++ b/nutkit/protocol/feature.py
@@ -55,3 +55,6 @@ class Feature(Enum):
     # Temporary driver feature that will be removed when all official driver
     # backends have implemented it.
     TMP_DRIVER_MAX_TX_RETRY_TIME = "Temporary:DriverMaxTxRetryTime"
+    # Temporary driver feature that will be removed when all official driver
+    # backends have implemented it.
+    TMP_RESULT_LIST = "Temporary:ResultList"

--- a/nutkit/protocol/requests.py
+++ b/nutkit/protocol/requests.py
@@ -274,6 +274,15 @@ class ResultConsume:
         self.resultId = resultId
 
 
+class ResultList:
+    """ Request to retrieve the entire result stream of records. Backend should
+    respond with RecordList or an Error if an error occurred.
+    """
+
+    def __init__(self, resultId):
+        self.resultId = resultId
+
+
 class RetryablePositive:
     """ Request to commit the retryable transaction.
     Backend responds with either a RetryableTry response (if it failed to

--- a/nutkit/protocol/responses.py
+++ b/nutkit/protocol/responses.py
@@ -172,6 +172,18 @@ class NullRecord:
         return isinstance(other, NullRecord)
 
 
+class RecordList:
+    """ Represents list of records returned from ResultList request."""
+
+    def __init__(self, records=None):
+        record_list = []
+        if records is not None:
+            for record in records:
+                record_list.append(Record(values=record['values']))
+
+        self.records = record_list
+
+
 class Summary:
     """ Represents summary returned from a ResultConsume request.
     """

--- a/tests/stub/routing/scripts/v4x1_no_routing/reader_tx_yielding_multiple_records.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/reader_tx_yielding_multiple_records.script
@@ -2,7 +2,10 @@
 
 C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "#USER_AGENT#" #ROUTING# #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
-*: RESET
+{*
+    C: RESET
+    S: SUCCESS {}
+*}
 C: BEGIN {"mode": "r", "db": "adb"}
 S: SUCCESS {}
 C: RUN "RETURN 1 as n" {} {}
@@ -14,5 +17,11 @@ S: RECORD [1]
    SUCCESS {"type": "r"}
 C: COMMIT
 S: SUCCESS { "bookmark": "ABookmark" }
-*: RESET
-?: GOODBYE
+{*
+    C: RESET
+    S: SUCCESS {}
+*}
+{?
+    C: GOODBYE
+    S: SUCCESS {}
+?}

--- a/tests/stub/routing/scripts/v4x1_no_routing/reader_tx_yielding_multiple_records.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/reader_tx_yielding_multiple_records.script
@@ -1,0 +1,18 @@
+!: BOLT #VERSION#
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "#USER_AGENT#" #ROUTING# #EXTRA_HELLO_PROPS#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+C: BEGIN {"mode": "r", "db": "adb"}
+S: SUCCESS {}
+C: RUN "RETURN 1 as n" {} {}
+S: SUCCESS {"fields": ["n"]}
+C: PULL { "n": 1000 }
+S: RECORD [1]
+   RECORD [5]
+   RECORD [7]
+   SUCCESS {"type": "r"}
+C: COMMIT
+S: SUCCESS { "bookmark": "ABookmark" }
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x1_no_routing/reader_yielding_multiple_records.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/reader_yielding_multiple_records.script
@@ -2,7 +2,10 @@
 
 C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "#USER_AGENT#" #ROUTING# #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
-*: RESET
+{*
+    C: RESET
+    S: SUCCESS {}
+*}
 C: RUN "RETURN 1 as n" {} {"mode": "r", "db": "adb"}
 S: SUCCESS {"fields": ["n"]}
 C: PULL { "n": 1000 }
@@ -10,5 +13,11 @@ S: RECORD [1]
    RECORD [5]
    RECORD [7]
    SUCCESS {"type": "r"}
-*: RESET
-?: GOODBYE
+{*
+    C: RESET
+    S: SUCCESS {}
+*}
+{?
+    C: GOODBYE
+    S: SUCCESS {}
+?}

--- a/tests/stub/routing/scripts/v4x1_no_routing/reader_yielding_multiple_records.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/reader_yielding_multiple_records.script
@@ -1,0 +1,14 @@
+!: BOLT #VERSION#
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "#USER_AGENT#" #ROUTING# #EXTRA_HELLO_PROPS#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+C: RUN "RETURN 1 as n" {} {"mode": "r", "db": "adb"}
+S: SUCCESS {"fields": ["n"]}
+C: PULL { "n": 1000 }
+S: RECORD [1]
+   RECORD [5]
+   RECORD [7]
+   SUCCESS {"type": "r"}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x1_no_routing/writer_with_custom_fetch_size.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/writer_with_custom_fetch_size.script
@@ -12,10 +12,14 @@ C: RUN "RETURN 1 as n" {} {"db": "adb"}
 S: SUCCESS {"fields": ["n"]}
 C: PULL {"n": 2}
 S: RECORD [1]
-   RECORD [5]
+   RECORD [3]
    SUCCESS {"has_more": true}
 C: PULL {"n": 2}
-S: RECORD [7]
+S: RECORD [5]
+   RECORD [7]
+   SUCCESS {"has_more": true}
+C: PULL {"n": 2}
+S: RECORD [9]
    SUCCESS {}
 C: RESET
 S: SUCCESS {}

--- a/tests/stub/routing/scripts/v4x1_no_routing/writer_with_custom_fetch_size.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/writer_with_custom_fetch_size.script
@@ -1,29 +1,43 @@
 !: BOLT #VERSION#
-!: AUTO GOODBYE
 
 C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "#USER_AGENT#" #ROUTING# #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
-# Added this block for GO
 {?
     C: RESET
     S: SUCCESS {}
 ?}
-C: RUN "RETURN 1 as n" {} {"db": "adb"}
-S: SUCCESS {"fields": ["n"]}
-C: PULL {"n": 2}
-S: RECORD [1]
-   RECORD [3]
-   SUCCESS {"has_more": true}
-C: PULL {"n": 2}
-S: RECORD [5]
-   RECORD [7]
-   SUCCESS {"has_more": true}
-C: PULL {"n": 2}
-S: RECORD [9]
-   SUCCESS {}
-C: RESET
-S: SUCCESS {}
+{{
+    C: RUN "RETURN 1 as n" {} {"db": "adb"}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL {"n": 2}
+    S: RECORD [1]
+       RECORD [3]
+       SUCCESS {"has_more": true}
+    C: PULL {"n": 2}
+    S: RECORD [5]
+       RECORD [7]
+       SUCCESS {"has_more": true}
+    C: PULL {"n": 2}
+    S: RECORD [9]
+       SUCCESS {}
+----
+    C: RUN "RETURN 5 as n" {} {"db": "adb"}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL {"n": 2}
+    S: RECORD [1]
+       RECORD [3]
+       SUCCESS {"has_more": true}
+    C: PULL {"n": -1}
+    S: RECORD [5]
+       RECORD [7]
+       RECORD [9]
+       SUCCESS {}
+}}
 {?
     C: RESET
     S: SUCCESS {}
+?}
+{?
+    C: GOODBYE
+    S: <EXIT>
 ?}

--- a/tests/stub/routing/test_no_routing_v3.py
+++ b/tests/stub/routing/test_no_routing_v3.py
@@ -24,6 +24,10 @@ class NoRoutingV3(NoRoutingV4x1):
             self):
         pass
 
+    def test_should_pull_custom_size_and_then_all_using_session_configuration(
+            self):
+        pass
+
     def test_should_read_successfully_with_database_name_using_session_run(
             self):
         pass

--- a/tests/stub/routing/test_no_routing_v3.py
+++ b/tests/stub/routing/test_no_routing_v3.py
@@ -24,5 +24,13 @@ class NoRoutingV3(NoRoutingV4x1):
             self):
         pass
 
+    def test_should_read_successfully_with_database_name_using_session_run(
+            self):
+        pass
+
+    def test_should_read_successfully_with_database_name_using_tx_function(
+            self):
+        pass
+
     def _assert_supports_multi_db(self, supports_multi_db):
         self.assertFalse(supports_multi_db)

--- a/tests/stub/routing/test_no_routing_v4x1.py
+++ b/tests/stub/routing/test_no_routing_v4x1.py
@@ -293,6 +293,35 @@ class NoRoutingV4x1(TestkitTestCase):
                           types.Record(values=[types.CypherInt(9)])], records)
         self._server.done()
 
+    @driver_feature(types.Feature.TMP_RESULT_LIST)
+    def test_should_pull_custom_size_and_then_all_using_session_configuration(
+            self):
+        uri = "bolt://%s" % self._server.address
+        self._server.start(
+            path=self.script_path(self.version_dir,
+                                  "writer_with_custom_fetch_size.script"),
+            vars=self.get_vars()
+        )
+        driver = Driver(self._backend, uri,
+                        types.AuthorizationToken(scheme="basic", principal="p",
+                                                 credentials="c"),
+                        userAgent="007")
+
+        session = driver.session('w', database=self.adb, fetchSize=2)
+        res = session.run("RETURN 5 as n")
+        record_list = res.list()
+
+        session.close()
+        driver.close()
+
+        self.assertEqual([types.Record(values=[types.CypherInt(1)]),
+                          types.Record(values=[types.CypherInt(3)]),
+                          types.Record(values=[types.CypherInt(5)]),
+                          types.Record(values=[types.CypherInt(7)]),
+                          types.Record(values=[types.CypherInt(9)])],
+                         record_list.records)
+        self._server.done()
+
     @driver_feature(types.Feature.TMP_DRIVER_FETCH_SIZE)
     def test_should_pull_all_when_fetch_is_minus_one_using_driver_configuration(
             self):

--- a/tests/stub/routing/test_no_routing_v4x1.py
+++ b/tests/stub/routing/test_no_routing_v4x1.py
@@ -260,8 +260,10 @@ class NoRoutingV4x1(TestkitTestCase):
         driver.close()
 
         self.assertEqual([types.Record(values=[types.CypherInt(1)]),
+                          types.Record(values=[types.CypherInt(3)]),
                           types.Record(values=[types.CypherInt(5)]),
-                          types.Record(values=[types.CypherInt(7)])], records)
+                          types.Record(values=[types.CypherInt(7)]),
+                          types.Record(values=[types.CypherInt(9)])], records)
         self._server.done()
 
     def test_should_accept_custom_fetch_size_using_session_configuration(
@@ -285,8 +287,10 @@ class NoRoutingV4x1(TestkitTestCase):
         driver.close()
 
         self.assertEqual([types.Record(values=[types.CypherInt(1)]),
+                          types.Record(values=[types.CypherInt(3)]),
                           types.Record(values=[types.CypherInt(5)]),
-                          types.Record(values=[types.CypherInt(7)])], records)
+                          types.Record(values=[types.CypherInt(7)]),
+                          types.Record(values=[types.CypherInt(9)])], records)
         self._server.done()
 
     @driver_feature(types.Feature.TMP_DRIVER_FETCH_SIZE)
@@ -449,6 +453,64 @@ class NoRoutingV4x1(TestkitTestCase):
 
         self._assert_is_transient_commit_exception(
             exc.exception, expected_msg="Database shut down.")
+        self._server.done()
+
+    def test_should_read_successfully_with_database_name_using_session_run(
+            self):
+        uri = "bolt://%s" % self._server.address
+        self._server.start(
+            path=self.script_path(
+                self.version_dir,
+                "reader_yielding_multiple_records.script"),
+            vars=self.get_vars()
+        )
+        driver = Driver(self._backend, uri,
+                        types.AuthorizationToken(scheme="basic", principal="p",
+                                                 credentials="c"),
+                        userAgent="007")
+
+        session = driver.session('r', database=self.adb)
+        res = session.run("RETURN 1 as n")
+        records = list(res)
+
+        session.close()
+        driver.close()
+
+        self.assertEqual([types.Record(values=[types.CypherInt(1)]),
+                          types.Record(values=[types.CypherInt(5)]),
+                          types.Record(values=[types.CypherInt(7)])], records)
+        self._server.done()
+
+    def test_should_read_successfully_with_database_name_using_tx_function(
+            self):
+        uri = "bolt://%s" % self._server.address
+        self._server.start(
+            path=self.script_path(
+                self.version_dir,
+                "reader_tx_yielding_multiple_records.script"),
+            vars=self.get_vars()
+        )
+        driver = Driver(self._backend, uri,
+                        types.AuthorizationToken(scheme="basic", principal="p",
+                                                 credentials="c"),
+                        userAgent="007")
+
+        session = driver.session('r', database=self.adb)
+        records = None
+
+        def work(tx):
+            nonlocal records
+            result = tx.run("RETURN 1 as n")
+            records = list(result)
+
+        session.readTransaction(work)
+
+        session.close()
+        driver.close()
+
+        self.assertEqual([types.Record(values=[types.CypherInt(1)]),
+                          types.Record(values=[types.CypherInt(5)]),
+                          types.Record(values=[types.CypherInt(7)])], records)
         self._server.done()
 
     def _assert_is_transient_rollback_exception(


### PR DESCRIPTION
Cherry-picks: #221, #229.

* Migrate tests from Java Driver to Testkit

New features:
- `Temporary:ResultList`

Migrated tests:
- shouldHandleLeaderSwitchAndRetryWhenWritingInTxFunctionAsync -> test_should_write_successfully_on_leader_switch_using_tx_function (existing test, bolt bump to 4.1)
- shouldOnlyPullRecordsWhenNeededAsyncSession -> test_should_accept_custom_fetch_size_using_session_configuration (existing test, bolt bump to 4.1)
- shouldPullAllRecordsOnListAsyncWhenOverWatermark -> test_should_pull_custom_size_and_then_all_using_session_configuration

* Update neo4j-enterprise-4.3.0-drop03.0 to neo4j-enterprise-4.3.4

* Update neo4j-enterprise-4.2.4 to neo4j-enterprise-4.2.10