### PR TITLE
Adding tests to check for the home database resolution

### DIFF
--- a/boltstub/parsing.py
+++ b/boltstub/parsing.py
@@ -804,7 +804,7 @@ class _RepeatBlock(Block, abc.ABC):
         return list(res.keys())
 
     def accepted_messages_after_reset(self) -> List[ClientLine]:
-        return self.block_list.accepted_messages_after_resets()
+        return self.block_list.accepted_messages_after_reset()
 
     def assert_no_init(self):
         self.block_list.assert_no_init()

--- a/tests/stub/homedb/scripts/reader_change_homedb.script
+++ b/tests/stub/homedb/scripts/reader_change_homedb.script
@@ -1,0 +1,22 @@
+!: BOLT 4.4
+!: ALLOW RESTART
+
+A: HELLO {"{}": "*"}
+*: RESET
+{*
+    {{
+        C: RUN "RETURN 1" {} {"[bookmarks]": "*", "[tx_metadata]": "*", "mode": "r", "imp_user": "the-imposter", "db": "homedb1"}
+        S: SUCCESS {"fields": ["1"]}
+        C: PULL {"n": 1000}
+        S: RECORD [1]
+           SUCCESS {"type": "r"}
+    ----
+        C: RUN "RETURN 2" {} {"[bookmarks]": "*", "[tx_metadata]": "*", "mode": "r", "imp_user": "the-imposter", "db": "homedb2"}
+        S: SUCCESS {"fields": ["2"]}
+        C: PULL {"n": 1000}
+        S: RECORD [2]
+           SUCCESS {"type": "r"}
+    }}
+    *: RESET
+*}
+?: GOODBYE

--- a/tests/stub/homedb/scripts/reader_change_homedb.script
+++ b/tests/stub/homedb/scripts/reader_change_homedb.script
@@ -7,16 +7,23 @@ A: HELLO {"{}": "*"}
     {{
         C: RUN "RETURN 1" {} {"[bookmarks]": "*", "[tx_metadata]": "*", "mode": "r", "imp_user": "the-imposter", "db": "homedb1"}
         S: SUCCESS {"fields": ["1"]}
-        C: PULL {"n": 1000}
-        S: RECORD [1]
-           SUCCESS {"type": "r"}
+        {{
+            C: PULL {"n": {"Z": "*"}, "[qid]": -1}
+            S: RECORD [1]
+        ----
+            C: DISCARD {"n": {"Z": "*"}, "[qid]": -1}
+        }}
     ----
         C: RUN "RETURN 2" {} {"[bookmarks]": "*", "[tx_metadata]": "*", "mode": "r", "imp_user": "the-imposter", "db": "homedb2"}
         S: SUCCESS {"fields": ["2"]}
-        C: PULL {"n": 1000}
-        S: RECORD [2]
-           SUCCESS {"type": "r"}
+        {{
+            C: PULL {"n": {"Z": "*"}, "[qid]": -1}
+            S: RECORD [2]
+        ----
+            C: DISCARD {"n": {"Z": "*"}, "[qid]": -1}
+        }}
     }}
+    S: SUCCESS {"type": "r"}
     *: RESET
 *}
 ?: GOODBYE

--- a/tests/stub/homedb/scripts/reader_change_homedb.script
+++ b/tests/stub/homedb/scripts/reader_change_homedb.script
@@ -1,5 +1,5 @@
 !: BOLT 4.4
-!: ALLOW RESTART
+!: ALLOW CONCURRENT
 
 A: HELLO {"{}": "*"}
 *: RESET

--- a/tests/stub/homedb/scripts/reader_change_homedb.script
+++ b/tests/stub/homedb/scripts/reader_change_homedb.script
@@ -3,7 +3,7 @@
 
 A: HELLO {"{}": "*"}
 *: RESET
