### PR TITLE
Add tests for Result.peek() and Result.single()

### DIFF
--- a/nutkit/frontend/result.py
+++ b/nutkit/frontend/result.py
@@ -12,6 +12,18 @@ class Result:
         req = protocol.ResultNext(self._result.id)
         return self._backend.sendAndReceive(req)
 
+    def single(self):
+        """ Returns one record if there is exactly one. Raises error otherwise.
+        """
+        req = protocol.ResultSingle(self._result.id)
+        return self._backend.sendAndReceive(req)
+
+    def peek(self):
+        """ Returns the next Record or NullRecord without consuming it
+        """
+        req = protocol.ResultPeek(self._result.id)
+        return self._backend.sendAndReceive(req)
+
     def consume(self):
         """ Discards all records in result and returns summary.
         """

--- a/nutkit/protocol/feature.py
+++ b/nutkit/protocol/feature.py
@@ -5,6 +5,16 @@ from enum import Enum
 
 
 class Feature(Enum):
+    # === FUNCTIONAL FEATURES ===
+    # The driver offers a method for the result to peek at the next record in
+    # the result stream without advancing it (i.e. without consuming any
+    # records)
+    API_RESULT_PEEK = "Feature:API:Result.Peek"
+    # The driver offers a method for the result to retrieve exactly one record.
+    # This methods asserts that exactly one record in left in the result stream,
+    # else it will raise an exception.
+    API_RESULT_SINGLE = "Feature:API:Result.Single"
+
     # === OPTIMIZATIONS ===
     # On receiving Neo.ClientError.Security.AuthorizationExpired, the driver
     # shouldn't reuse any open connections for anything other than finishing

--- a/nutkit/protocol/requests.py
+++ b/nutkit/protocol/requests.py
@@ -256,7 +256,31 @@ class TransactionClose:
 class ResultNext:
     """ Request to retrieve the next record on a result living on the backend.
     Backend should respond with a Record if there is a record, an Error if an
-    error occured while retrieving next record or NullRecord if there were no
+    error occurred while retrieving next record or NullRecord if there were no
+    error and no record.
+    """
+
+    def __init__(self, resultId):
+        self.resultId = resultId
+
+
+class ResultSingle:
+    """ Request to expect and return exactly one record in the result stream.
+    Backend should respond with a Record if exactly one record was found.
+    If more or fewer records are left in the result stream, or if any other
+    error occurs while retrieving the records, an Error response should be
+    returned.
+    """
+
+    def __init__(self, resultId):
+        self.resultId = resultId
+
+
+class ResultPeek:
+    """ Request to return the next result in the Stream without consuming it
+    (i.e. without advancing the position in the stream).
+    Backend should respond with a Record if there is a record, an Error if an
+    error occurred while retrieving next record or NullRecord if there were no
     error and no record.
     """
 

--- a/tests/stub/iteration/scripts/v4x0/disconnect_on_pull.script
+++ b/tests/stub/iteration/scripts/v4x0/disconnect_on_pull.script
@@ -1,0 +1,8 @@
+!: BOLT 4
+
+A: HELLO {"{}": "*"}
+*: RESET
+C: RUN "RETURN 1 AS n" {} {}
+S: SUCCESS {"fields": ["1"]}
+C: PULL {"n": {"Z": "*"}}
+S: <EXIT>

--- a/tests/stub/iteration/scripts/v4x0/error_on_pull.script
+++ b/tests/stub/iteration/scripts/v4x0/error_on_pull.script
@@ -1,0 +1,10 @@
+!: BOLT 4
+
+A: HELLO {"{}": "*"}
+*: RESET
+C: RUN "RETURN 1 AS n" {} {}
+S: SUCCESS {"fields": ["1"]}
+C: PULL {"n": {"Z": "*"}}
+S: FAILURE {"code": "#ERROR#", "message": "<whatever>"}
++: RESET
+?: GOODBYE

