### PR TITLE
Enable checking of exception codes for GO

### DIFF
--- a/tests/neo4j/test_direct_driver.py
+++ b/tests/neo4j/test_direct_driver.py
@@ -116,10 +116,6 @@ class TestDirectDriver(TestkitTestCase):
             result = self._session.run("RETURN 1")
             result.next()
         exc = e.exception
-        # TODO remove this block once all languages work
-        if get_driver_name() in ["go"]:
-            # does not set exception code or message
-            return
         self.assertEqual(exc.code,
                          "Neo.ClientError.Database.DatabaseNotFound")
         self.assertIn("test-database", exc.msg)

--- a/tests/neo4j/txfuncrun.py
+++ b/tests/neo4j/txfuncrun.py
@@ -224,10 +224,6 @@ class TestTxFuncRun(TestkitTestCase):
             "w", bookmarks=self._session1.lastBookmarks()
         )
         self._session1.writeTransaction(update1)
-        # TODO remove this block once all languages work
-        if get_driver_name() in ["go"]:
-            # does not set exception code
-            return
         self.assertIsNotNone(exc)
         self.assertEqual(exc.exception.code,
                          "Neo.TransientError.Transaction.LockClientStopped")


### PR DESCRIPTION
These tests have been fixed in the driver with https://github.com/neo4j/neo4j-go-driver/pull/250/files