### PR TITLE
Update test matrix

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,75 +45,84 @@ test_flags = {
 
 
 def initialise_configurations():
-    configurations = []
-    configurations.append(neo4j.Config(
-        name="4.2-cluster",
-        image="neo4j:4.2-enterprise",
-        version="4.2",
-        edition="enterprise",
-        cluster=True,
-        suite="",  # TODO: Define cluster suite
-        scheme="neo4j",
-        download=None,
-        stress_test_duration=90))
+    def generate_config(version, enterprise, cluster, scheme, stress_test):
+        assert (cluster and scheme == "neo4j"
+                or not cluster and scheme in ("neo4j", "bolt"))
+        edition = "enterprise" if enterprise else "community"
+        name = "%s-%s%s-%s" % (version, edition,
+                              "-cluster" if cluster else "", scheme)
+        return neo4j.Config(
+            name=name,
+            image="neo4j:%s%s" % (version, "-enterprise" if enterprise else ""),
+            version=version,
+            edition=edition,
+            cluster=cluster,
+            suite=version,
+            scheme=scheme,
+            download=None,
+            stress_test_duration=stress_test
+        )
 
-    configurations.append(neo4j.Config(
-        name="3.5-enterprise",
-        image="neo4j:3.5-enterprise",
-        version="3.5",
-        edition="enterprise",
-        cluster=False,
-        suite="3.5",
-        scheme="bolt",
-        download=None,
-        stress_test_duration=0))
-
-    configurations.append(neo4j.Config(
-        name="4.0-community",
-        version="4.0",
-        image="neo4j:4.0",
-        edition="community",
-        cluster=False,
-        suite="4.0",
-        scheme="neo4j",
-        download=None,
-        stress_test_duration=0))
-
-    configurations.append(neo4j.Config(
-        name="4.1-enterprise",
-        image="neo4j:4.1-enterprise",
-        version="4.1",
-        edition="enterprise",
-        cluster=False,
-        suite="4.1",
-        scheme="neo4j",
-        download=None,
-        stress_test_duration=0))
-
-    if in_teamcity:
-        configurations.append(neo4j.Config(
-            name="4.2-tc-enterprise",
-            image="neo4j:4.2.10-enterprise",
-            version="4.2",
-            edition="enterprise",
-            cluster=False,
-            suite="4.2",
-            scheme="neo4j",
+    def generate_tc_config(version, enterprise, cluster, scheme, stress_test):
+        if not in_teamcity:
+            return None
+        assert (cluster and scheme == "neo4j"
+                or not cluster and scheme in ("neo4j", "bolt"))
+        edition = "enterprise" if enterprise else "community"
+        name = "%s-tc-%s%s-%s" % (version, edition,
+                                  "-cluster" if cluster else "", scheme)
+        version_without_drop = ".".join(version.split(".")[:2])
+        return neo4j.Config(
+            name=name,
+            image="neo4j:%s%s" % (version, "-enterprise" if enterprise else ""),
+            version=version_without_drop,
+            edition=edition,
+            cluster=cluster,
+            suite=version_without_drop,
+            scheme=scheme,
             download=teamcity.DockerImage(
-                "neo4j-enterprise-4.2.10-docker-loadable.tar"),
-            stress_test_duration=0))
+                "neo4j-%s-%s-docker-loadable.tar" % (edition, version)
+            ),
+            stress_test_duration=stress_test
+        )
 
