### PR TITLE
Add tests for query types in summary

### DIFF
--- a/tests/stub/summary/scripts/empty_summary_no_type.script
+++ b/tests/stub/summary/scripts/empty_summary_no_type.script
@@ -1,0 +1,11 @@
+!: BOLT 4.4
+
+A: HELLO {"{}": "*"}
+*: RESET
+C: RUN "*" "*" "*"
+S: SUCCESS {"t_first": 2001, "fields": ["n"]}
+C: PULL {"n": "*"}
+S: RECORD [1]
+   SUCCESS {"db": "apple", "t_last": 2002, "stats": {}}
+*: RESET
+?: GOODBYE

--- a/tests/stub/summary/scripts/empty_summary_type_wr.script
+++ b/tests/stub/summary/scripts/empty_summary_type_wr.script
@@ -1,0 +1,11 @@
+!: BOLT 4.4
+
+A: HELLO {"{}": "*"}
+*: RESET
+C: RUN "*" "*" "*"
+S: SUCCESS {"t_first": 2001, "fields": ["n"]}
+C: PULL {"n": "*"}
+S: RECORD [1]
+   SUCCESS {"type": "wr", "db": "apple", "t_last": 2002, "stats": {}}
+*: RESET
+?: GOODBYE


### PR DESCRIPTION
Drivers should only accept know query types in the result summary
(`"r"`, `"w"`, `"rw"`, `"s"`) or if the key is missing altogether.