-{*
+{+
     {{
         C: RUN "RETURN 1" {} {"[bookmarks]": "*", "[tx_metadata]": "*", "mode": "r", "imp_user": "the-imposter", "db": "homedb1"}
         S: SUCCESS {"fields": ["1"]}
@@ -25,5 +25,5 @@ A: HELLO {"{}": "*"}
     }}
     S: SUCCESS {"type": "r"}
     *: RESET
-*}
++}
 ?: GOODBYE

--- a/tests/stub/homedb/scripts/reader_tx_change_homedb.script
+++ b/tests/stub/homedb/scripts/reader_tx_change_homedb.script
@@ -1,0 +1,35 @@
+!: BOLT 4.4
+!: ALLOW RESTART
+
+A: HELLO {"{}": "*"}
+*: RESET
+{*
+    {{
+        C: BEGIN {"[bookmarks]": "*", "[tx_metadata]": "*", "mode": "r", "imp_user": "the-imposter", "db": "homedb1"}
+        S: SUCCESS {}
+        C: RUN "RETURN 1" {} {}
+        S: SUCCESS {"fields": ["1"]}
+        {{
+            C: PULL {"n": {"Z": "*"}, "[qid]": -1}
+            S: RECORD [1]
+        ----
+            C: DISCARD {"n": {"Z": "*"}, "[qid]": -1}
+        }}
+    ----
+        C: BEGIN  {"[bookmarks]": "*", "[tx_metadata]": "*", "mode": "r", "imp_user": "the-imposter", "db": "homedb2"}
+        S: SUCCESS {}
+        C: RUN "RETURN 2" {} {}
+        S: SUCCESS {"fields": ["2"]}
+        {{
+            C: PULL {"n": {"Z": "*"}, "[qid]": -1}
+            S: RECORD [2]
+        ----
+            C: DISCARD {"n": {"Z": "*"}, "[qid]": -1}
+        }}
+    }}
+    S: SUCCESS {"type": "r"}
+    C: COMMIT
+    S: SUCCESS {}
+    *: RESET
+*}
+?: GOODBYE

--- a/tests/stub/homedb/scripts/reader_tx_change_homedb.script
+++ b/tests/stub/homedb/scripts/reader_tx_change_homedb.script
@@ -3,7 +3,7 @@
 
 A: HELLO {"{}": "*"}
 *: RESET