-        configurations.append(neo4j.Config(
-            name="4.3-tc-enterprise",
-            image="neo4j:4.3.4-enterprise",
-            version="4.3",
-            edition="enterprise",
-            cluster=False,
-            suite="4.3",
-            scheme="neo4j",
-            download=teamcity.DockerImage(
-                "neo4j-enterprise-4.3.4-docker-loadable.tar"),
-            stress_test_duration=0))
+    configurations = [
+        generate_config(version_, enterprise_, cluster_, scheme_, stress_test_)
+        for (version_, enterprise_, cluster_, scheme_, stress_test_) in (
+            # LTS version
+            # 3.5 servers only support routing scheme if configured as cluster
+            ("3.5",    False,       False,    "bolt",   0),
+            ("3.5",    True,        False,    "bolt",   0),
+            ("3.5",    True,        True,     "neo4j", 60),
+            # not officially supported versions
+            ("4.0",    True,        False,    "neo4j",  0),
+            ("4.1",    True,        False,    "neo4j",  0),
+            # official backwards-compatibility
+            ("4.2",    False,       False,    "bolt",   0),
+            ("4.2",    False,       False,    "neo4j",  0),
+            ("4.2",    True,        False,    "bolt",   0),
+            ("4.2",    True,        False,    "neo4j",  0),
+            ("4.2",    True,        True,     "neo4j", 90),
+            # latest version
+            ("4.3",    False,       False,    "bolt",  90),
+            ("4.3",    False,       False,    "neo4j",  0),
+            ("4.3",    True,        False,    "bolt",   0),
+            ("4.3",    True,        False,    "neo4j",  0),
+            ("4.3",    True,        True,     "neo4j", 90),
+        )
+    ]
+    configurations += [
+        generate_tc_config(version_, enterprise_, cluster_, scheme_,
+                           stress_test_)
+        for (version_, enterprise_, cluster_, scheme_, stress_test_) in (
+            # nightly build of backwards-compatible version
+            ("4.2.12", True,        True,     "neo4j",  0),
+            # nightly build of latest version
+            ("4.3.4",  True,        True,     "neo4j", 60),
+        )
+    ]
+
+    configurations = list(filter(lambda conf: conf is not None, configurations))
     return configurations
 
 
@@ -338,25 +347,28 @@ def main(settings, configurations):
 
         # Start a Neo4j server
         if cluster:
-            print("Starting neo4j cluster (%s)" % server_name)
+            print("\n    Starting neo4j cluster (%s)\n" % server_name)
             server = neo4j.Cluster(neo4j_config.image,
                                    server_name,
                                    neo4j_artifacts_path)
         else:
-            print("Starting neo4j standalone server (%s)" % server_name)
+            print("\n    Starting neo4j standalone server (%s)\n" % server_name)
             server = neo4j.Standalone(neo4j_config.image,
                                       server_name,
                                       neo4j_artifacts_path,
                                       "neo4jserver", 7687,
                                       neo4j_config.edition)
         server.start(networks[0])
-        hostname, port = server.address()
+        addresses = server.addresses()
+        hostname, port = addresses[0]
 
         # Wait until server is listening before running tests
         # Use driver container to check for Neo4j availability since connect
         # will be done from there
-        print("Waiting for neo4j service port to be available")
-        driver_container.poll_host_and_port_until_available(hostname, port)
+        for address in addresses:
+            print("Waiting for neo4j service at %s to be available"
+                  % (address,))
+            driver_container.poll_host_and_port_until_available(*address)
         print("Neo4j is reachable from driver")
 
         if test_flags["TESTKIT_TESTS"]:

--- a/main.py
+++ b/main.py
@@ -50,7 +50,7 @@ def initialise_configurations():
                 or not cluster and scheme in ("neo4j", "bolt"))
         edition = "enterprise" if enterprise else "community"
         name = "%s-%s%s-%s" % (version, edition,
-                              "-cluster" if cluster else "", scheme)
+                               "-cluster" if cluster else "", scheme)
         return neo4j.Config(
             name=name,
             image="neo4j:%s%s" % (version, "-enterprise" if enterprise else ""),

--- a/neo4j.py
+++ b/neo4j.py
@@ -45,8 +45,8 @@ class Standalone:
             env_map=env_map,
             network=network)
 
-    def address(self):
-        return (self._hostname, self._port)
+    def addresses(self):
+        return [(self._hostname, self._port)]
 
     def stop(self):
         self._container.rm()
@@ -74,8 +74,8 @@ class Cluster:
         for core in self._cores:
             core.start(self._image, initial_members, network)
 
-    def address(self):
-        return ("core0", 7687)
+    def addresses(self):
+        return [("core%d" % i, 7687) for i in range(self._num_cores)]
 
     def stop(self):
         for core in self._cores:

--- a/tests/neo4j/suites.py
+++ b/tests/neo4j/suites.py
@@ -35,51 +35,24 @@ suite_3x5.addTests(loader.loadTestsFromModule(txrun))
 """
 Suite for Neo4j 4.0
 """
