### PR TITLE
Fix token expiration exception verification for JS

### DIFF
--- a/tests/stub/authorization/test_authorization.py
+++ b/tests/stub/authorization/test_authorization.py
@@ -56,6 +56,9 @@ class AuthorizationBase(TestkitTestCase):
             self.assertEqual('Neo.ClientError.Security.TokenExpired',
                              error.code)
             self.assertIn("Token expired", error.msg)
+        elif driver == 'javascript':
+            # only test for code
+            pass
         else:
             self.fail("no error mapping is defined for %s driver" % driver)
 

--- a/tests/stub/authorization/test_authorization.py
+++ b/tests/stub/authorization/test_authorization.py
@@ -43,7 +43,7 @@ class AuthorizationBase(TestkitTestCase):
             self.assertEqual(
                 "<class 'neo4j.exceptions.TokenExpired'>", error.errorType
             )
-        elif driver == 'go':
+        elif driver in ['go', 'javascript']:
             self.assertEqual('Neo.ClientError.Security.TokenExpired',
                              error.code)
             self.assertIn(
@@ -56,9 +56,6 @@ class AuthorizationBase(TestkitTestCase):
             self.assertEqual('Neo.ClientError.Security.TokenExpired',
                              error.code)
             self.assertIn("Token expired", error.msg)
-        elif driver == 'javascript':
-            # only test for code
-            pass
         else:
             self.fail("no error mapping is defined for %s driver" % driver)
 


### PR DESCRIPTION
Javascript only checks for the error code and the message.