--- a/tests/stub/iteration/scripts/v4x0/tx_error_on_pull.script
+++ b/tests/stub/iteration/scripts/v4x0/tx_error_on_pull.script
@@ -1,0 +1,27 @@
+!: BOLT 4
+
+A: HELLO {"{}": "*"}
+*: RESET
+
+C: BEGIN {"{}": "*"}
+S: SUCCESS {}
+C: RUN "RETURN 1 AS n" {} {}
+S: SUCCESS {"fields": ["1"]}
+C: PULL {"n": {"Z": "*"}}
+S: FAILURE {"code": "#ERROR#", "message": "<whatever>"}
++: RESET
+
+{?
+    C: BEGIN {"{}": "*"}
+    S: SUCCESS {}
+    C: RUN "RETURN 1 AS n" {} {}
+    S: SUCCESS {"fields": ["1"]}
+    C: PULL {"n": {"Z": "*"}}
+    S: RECORD [1]
+       SUCCESS {"type": "r"}
+    C: COMMIT
+    S: SUCCESS {}
+
+    *: RESET
+?}
+?: GOODBYE

--- a/tests/stub/iteration/scripts/v4x0/yield_0_records.script
+++ b/tests/stub/iteration/scripts/v4x0/yield_0_records.script
@@ -1,0 +1,10 @@
+!: BOLT 4
+
+A: HELLO {"{}": "*"}
+*: RESET
+C: RUN "RETURN 1 AS n" {} {}
+S: SUCCESS {"fields": ["1"]}
+C: PULL {"n": {"Z": "*"}}
+S: SUCCESS {"type": "r"}
+*: RESET
+?: GOODBYE

--- a/tests/stub/iteration/scripts/v4x0/yield_1_record.script
+++ b/tests/stub/iteration/scripts/v4x0/yield_1_record.script
@@ -1,0 +1,11 @@
+!: BOLT 4
+
+A: HELLO {"{}": "*"}
+*: RESET
+C: RUN "RETURN 1 AS n" {} {}
+S: SUCCESS {"fields": ["1"]}
+C: PULL {"n": {"Z": "*"}}
+S: RECORD [1]
+   SUCCESS {"type": "r"}
+*: RESET
+?: GOODBYE

--- a/tests/stub/iteration/scripts/v4x0/yield_2_records.script
+++ b/tests/stub/iteration/scripts/v4x0/yield_2_records.script
@@ -1,0 +1,23 @@
+!: BOLT 4
+
+A: HELLO {"{}": "*"}
+*: RESET
+C: RUN "RETURN 1 AS n" {} {}
+S: SUCCESS {"fields": ["1"]}
+{{
+    C: PULL {"n": {"Z": "1"}}
+    S: RECORD [1]
+       SUCCESS {"has_more": true}
+   {?
+        C: PULL {"n": {"Z": "*"}}
+        S: RECORD [2]
+           SUCCESS {"type": "r"}
+   ?}
+----
+    C: PULL {"n": {"Z": "*"}}
+    S: RECORD [1]
+       RECORD [2]
+       SUCCESS {"type": "r"}
+}}
+*: RESET
+?: GOODBYE