-suite_4x0 = unittest.TestSuite()
-suite_4x0.addTests(loader.loadTestsFromModule(datatypes))
-suite_4x0.addTests(loader.loadTestsFromModule(sessionrun))
-suite_4x0.addTests(loader.loadTestsFromModule(authentication))
-suite_4x0.addTests(loader.loadTestsFromModule(test_direct_driver))
-suite_4x0.addTests(loader.loadTestsFromModule(test_summary))
-suite_4x0.addTests(loader.loadTestsFromModule(txfuncrun))
-suite_4x0.addTests(loader.loadTestsFromModule(txrun))
+suite_4x0 = suite_3x5
 
 
 """
 Suite for Neo4j 4.1
 """
-suite_4x1 = unittest.TestSuite()
-suite_4x1.addTests(loader.loadTestsFromModule(datatypes))
-suite_4x1.addTests(loader.loadTestsFromModule(sessionrun))
-suite_4x1.addTests(loader.loadTestsFromModule(authentication))
-suite_4x1.addTests(loader.loadTestsFromModule(test_direct_driver))
-suite_4x1.addTests(loader.loadTestsFromModule(test_summary))
-suite_4x1.addTests(loader.loadTestsFromModule(txfuncrun))
-suite_4x1.addTests(loader.loadTestsFromModule(txrun))
+suite_4x1 = suite_4x0
 
 """
 Suite for Neo4j 4.2
 """
-suite_4x2 = unittest.TestSuite()
-suite_4x2.addTests(loader.loadTestsFromModule(datatypes))
-suite_4x2.addTests(loader.loadTestsFromModule(sessionrun))
-suite_4x2.addTests(loader.loadTestsFromModule(authentication))
-suite_4x2.addTests(loader.loadTestsFromModule(test_direct_driver))
-suite_4x2.addTests(loader.loadTestsFromModule(test_summary))
-suite_4x2.addTests(loader.loadTestsFromModule(txfuncrun))
-suite_4x2.addTests(loader.loadTestsFromModule(txrun))
+suite_4x2 = suite_4x1
 
 """
 Suite for Neo4j 4.3
 """
-suite_4x3 = unittest.TestSuite()
-suite_4x3.addTests(loader.loadTestsFromModule(datatypes))
-suite_4x3.addTests(loader.loadTestsFromModule(sessionrun))
-suite_4x3.addTests(loader.loadTestsFromModule(authentication))
-suite_4x3.addTests(loader.loadTestsFromModule(test_direct_driver))
-suite_4x3.addTests(loader.loadTestsFromModule(test_summary))
-suite_4x3.addTests(loader.loadTestsFromModule(txfuncrun))
-suite_4x3.addTests(loader.loadTestsFromModule(txrun))
+suite_4x3 = suite_4x2
+
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:

--- a/tests/neo4j/test_summary.py
+++ b/tests/neo4j/test_summary.py
@@ -5,6 +5,7 @@ from ..shared import (
     TestkitTestCase,
 )
 from .shared import (
+    cluster_unsafe_test,
     get_driver,
     get_server_info,
 )
@@ -25,13 +26,15 @@ class TestDirectDriver(TestkitTestCase):
         super().tearDown()
 
     def get_summary(self, query, params=None, **kwargs):
+        def work(tx):
+            result = tx.run(query, params=params, **kwargs)
+            for _ in result:
+                pass
+            summary = result.consume()
+            return summary
         params = {} if params is None else params
         self._session = self._driver.session("w")
-        result = self._session.run(query, params=params, **kwargs)
-        for _ in result:
-            pass
-        summary = result.consume()
-        return summary
+        return self._session.writeTransaction(work)
 
     @driver_feature(types.Feature.TMP_FULL_SUMMARY)
     def test_can_obtain_summary_after_consuming_result(self):
@@ -130,6 +133,7 @@ class TestDirectDriver(TestkitTestCase):
 
     @driver_feature(types.Feature.TMP_RESULT_KEYS,
                     types.Feature.TMP_FULL_SUMMARY)
+    @cluster_unsafe_test
     def test_summary_counters_case_2(self):
         if not get_server_info().supports_multi_db:
             self.skipTest("Needs multi DB support")

--- a/tests/neo4j/txrun.py
+++ b/tests/neo4j/txrun.py
@@ -1,5 +1,10 @@
 from tests.neo4j.shared import get_driver
 import nutkit.protocol as types