-{*
+{+
     {{
         C: BEGIN {"[bookmarks]": "*", "[tx_metadata]": "*", "mode": "r", "imp_user": "the-imposter", "db": "homedb1"}
         S: SUCCESS {}
@@ -31,5 +31,5 @@ A: HELLO {"{}": "*"}
     C: COMMIT
     S: SUCCESS {}
     *: RESET
-*}
++}
 ?: GOODBYE

--- a/tests/stub/homedb/scripts/reader_tx_change_homedb.script
+++ b/tests/stub/homedb/scripts/reader_tx_change_homedb.script
@@ -1,5 +1,5 @@
 !: BOLT 4.4
-!: ALLOW RESTART
+!: ALLOW CONCURRENT
 
 A: HELLO {"{}": "*"}
 *: RESET

--- a/tests/stub/homedb/scripts/reader_tx_exits.script
+++ b/tests/stub/homedb/scripts/reader_tx_exits.script
@@ -1,0 +1,9 @@
+!: BOLT 4.4
+!: ALLOW RESTART
+
+A: HELLO {"{}": "*"}
+*: RESET
+C: BEGIN {"[bookmarks]": "*", "[tx_metadata]": "*", "mode": "r", "[imp_user]": "the-imposter", "db": "homedb"}
+S: SUCCESS {}
+C: RUN "RETURN 1" {} {}
+S: <EXIT>

--- a/tests/stub/homedb/scripts/reader_tx_exits.script
+++ b/tests/stub/homedb/scripts/reader_tx_exits.script
@@ -1,5 +1,5 @@
 !: BOLT 4.4
-!: ALLOW RESTART
+!: ALLOW CONCURRENT
 
 A: HELLO {"{}": "*"}
 *: RESET

--- a/tests/stub/homedb/scripts/reader_tx_homedb.script
+++ b/tests/stub/homedb/scripts/reader_tx_homedb.script
@@ -7,9 +7,14 @@ C: BEGIN {"[bookmarks]": "*", "[tx_metadata]": "*", "mode": "r", "[imp_user]": "
 S: SUCCESS {}
 C: RUN "RETURN 1" {} {}
 S: SUCCESS {"fields": ["1"]}
-C: PULL {"n": 1000}
-S: RECORD [1]
-   SUCCESS {"type": "r"}
+{{
+    C: PULL {"n": {"Z": "*"}, "[qid]": -1}
+    S: RECORD [1]
+       SUCCESS {"type": "r"}
+----
+    C: DISCARD {"n": {"Z": "*"}, "[qid]": -1}
+    S: SUCCESS {"type": "r"}
+}}
 C: COMMIT
 S: SUCCESS {}
 *: RESET

--- a/tests/stub/homedb/scripts/reader_tx_homedb.script
+++ b/tests/stub/homedb/scripts/reader_tx_homedb.script
@@ -1,0 +1,16 @@
+!: BOLT 4.4
+!: ALLOW RESTART
+
+A: HELLO {"{}": "*"}
+*: RESET
+C: BEGIN {"[bookmarks]": "*", "[tx_metadata]": "*", "mode": "r", "[imp_user]": "the-imposter", "db": "homedb"}
+S: SUCCESS {}
+C: RUN "RETURN 1" {} {}
+S: SUCCESS {"fields": ["1"]}
+C: PULL {"n": 1000}
+S: RECORD [1]
+   SUCCESS {"type": "r"}
+C: COMMIT
+S: SUCCESS {}
+*: RESET
+?: GOODBYE

--- a/tests/stub/homedb/scripts/reader_tx_homedb.script
+++ b/tests/stub/homedb/scripts/reader_tx_homedb.script
@@ -1,5 +1,5 @@
 !: BOLT 4.4
-!: ALLOW RESTART
+!: ALLOW CONCURRENT
 
 A: HELLO {"{}": "*"}
 *: RESET

--- a/tests/stub/homedb/scripts/router_change_homedb.script
+++ b/tests/stub/homedb/scripts/router_change_homedb.script
@@ -1,0 +1,16 @@
+!: BOLT 4.4
+!: ALLOW RESTART
+
+A: HELLO {"{}": "*"}
+*: RESET
+{*
+    {{
+        C: ROUTE "*" [] {"[imp_user]": "the-imposter"}
+        S: SUCCESS { "rt": { "ttl": 1000000, "db": "homedb1", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010"], "role":"READ"}, {"addresses": ["#HOST#:9010"], "role":"WRITE"}]}}
+    ----
+        C: ROUTE "*" ["bookmark"] {"[imp_user]": "the-imposter"}
+        S: SUCCESS { "rt": { "ttl": 1000000, "db": "homedb2", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010"], "role":"READ"}, {"addresses": ["#HOST#:9010"], "role":"WRITE"}]}}
+    }}
+    *: RESET
+*}
+?: GOODBYE

--- a/tests/stub/homedb/scripts/router_change_homedb.script
+++ b/tests/stub/homedb/scripts/router_change_homedb.script
@@ -3,7 +3,7 @@
 
 A: HELLO {"{}": "*"}
 *: RESET
-{*
+{+
     {{
         C: ROUTE "*" [] {"[imp_user]": "the-imposter"}
         S: SUCCESS { "rt": { "ttl": 1000000, "db": "homedb1", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010"], "role":"READ"}, {"addresses": ["#HOST#:9010"], "role":"WRITE"}]}}
@@ -12,5 +12,5 @@ A: HELLO {"{}": "*"}
         S: SUCCESS { "rt": { "ttl": 1000000, "db": "homedb2", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010"], "role":"READ"}, {"addresses": ["#HOST#:9010"], "role":"WRITE"}]}}
     }}
     *: RESET
-*}
++}
 ?: GOODBYE

--- a/tests/stub/homedb/scripts/router_change_homedb.script
+++ b/tests/stub/homedb/scripts/router_change_homedb.script
@@ -1,5 +1,5 @@
 !: BOLT 4.4
-!: ALLOW RESTART
+!: ALLOW CONCURRENT
 
 A: HELLO {"{}": "*"}
 *: RESET

--- a/tests/stub/homedb/scripts/router_explicit_homedb.script
+++ b/tests/stub/homedb/scripts/router_explicit_homedb.script
@@ -3,9 +3,9 @@
 
 A: HELLO {"{}": "*"}
 *: RESET
-{*
+{+
     C: ROUTE "*" [] {"[imp_user]": "the-imposter", "db": "homedb"}
     S: SUCCESS { "rt": { "ttl": 1000000, "db": "homedb", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9011"], "role":"WRITE"}]}}
     *: RESET
-*}
++}
 ?: GOODBYE

--- a/tests/stub/homedb/scripts/router_explicit_homedb.script
+++ b/tests/stub/homedb/scripts/router_explicit_homedb.script
@@ -1,0 +1,11 @@
+!: BOLT 4.4
+!: ALLOW RESTART
+
+A: HELLO {"{}": "*"}
+*: RESET
+{*
+    C: ROUTE "*" [] {"[imp_user]": "the-imposter", "db": "homedb"}
+    S: SUCCESS { "rt": { "ttl": 1000000, "db": "homedb", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9011"], "role":"WRITE"}]}}
+    *: RESET
+*}
+?: GOODBYE

--- a/tests/stub/homedb/scripts/router_explicit_homedb.script
+++ b/tests/stub/homedb/scripts/router_explicit_homedb.script
@@ -1,5 +1,5 @@
 !: BOLT 4.4
-!: ALLOW RESTART
+!: ALLOW CONCURRENT
 
 A: HELLO {"{}": "*"}
 *: RESET

--- a/tests/stub/homedb/scripts/router_homedb.script
+++ b/tests/stub/homedb/scripts/router_homedb.script
@@ -3,9 +3,9 @@
 
 A: HELLO {"{}": "*"}
 *: RESET
-{*
+{+
     C: ROUTE "*" [] {"[imp_user]": "the-imposter"}
     S: SUCCESS { "rt": { "ttl": 1000000, "db": "homedb", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010"], "role":"READ"}, {"addresses": ["#HOST#:9010"], "role":"WRITE"}]}}
     *: RESET
-*}
++}
 ?: GOODBYE

--- a/tests/stub/homedb/scripts/router_homedb.script
+++ b/tests/stub/homedb/scripts/router_homedb.script
@@ -1,0 +1,11 @@
+!: BOLT 4.4
+!: ALLOW RESTART
+
+A: HELLO {"{}": "*"}
+*: RESET
+{*
+    C: ROUTE "*" [] {"[imp_user]": "the-imposter"}
+    S: SUCCESS { "rt": { "ttl": 1000000, "db": "homedb", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010"], "role":"READ"}, {"addresses": ["#HOST#:9010"], "role":"WRITE"}]}}
+    *: RESET
+*}
+?: GOODBYE

--- a/tests/stub/homedb/scripts/router_homedb.script
+++ b/tests/stub/homedb/scripts/router_homedb.script
@@ -1,5 +1,5 @@
 !: BOLT 4.4
-!: ALLOW RESTART
+!: ALLOW CONCURRENT
 
 A: HELLO {"{}": "*"}
 *: RESET

--- a/tests/stub/homedb/test_homedb.py
+++ b/tests/stub/homedb/test_homedb.py
@@ -1,0 +1,46 @@
+from nutkit.frontend import Driver
+import nutkit.protocol as types
+from tests.shared import (
+    driver_feature,
+    get_driver_name,
+    TestkitTestCase,
+)
+from tests.stub.shared import StubServer
+
+
+class TestHomeDb(TestkitTestCase):
+    def setUp(self):
+        super().setUp()
+        self._router = StubServer(9000)
+        self._reader = StubServer(9010)
+        self._authtoken = types.AuthorizationToken(
+            "basic", principal="p", credentials="c")
+        self._uri = "neo4j://%s" % self._router.address
+
+    def tearDown(self):
+        self._reader.reset()
+        self._router.reset()
+        super().tearDown()
+
+    @driver_feature(types.Feature.IMPERSONATION, types.Feature.BOLT_4_4)
+    def test_should_resolve_db_per_session(self):
+        self._router.start(path=self.script_path(
+            "router_change_homedb.script"), vars={"#HOST#": self._router.host})
+
+        self._reader.start(path=self.script_path(
+            "reader_change_homedb.script"))
+
+        driver = Driver(self._backend, self._uri, self._authtoken)
+
+        session = driver.session("r", impersonatedUser="the-imposter")
+        result = session.run("RETURN 1")
+        result.consume()
+        session.close()
+
+        session2 = driver.session(
+            "r", bookmarks=["bookmark"], impersonatedUser="the-imposter")
+        result2 = session2.run("RETURN 2")
+        result2.consume()
+        session2.close()
+
+        driver.close()

--- a/tests/stub/homedb/test_homedb.py
+++ b/tests/stub/homedb/test_homedb.py
@@ -164,7 +164,6 @@ class TestHomeDb(TestkitTestCase):
                     return res.next()
                 self._router.done()
                 self._reader1.done()
-                self._reader1._dump()
                 self._router.start(path=self.script_path(
                     "router_explicit_homedb.script"),
                     vars={"#HOST#": self._router.host})

--- a/tests/stub/homedb/test_homedb.py
+++ b/tests/stub/homedb/test_homedb.py
@@ -40,7 +40,7 @@ class TestHomeDb(TestkitTestCase):
             session1 = driver.session("r", impersonatedUser="the-imposter")
             result = session1.run("RETURN 1")
             result.consume()
-            if not simultaneous_sessions:
+            if not parallel_sessions:
                 session1.close()
 
             session2 = driver.session(
@@ -48,7 +48,7 @@ class TestHomeDb(TestkitTestCase):
             result = session2.run("RETURN 2")
             result.consume()
             session2.close()
-            if simultaneous_sessions:
+            if parallel_sessions:
                 session1.close()
 
             driver.close()
@@ -56,9 +56,9 @@ class TestHomeDb(TestkitTestCase):
             self._router.done()
             self._reader1.done()
 
-        for simultaneous_sessions in (True, False):
-            with self.subTest("simultaneous-sessions" if simultaneous_sessions
-                              else "parallel-sessions"):
+        for parallel_sessions in (True, False):
+            with self.subTest("parallel-sessions" if parallel_sessions
+                              else "sequential-sessions"):
                 _test()
             self._router.reset()
             self._reader1.reset()
@@ -82,7 +82,7 @@ class TestHomeDb(TestkitTestCase):
             result = tx.run("RETURN 1")
             result.consume()
             tx.commit()
-            if not simultaneous_sessions:
+            if not parallel_sessions:
                 session1.close()
 
             session2 = driver.session(
@@ -92,7 +92,7 @@ class TestHomeDb(TestkitTestCase):
             result.consume()
             tx.commit()
             session2.close()
-            if simultaneous_sessions:
+            if parallel_sessions:
                 session1.close()
 
             driver.close()
@@ -100,9 +100,9 @@ class TestHomeDb(TestkitTestCase):
             self._router.done()
             self._reader1.done()
 
-        for simultaneous_sessions in (True, False):
-            with self.subTest("simultaneous-sessions" if simultaneous_sessions
-                              else "parallel-sessions"):
+        for parallel_sessions in (True, False):
+            with self.subTest("parallel-sessions" if parallel_sessions
+                              else "sequential-sessions"):
                 _test()
             self._router.reset()
             self._reader1.reset()
@@ -128,7 +128,7 @@ class TestHomeDb(TestkitTestCase):
             session1 = driver.session("r", impersonatedUser="the-imposter")
             query = "RETURN 1"
             session1.readTransaction(work)
-            if not simultaneous_sessions:
+            if not parallel_sessions:
                 session1.close()
 
             session2 = driver.session(
@@ -136,7 +136,7 @@ class TestHomeDb(TestkitTestCase):
             query = "RETURN 2"
             session2.readTransaction(work)
             session2.close()
-            if simultaneous_sessions:
+            if parallel_sessions:
                 session1.close()
 
             driver.close()
@@ -144,9 +144,9 @@ class TestHomeDb(TestkitTestCase):
             self._router.done()
             self._reader1.done()
 
-        for simultaneous_sessions in (True, False):
-            with self.subTest("simultaneous-sessions" if simultaneous_sessions
-                              else "parallel-sessions"):
+        for parallel_sessions in (True, False):
+            with self.subTest("parallel-sessions" if parallel_sessions
+                              else "sequential-sessions"):
                 _test()
             self._router.reset()
             self._reader1.reset()

--- a/tests/stub/homedb/test_homedb.py
+++ b/tests/stub/homedb/test_homedb.py
@@ -164,6 +164,7 @@ class TestHomeDb(TestkitTestCase):
                     return res.next()
                 self._router.done()
                 self._reader1.done()
+                self._reader1._dump()
                 self._router.start(path=self.script_path(
                     "router_explicit_homedb.script"),
                     vars={"#HOST#": self._router.host})
@@ -192,3 +193,4 @@ class TestHomeDb(TestkitTestCase):
 
         self._router.done()
         self._reader2.done()
+        self.assertEqual(i, 2)

--- a/tests/stub/homedb/test_homedb.py
+++ b/tests/stub/homedb/test_homedb.py
@@ -2,7 +2,6 @@ from nutkit.frontend import Driver
 import nutkit.protocol as types
 from tests.shared import (
     driver_feature,
-    get_driver_name,
     TestkitTestCase,
 )
 from tests.stub.shared import StubServer

--- a/tests/stub/session_run_parameters/test_session_run_parameters.py
+++ b/tests/stub/session_run_parameters/test_session_run_parameters.py
@@ -161,11 +161,13 @@ class TestSessionRunParameters(TestkitTestCase):
                         "<class 'neo4j.exceptions.ConfigurationError'>"
                     )
                     self.assertIn("that-other-dude", exc.exception.msg)
-                if self._driver_name in ["java"]:
+                elif self._driver_name in ["java"]:
                     self.assertEqual(
                         exc.exception.errorType,
                         "org.neo4j.driver.exceptions.ClientException"
                     )
+                elif self._driver_name in ["go"]:
+                    self.assertIn("impersonation", exc.exception.msg)
 
     @driver_feature(types.Feature.IMPERSONATION,
                     types.Feature.BOLT_4_4)

--- a/tests/stub/tx_begin_parameters/test_tx_begin_parameters.py
+++ b/tests/stub/tx_begin_parameters/test_tx_begin_parameters.py
@@ -199,11 +199,13 @@ class TestTxBeginParameters(TestkitTestCase):
                         "<class 'neo4j.exceptions.ConfigurationError'>"
                     )
                     self.assertIn("that-other-dude", exc.exception.msg)
-                if self._driver_name in ["java"]:
+                elif self._driver_name in ["java"]:
                     self.assertEqual(
                         exc.exception.errorType,
                         "org.neo4j.driver.exceptions.ClientException"
                     )
+                elif self._driver_name in ["go"]:
+                    self.assertIn("impersonation", exc.exception.msg)
 
     @driver_feature(types.Feature.IMPERSONATION,
                     types.Feature.BOLT_4_4)


### PR DESCRIPTION
The home database resolution is not being covered by other tests and it's an important part of the 4.4 release. This PR adds test to exercise this logic in different scenarios.

* [x] Using Session.run in two different sessions in sequence
* [x] Using Session.runTransaction in two different sessions in sequence
* [x] Using Session.run in two different session in parallel
* [x] Using Session.runTransaction in two different in parallel

This PR also fixes a small error in the stubtest