--- a/tests/stub/iteration/test_result_peek.py
+++ b/tests/stub/iteration/test_result_peek.py
@@ -1,0 +1,137 @@
+from contextlib import contextmanager
+
+from nutkit.frontend import Driver
+import nutkit.protocol as types
+from tests.shared import (
+    driver_feature,
+    TestkitTestCase,
+    get_driver_name,
+)
+from tests.stub.shared import StubServer
+
+
+class TestResultPeek(TestkitTestCase):
+    def setUp(self):
+        super().setUp()
+        self._server = StubServer(9001)
+
+    def tearDown(self):
+        self._server.reset()
+        super().tearDown()
+
+    def _assert_not_exactly_one_record_error(self, error):
+        self.assertIsInstance(error, types.DriverError)
+        driver = get_driver_name()
+        if driver in ["python"]:
+            self.assertEqual("<class 'ToBeDecided'>",
+                             error.errorType)
+        else:
+            self.fail("no error mapping is defined for %s driver" % driver)
+
+    def _assert_connection_error(self, error):
+        self.assertIsInstance(error, types.DriverError)
+        driver = get_driver_name()
+        if driver in ["python"]:
+            self.assertEqual("<class 'neo4j.exceptions.ServiceUnavailable'>",
+                             error.errorType)
+        else:
+            self.fail("no error mapping is defined for %s driver" % driver)
+
+    @contextmanager
+    def _session(self, script_fn, fetch_size=2, vars_=None):
+        uri = "bolt://%s" % self._server.address
+        driver = Driver(self._backend, uri,
+                        types.AuthorizationToken(scheme="basic", principal="",
+                                                 credentials=""))
+        self._server.start(path=self.script_path("v4x0", script_fn),
+                           vars=vars_)
+        session = driver.session("w", fetchSize=fetch_size)
+        try:
+            yield session
+            session.close()
+        finally:
+            self._server.reset()
+
+    @driver_feature(types.Feature.API_RESULT_PEEK)
+    def test_result_single_with_0_records(self):
+        with self._session("yield_0_records.script") as session:
+            result = session.run("RETURN 1 AS n")
+            with self.assertRaises(types.DriverError) as exc:
+                result.single()
+            self._assert_not_exactly_one_record_error(exc.exception)
+
+    @driver_feature(types.Feature.API_RESULT_PEEK)
+    def test_result_single_with_1_records(self):
+        with self._session("yield_1_record.script") as session:
+            result = session.run("RETURN 1 AS n")
+            record = result.single()
+            self.assertIsInstance(record, types.Record)
+            self.assertEqual(record.values, [types.CypherInt(1)])
+
+    @driver_feature(types.Feature.API_RESULT_PEEK)
+    def test_result_single_with_2_records(self):
+        def _test():
+            with self._session("yield_2_records.script",
+                               fetch_size=fetch_size) as session:
+                result = session.run("RETURN 1 AS n")
+                with self.assertRaises(types.DriverError) as exc:
+                    result.single()
+                self._assert_not_exactly_one_record_error(exc.exception)
+
+        for fetch_size in (1, 2):
+            with self.subTest("fetch_size-%i" % fetch_size):
+                _test()
+
+    @driver_feature(types.Feature.API_RESULT_PEEK)
+    def test_result_single_with_disconnect(self):
+        with self._session("disconnect_on_pull.script") as session:
+            result = session.run("RETURN 1 AS n")
+            with self.assertRaises(types.DriverError) as exc:
+                result.single()
+            self._assert_connection_error(exc.exception)
+
+    @driver_feature(types.Feature.API_RESULT_PEEK)
+    def test_result_single_with_failure(self):
+        err = "Neo.TransientError.Completely.MadeUp"
+
+        with self._session("error_on_pull.script",
+                           vars_={"#ERROR#": err}) as session:
+            result = session.run("RETURN 1 AS n")
+            with self.assertRaises(types.DriverError) as exc:
+                result.single()
+            self.assertEqual(err, exc.exception.code)
+
+    @driver_feature(types.Feature.API_RESULT_PEEK)
+    def test_result_single_with_failure_tx_run(self):
+        err = "Neo.TransientError.Completely.MadeUp"
+
+        with self._session("tx_error_on_pull.script",
+                           vars_={"#ERROR#": err}) as session:
+            tx = session.beginTransaction()
+            result = tx.run("RETURN 1 AS n")
+            with self.assertRaises(types.DriverError) as exc:
+                result.single()
+            self.assertEqual(err, exc.exception.code)
+
+    @driver_feature(types.Feature.API_RESULT_PEEK)
+    def test_result_single_with_failure_tx_func_run(self):
+        err = "Neo.TransientError.Completely.MadeUp"
+        work_call_count = 0
+
+        def work(tx):
+            nonlocal work_call_count
+            work_call_count += 1
+            result = tx.run("RETURN 1 AS n")
+            if work_call_count == 1:
+                with self.assertRaises(types.DriverError) as exc:
+                    result.single()
+                self.assertEqual(err, exc.exception.code)
+                raise exc.exception
+            else:
+                return result.single()
+
+        with self._session("tx_error_on_pull.script",
+                           vars_={"#ERROR#": err}) as session:
+            record = session.readTransaction(work)
+            self.assertIsInstance(record, types.Record)
+            self.assertEqual(record.values, [types.CypherInt(1)])