+from tests.neo4j.shared import (
+    cluster_unsafe_test,
+    get_driver,
+    get_server_info,
+)
 from tests.shared import (
     get_driver_name,
     TestkitTestCase,
@@ -18,6 +23,7 @@ class TestTxRun(TestkitTestCase):
         self._driver.close()
         super().tearDown()
 
+    @cluster_unsafe_test
     def test_updates_last_bookmark_on_commit(self):
         # Verifies that last bookmark is set on the session upon
         # succesful commit.
@@ -29,6 +35,7 @@ class TestTxRun(TestkitTestCase):
         self.assertEqual(len(bookmarks), 1)
         self.assertGreater(len(bookmarks[0]), 3)
 
+    @cluster_unsafe_test
     def test_does_not_update_last_bookmark_on_rollback(self):
         # Verifies that last bookmark is set on the session upon
         # succesful commit.
@@ -39,6 +46,7 @@ class TestTxRun(TestkitTestCase):
         bookmarks = self._session.lastBookmarks()
         self.assertEqual(len(bookmarks), 0)
 
+    @cluster_unsafe_test
     def test_does_not_update_last_bookmark_on_failure(self):
         session = self._driver.session("w")
         tx = session.beginTransaction()
@@ -48,6 +56,7 @@ class TestTxRun(TestkitTestCase):
         bookmarks = session.lastBookmarks()
         self.assertEqual(len(bookmarks), 0)
 
+    @cluster_unsafe_test
     def test_should_be_able_to_rollback_a_failure(self):
         if get_driver_name() in ["go"]:
             self.skipTest('Could not rollback transaction')
@@ -57,6 +66,7 @@ class TestTxRun(TestkitTestCase):
             tx.run("RETURN").next()
         tx.rollback()
 
+    @cluster_unsafe_test
     def test_should_not_rollback_a_rollbacked_tx(self):
         if get_driver_name() in ["go"]:
             self.skipTest('Does not raise the exception')
@@ -67,6 +77,7 @@ class TestTxRun(TestkitTestCase):
         with self.assertRaises(types.responses.DriverError):
             tx.rollback()
 
+    @cluster_unsafe_test
     def test_should_not_rollback_a_commited_tx(self):
         if get_driver_name() in ["go"]:
             self.skipTest('Does not raise the exception')
@@ -77,6 +88,7 @@ class TestTxRun(TestkitTestCase):
         with self.assertRaises(types.responses.DriverError):
             tx.rollback()
 
+    @cluster_unsafe_test
     def test_should_not_commit_a_commited_tx(self):
         if get_driver_name() in ["go"]:
             self.skipTest('Does not raise exception')
@@ -87,6 +99,7 @@ class TestTxRun(TestkitTestCase):
         with self.assertRaises(types.responses.DriverError):
             tx.commit()
 
+    @cluster_unsafe_test
     def test_should_not_run_valid_query_in_invalid_tx(self):
         if get_driver_name() in ["python"]:
             self.skipTest("executes the second RUN")
@@ -103,6 +116,7 @@ class TestTxRun(TestkitTestCase):
 
         tx.rollback()
 
+    @cluster_unsafe_test
     def test_should_fail_run_in_a_commited_tx(self):
         self._session = self._driver.session("w")
         tx = self._session.beginTransaction()
@@ -110,6 +124,7 @@ class TestTxRun(TestkitTestCase):
         with self.assertRaises(types.responses.DriverError):
             tx.run("RETURN 42").next()
 
+    @cluster_unsafe_test
     def test_should_fail_run_in_a_rollbacked_tx(self):
         self._session = self._driver.session("w")
         tx = self._session.beginTransaction()
@@ -117,6 +132,7 @@ class TestTxRun(TestkitTestCase):
         with self.assertRaises(types.responses.DriverError):
             tx.run("RETURN 42").next()
 
+    @cluster_unsafe_test
     def test_should_fail_to_run_query_for_invalid_bookmark(self):
         session = self._driver.session("w")
         tx1 = session.beginTransaction()


### PR DESCRIPTION
 - Use publicly available 4.3 images
 - Update test matrix to be more comprehensive
 - Run suitable integration tests also on cluster configurations

Backport of https://github.com/neo4j-drivers/testkit/pull/241