--- a/tests/stub/iteration/test_result_peek.py
+++ b/tests/stub/iteration/test_result_peek.py
@@ -19,15 +19,6 @@ class TestResultPeek(TestkitTestCase):
         self._server.reset()
         super().tearDown()
 
-    def _assert_not_exactly_one_record_error(self, error):
-        self.assertIsInstance(error, types.DriverError)
-        driver = get_driver_name()
-        if driver in ["python"]:
-            self.assertEqual("<class 'ToBeDecided'>",
-                             error.errorType)
-        else:
-            self.fail("no error mapping is defined for %s driver" % driver)
-
     def _assert_connection_error(self, error):
         self.assertIsInstance(error, types.DriverError)
         driver = get_driver_name()
@@ -53,56 +44,66 @@ class TestResultPeek(TestkitTestCase):
             self._server.reset()
 
     @driver_feature(types.Feature.API_RESULT_PEEK)
-    def test_result_single_with_0_records(self):
+    def test_result_peek_with_0_records(self):
         with self._session("yield_0_records.script") as session:
             result = session.run("RETURN 1 AS n")
-            with self.assertRaises(types.DriverError) as exc:
-                result.single()
-            self._assert_not_exactly_one_record_error(exc.exception)
+            record = result.peek()
+            self.assertIsInstance(record, types.NullRecord)
 
     @driver_feature(types.Feature.API_RESULT_PEEK)
-    def test_result_single_with_1_records(self):
+    def test_result_peek_with_1_records(self):
         with self._session("yield_1_record.script") as session:
             result = session.run("RETURN 1 AS n")
-            record = result.single()
+            record = result.peek()
             self.assertIsInstance(record, types.Record)
             self.assertEqual(record.values, [types.CypherInt(1)])
+            record = result.next()
+            self.assertIsInstance(record, types.Record)
+            self.assertEqual(record.values, [types.CypherInt(1)])
+            record = result.peek()
+            self.assertIsInstance(record, types.NullRecord)
 
     @driver_feature(types.Feature.API_RESULT_PEEK)
-    def test_result_single_with_2_records(self):
+    def test_result_peek_with_2_records(self):
         def _test():
             with self._session("yield_2_records.script",
                                fetch_size=fetch_size) as session:
                 result = session.run("RETURN 1 AS n")
-                with self.assertRaises(types.DriverError) as exc:
-                    result.single()
-                self._assert_not_exactly_one_record_error(exc.exception)
+                for i in (1, 2):
+                    record = result.peek()
+                    self.assertIsInstance(record, types.Record)
+                    self.assertEqual(record.values, [types.CypherInt(i)])
+                    record = result.next()
+                    self.assertIsInstance(record, types.Record)
+                    self.assertEqual(record.values, [types.CypherInt(i)])
+                record = result.peek()
+                self.assertIsInstance(record, types.NullRecord)
 
         for fetch_size in (1, 2):
             with self.subTest("fetch_size-%i" % fetch_size):
                 _test()
 
     @driver_feature(types.Feature.API_RESULT_PEEK)
-    def test_result_single_with_disconnect(self):
+    def test_result_peek_with_disconnect(self):
         with self._session("disconnect_on_pull.script") as session:
             result = session.run("RETURN 1 AS n")
             with self.assertRaises(types.DriverError) as exc:
-                result.single()
+                result.peek()
             self._assert_connection_error(exc.exception)
 
     @driver_feature(types.Feature.API_RESULT_PEEK)
-    def test_result_single_with_failure(self):
+    def test_result_peek_with_failure(self):
         err = "Neo.TransientError.Completely.MadeUp"
 
         with self._session("error_on_pull.script",
                            vars_={"#ERROR#": err}) as session:
             result = session.run("RETURN 1 AS n")
             with self.assertRaises(types.DriverError) as exc:
-                result.single()
+                result.peek()
             self.assertEqual(err, exc.exception.code)
 
     @driver_feature(types.Feature.API_RESULT_PEEK)
-    def test_result_single_with_failure_tx_run(self):
+    def test_result_peek_with_failure_tx_run(self):
         err = "Neo.TransientError.Completely.MadeUp"
 
         with self._session("tx_error_on_pull.script",
@@ -110,11 +111,11 @@ class TestResultPeek(TestkitTestCase):
             tx = session.beginTransaction()
             result = tx.run("RETURN 1 AS n")
             with self.assertRaises(types.DriverError) as exc:
-                result.single()
+                result.peek()
             self.assertEqual(err, exc.exception.code)
 
     @driver_feature(types.Feature.API_RESULT_PEEK)
-    def test_result_single_with_failure_tx_func_run(self):
+    def test_result_peek_with_failure_tx_func_run(self):
         err = "Neo.TransientError.Completely.MadeUp"
         work_call_count = 0
 
@@ -124,11 +125,11 @@ class TestResultPeek(TestkitTestCase):
             result = tx.run("RETURN 1 AS n")
             if work_call_count == 1:
                 with self.assertRaises(types.DriverError) as exc:
-                    result.single()
+                    result.peek()
                 self.assertEqual(err, exc.exception.code)
                 raise exc.exception
             else:
-                return result.single()
+                return result.peek()
 
         with self._session("tx_error_on_pull.script",
                            vars_={"#ERROR#": err}) as session:

--- a/tests/stub/iteration/test_result_single.py
+++ b/tests/stub/iteration/test_result_single.py
@@ -19,6 +19,15 @@ class TestResultSingle(TestkitTestCase):
         self._server.reset()
         super().tearDown()
 
+    def _assert_not_exactly_one_record_error(self, error):
+        self.assertIsInstance(error, types.DriverError)
+        driver = get_driver_name()
+        if driver in ["python"]:
+            self.assertEqual("<class 'ToBeDecided'>",
+                             error.errorType)
+        else:
+            self.fail("no error mapping is defined for %s driver" % driver)
+
     def _assert_connection_error(self, error):
         self.assertIsInstance(error, types.DriverError)
         driver = get_driver_name()
@@ -44,66 +53,56 @@ class TestResultSingle(TestkitTestCase):
             self._server.reset()
 
     @driver_feature(types.Feature.API_RESULT_SINGLE)
-    def test_result_peek_with_0_records(self):
+    def test_result_single_with_0_records(self):
         with self._session("yield_0_records.script") as session:
             result = session.run("RETURN 1 AS n")
-            record = result.peek()
-            self.assertIsInstance(record, types.NullRecord)
+            with self.assertRaises(types.DriverError) as exc:
+                result.single()
+            self._assert_not_exactly_one_record_error(exc.exception)
 
     @driver_feature(types.Feature.API_RESULT_SINGLE)
-    def test_result_peek_with_1_records(self):
+    def test_result_single_with_1_records(self):
         with self._session("yield_1_record.script") as session:
             result = session.run("RETURN 1 AS n")
-            record = result.peek()
+            record = result.single()
             self.assertIsInstance(record, types.Record)
             self.assertEqual(record.values, [types.CypherInt(1)])
-            record = result.next()
-            self.assertIsInstance(record, types.Record)
-            self.assertEqual(record.values, [types.CypherInt(1)])
-            record = result.peek()
-            self.assertIsInstance(record, types.NullRecord)
 
     @driver_feature(types.Feature.API_RESULT_SINGLE)
-    def test_result_peek_with_2_records(self):
+    def test_result_single_with_2_records(self):
         def _test():
             with self._session("yield_2_records.script",
                                fetch_size=fetch_size) as session:
                 result = session.run("RETURN 1 AS n")
-                for i in (1, 2):
-                    record = result.peek()
-                    self.assertIsInstance(record, types.Record)
-                    self.assertEqual(record.values, [types.CypherInt(i)])
-                    record = result.next()
-                    self.assertIsInstance(record, types.Record)
-                    self.assertEqual(record.values, [types.CypherInt(i)])
-                record = result.peek()
-                self.assertIsInstance(record, types.NullRecord)
+                with self.assertRaises(types.DriverError) as exc:
+                    result.single()
+                self._assert_not_exactly_one_record_error(exc.exception)
 
         for fetch_size in (1, 2):
             with self.subTest("fetch_size-%i" % fetch_size):
                 _test()
 
     @driver_feature(types.Feature.API_RESULT_SINGLE)
-    def test_result_peek_with_disconnect(self):
+    def test_result_single_with_disconnect(self):
         with self._session("disconnect_on_pull.script") as session:
             result = session.run("RETURN 1 AS n")
             with self.assertRaises(types.DriverError) as exc:
-                result.peek()
+                result.single()
             self._assert_connection_error(exc.exception)
 
     @driver_feature(types.Feature.API_RESULT_SINGLE)
-    def test_result_peek_with_failure(self):
+    def test_result_single_with_failure(self):
         err = "Neo.TransientError.Completely.MadeUp"
 
         with self._session("error_on_pull.script",
                            vars_={"#ERROR#": err}) as session:
             result = session.run("RETURN 1 AS n")
             with self.assertRaises(types.DriverError) as exc:
-                result.peek()
+                result.single()
             self.assertEqual(err, exc.exception.code)
 
     @driver_feature(types.Feature.API_RESULT_SINGLE)
-    def test_result_peek_with_failure_tx_run(self):
+    def test_result_single_with_failure_tx_run(self):
         err = "Neo.TransientError.Completely.MadeUp"
 
         with self._session("tx_error_on_pull.script",
@@ -111,11 +110,11 @@ class TestResultSingle(TestkitTestCase):
             tx = session.beginTransaction()
             result = tx.run("RETURN 1 AS n")
             with self.assertRaises(types.DriverError) as exc:
-                result.peek()
+                result.single()
             self.assertEqual(err, exc.exception.code)
 
     @driver_feature(types.Feature.API_RESULT_SINGLE)
-    def test_result_peek_with_failure_tx_func_run(self):
+    def test_result_single_with_failure_tx_func_run(self):
         err = "Neo.TransientError.Completely.MadeUp"
         work_call_count = 0
 
@@ -125,11 +124,11 @@ class TestResultSingle(TestkitTestCase):
             result = tx.run("RETURN 1 AS n")
             if work_call_count == 1:
                 with self.assertRaises(types.DriverError) as exc:
-                    result.peek()
+                    result.single()
                 self.assertEqual(err, exc.exception.code)
                 raise exc.exception
             else:
-                return result.peek()
+                return result.single()
 
         with self._session("tx_error_on_pull.script",
                            vars_={"#ERROR#": err}) as session:

--- a/tests/stub/iteration/test_result_single.py
+++ b/tests/stub/iteration/test_result_single.py
@@ -1,0 +1,138 @@
+from contextlib import contextmanager
+
+from nutkit.frontend import Driver
+import nutkit.protocol as types
+from tests.shared import (
+    driver_feature,
+    TestkitTestCase,
+    get_driver_name,
+)
+from tests.stub.shared import StubServer
+
+
+class TestResultSingle(TestkitTestCase):
+    def setUp(self):
+        super().setUp()
+        self._server = StubServer(9001)
+
+    def tearDown(self):
+        self._server.reset()
+        super().tearDown()
+
+    def _assert_connection_error(self, error):
+        self.assertIsInstance(error, types.DriverError)
+        driver = get_driver_name()
+        if driver in ["python"]:
+            self.assertEqual("<class 'neo4j.exceptions.ServiceUnavailable'>",
+                             error.errorType)
+        else:
+            self.fail("no error mapping is defined for %s driver" % driver)
+
+    @contextmanager
+    def _session(self, script_fn, fetch_size=2, vars_=None):
+        uri = "bolt://%s" % self._server.address
+        driver = Driver(self._backend, uri,
+                        types.AuthorizationToken(scheme="basic", principal="",
+                                                 credentials=""))
+        self._server.start(path=self.script_path("v4x0", script_fn),
+                           vars=vars_)
+        session = driver.session("w", fetchSize=fetch_size)
+        try:
+            yield session
+            session.close()
+        finally:
+            self._server.reset()
+
+    @driver_feature(types.Feature.API_RESULT_SINGLE)
+    def test_result_peek_with_0_records(self):
+        with self._session("yield_0_records.script") as session:
+            result = session.run("RETURN 1 AS n")
+            record = result.peek()
+            self.assertIsInstance(record, types.NullRecord)
+
+    @driver_feature(types.Feature.API_RESULT_SINGLE)
+    def test_result_peek_with_1_records(self):
+        with self._session("yield_1_record.script") as session:
+            result = session.run("RETURN 1 AS n")
+            record = result.peek()
+            self.assertIsInstance(record, types.Record)
+            self.assertEqual(record.values, [types.CypherInt(1)])
+            record = result.next()
+            self.assertIsInstance(record, types.Record)
+            self.assertEqual(record.values, [types.CypherInt(1)])
+            record = result.peek()
+            self.assertIsInstance(record, types.NullRecord)
+
+    @driver_feature(types.Feature.API_RESULT_SINGLE)
+    def test_result_peek_with_2_records(self):
+        def _test():
+            with self._session("yield_2_records.script",
+                               fetch_size=fetch_size) as session:
+                result = session.run("RETURN 1 AS n")
+                for i in (1, 2):
+                    record = result.peek()
+                    self.assertIsInstance(record, types.Record)
+                    self.assertEqual(record.values, [types.CypherInt(i)])
+                    record = result.next()
+                    self.assertIsInstance(record, types.Record)
+                    self.assertEqual(record.values, [types.CypherInt(i)])
+                record = result.peek()
+                self.assertIsInstance(record, types.NullRecord)
+
+        for fetch_size in (1, 2):
+            with self.subTest("fetch_size-%i" % fetch_size):
+                _test()
+
+    @driver_feature(types.Feature.API_RESULT_SINGLE)
+    def test_result_peek_with_disconnect(self):
+        with self._session("disconnect_on_pull.script") as session:
+            result = session.run("RETURN 1 AS n")
+            with self.assertRaises(types.DriverError) as exc:
+                result.peek()
+            self._assert_connection_error(exc.exception)
+
+    @driver_feature(types.Feature.API_RESULT_SINGLE)
+    def test_result_peek_with_failure(self):
+        err = "Neo.TransientError.Completely.MadeUp"
+
+        with self._session("error_on_pull.script",
+                           vars_={"#ERROR#": err}) as session:
+            result = session.run("RETURN 1 AS n")
+            with self.assertRaises(types.DriverError) as exc:
+                result.peek()
+            self.assertEqual(err, exc.exception.code)
+
+    @driver_feature(types.Feature.API_RESULT_SINGLE)
+    def test_result_peek_with_failure_tx_run(self):
+        err = "Neo.TransientError.Completely.MadeUp"
+
+        with self._session("tx_error_on_pull.script",
+                           vars_={"#ERROR#": err}) as session:
+            tx = session.beginTransaction()
+            result = tx.run("RETURN 1 AS n")
+            with self.assertRaises(types.DriverError) as exc:
+                result.peek()
+            self.assertEqual(err, exc.exception.code)
+
+    @driver_feature(types.Feature.API_RESULT_SINGLE)
+    def test_result_peek_with_failure_tx_func_run(self):
+        err = "Neo.TransientError.Completely.MadeUp"
+        work_call_count = 0
+
+        def work(tx):
+            nonlocal work_call_count
+            work_call_count += 1
+            result = tx.run("RETURN 1 AS n")
+            if work_call_count == 1:
+                with self.assertRaises(types.DriverError) as exc:
+                    result.peek()
+                self.assertEqual(err, exc.exception.code)
+                raise exc.exception
+            else:
+                return result.peek()
+
+        with self._session("tx_error_on_pull.script",
+                           vars_={"#ERROR#": err}) as session:
+            record = session.readTransaction(work)
+            self.assertIsInstance(record, types.Record)
+            self.assertEqual(record.values, [types.CypherInt(1)])


### PR DESCRIPTION
Tests are guarded by feature flags `API_RESULT_PEEK = "Feature:API:Result.Peek"`
and `API_RESULT_SINGLE = "Feature:API:Result.Single"` respectively.