### PR TITLE
Add feature flags for different bolt versions

### DIFF
--- a/boltstub/bolt_protocol.py
+++ b/boltstub/bolt_protocol.py
@@ -363,6 +363,6 @@ class Bolt4x4Protocol(Bolt4x3Protocol):
     protocol_version = (4, 4)
     version_aliases = set()
     # allow the server to negotiate other bolt versions
-    equivalent_versions = {(4, 3)}
+    equivalent_versions = set()
 
     server_agent = "Neo4j/4.4.0"

--- a/nutkit/protocol/feature.py
+++ b/nutkit/protocol/feature.py
@@ -23,6 +23,16 @@ class Feature(Enum):
     # The driver supports Kerberos authentication by providing a dedicated auth
     # token API.
     AUTH_KERBEROS = "Feature:Auth:Kerberos"
+    # The driver supports Bolt protocol version 3
+    BOLT_3_0 = "Feature:Bolt:3.0"
+    # The driver supports Bolt protocol version 4.0
+    BOLT_4_0 = "Feature:Bolt:4.0"
+    # The driver supports Bolt protocol version 4.1
+    BOLT_4_1 = "Feature:Bolt:4.1"
+    # The driver supports Bolt protocol version 4.2
+    BOLT_4_2 = "Feature:Bolt:4.2"
+    # The driver supports Bolt protocol version 4.3
+    BOLT_4_3 = "Feature:Bolt:4.3"
     # The driver supports Bolt protocol version 4.4
     BOLT_4_4 = "Feature:Bolt:4.4"
     # The driver supports impersonation

--- a/tests/neo4j/shared.py
+++ b/tests/neo4j/shared.py
@@ -171,7 +171,7 @@ def requires_min_bolt_version(feature):
             if server_max_version < min_version:
                 test_case.skipTest("Server does not support minimum required "
                                    "Bolt version: " + min_version)
-            missing = test_case.driver_missing_features(all_viable_versions)
+            missing = test_case.driver_missing_features(*all_viable_versions)
             if len(missing) == len(all_viable_versions):
                 test_case.skipTest("There is no common version between server "
                                    "and driver that fulfills the minimum "

--- a/tests/neo4j/shared.py
+++ b/tests/neo4j/shared.py
@@ -14,10 +14,12 @@ TEST_NEO4J_EDITION   Edition ("enterprise" or "community") of the Neo4j server,
                      default "enterprise"
 TEST_NEO4J_CLUSTER   Whether the Neo4j server is a cluster, default "False"
 """
+from functools import wraps
 import os
 from warnings import warn
 
 from nutkit.frontend import Driver
+from nutkit import protocol
 from nutkit.protocol import AuthorizationToken
 from tests.shared import (
     dns_resolve_single,
@@ -125,3 +127,55 @@ def cluster_unsafe_test(func):
                  "TestkitTestCase methods.")
             return func(*args, **kwargs)
     return wrapper
+
+
+def requires_multi_db_support(func):
+    def get_valid_test_case(*args, **kwargs):
+        if not args or not isinstance(args[0], TestkitTestCase):
+            raise TypeError("Should only decorate TestkitTestCase methods")
+        return args[0]
+
+    @wraps(func)
+    @requires_min_bolt_version(protocol.Feature.BOLT_4_0)
+    def wrapper(*args, **kwargs):
+        test_case = get_valid_test_case(*args, **kwargs)
+        if not get_server_info().supports_multi_db:
+            test_case.skip("Server does not support multiple databases.")
+        return func(*args, **kwargs)
+    return wrapper
+
+
+def requires_min_bolt_version(feature):
+    if not isinstance(feature, protocol.Feature):
+        raise TypeError("The arguments must be instances of Feature")
+    if not feature.name.startswith("BOLT_"):
+        raise ValueError("Bolt version feature expected")
+
+    min_version = feature.value.split(":")[-1]
+    server_max_version = get_server_info().max_protocol_version
+    all_viable_versions = [
+        f for f in protocol.Feature
+        if (f.value.startswith("BOLT_")
+            and min_version <= f.value.spit(":")[-1] <= server_max_version)
+    ]
+
+    def get_valid_test_case(*args, **kwargs):
+        if not args or not isinstance(args[0], TestkitTestCase):
+            raise TypeError("Should only decorate TestkitTestCase methods")
+        return args[0]
+
+    def bolt_version_decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            test_case = get_valid_test_case(*args, **kwargs)
+            if server_max_version < min_version:
+                test_case.skip("Server does not support minimum required Bolt "
+                               "version: " + min_version)
+            missing = test_case.driver_missing_features(all_viable_versions)
+            if len(missing) == len(all_viable_versions):
+                test_case.skip("There is no common version between server and "
+                               "driver that fulfills the minimum required "
+                               "protocol version: " + min_version)
+            return func(*args, **kwargs)
+        return wrapper
+    return bolt_version_decorator

--- a/tests/neo4j/shared.py
+++ b/tests/neo4j/shared.py
@@ -140,7 +140,7 @@ def requires_multi_db_support(func):
     def wrapper(*args, **kwargs):
         test_case = get_valid_test_case(*args, **kwargs)
         if not get_server_info().supports_multi_db:
-            test_case.skip("Server does not support multiple databases.")
+            test_case.skipTest("Server does not support multiple databases.")
         return func(*args, **kwargs)
     return wrapper
 
@@ -169,13 +169,13 @@ def requires_min_bolt_version(feature):
         def wrapper(*args, **kwargs):
             test_case = get_valid_test_case(*args, **kwargs)
             if server_max_version < min_version:
-                test_case.skip("Server does not support minimum required Bolt "
-                               "version: " + min_version)
+                test_case.skipTest("Server does not support minimum required "
+                                   "Bolt version: " + min_version)
             missing = test_case.driver_missing_features(all_viable_versions)
             if len(missing) == len(all_viable_versions):
-                test_case.skip("There is no common version between server and "
-                               "driver that fulfills the minimum required "
-                               "protocol version: " + min_version)
+                test_case.skipTest("There is no common version between server "
+                                   "and driver that fulfills the minimum "
+                                   "required protocol version: " + min_version)
             return func(*args, **kwargs)
         return wrapper
     return bolt_version_decorator

--- a/tests/neo4j/test_authentication.py
+++ b/tests/neo4j/test_authentication.py
@@ -1,6 +1,5 @@
 import os
 
-from nutkit.frontend import Driver
 import nutkit.protocol as types
 from tests.neo4j.shared import (
     cluster_unsafe_test,

--- a/tests/neo4j/test_direct_driver.py
+++ b/tests/neo4j/test_direct_driver.py
@@ -14,6 +14,7 @@ from .shared import (
     get_neo4j_host_and_port,
     get_neo4j_scheme,
     get_server_info,
+    requires_multi_db_support,
 )
 
 
@@ -130,13 +131,12 @@ class TestDirectDriver(TestkitTestCase):
                              "<class 'neo4j.exceptions.ClientError'>")
 
     @driver_feature(types.Feature.TMP_FULL_SUMMARY)
+    @requires_multi_db_support
     @cluster_unsafe_test
     def test_multi_db(self):
         self._driver = get_driver(self._backend)
         server_info = get_server_info()
         if server_info.max_protocol_version >= "4":
-            if not get_server_info().supports_multi_db:
-                self.skipTest("Needs multi DB support")
             self._session = self._driver.session("w", database="system")
 
             self._session.run("DROP DATABASE `test-database` IF EXISTS")\
@@ -167,6 +167,7 @@ class TestDirectDriver(TestkitTestCase):
                     e.exception.msg
                 )
 
+    @requires_multi_db_support
     @cluster_unsafe_test
     def test_multi_db_various_databases(self):
         def get_names(result_, node=True):
@@ -192,9 +193,6 @@ class TestDirectDriver(TestkitTestCase):
                 self.assertIsInstance(name, types.CypherString)
                 names.add(name.value)
             return names
-
-        if not get_server_info().supports_multi_db:
-            self.skipTest("Needs multi DB support")
 
         self._driver = get_driver(self._backend)
 

--- a/tests/neo4j/test_summary.py
+++ b/tests/neo4j/test_summary.py
@@ -9,6 +9,7 @@ from .shared import (
     get_driver,
     get_neo4j_resolved_host_and_port,
     get_server_info,
+    requires_multi_db_support,
 )
 
 
@@ -87,8 +88,14 @@ class TestSummary(TestkitTestCase):
     def test_protocol_version_information(self):
         summary = self.get_summary("RETURN 1 AS number")
 
-        max_protocol_version = get_server_info().max_protocol_version
-        if max_protocol_version == "4.2":
+        max_server_protocol_version = get_server_info().max_protocol_version
+        common_protocol_versions = [
+            f.value.split(":")[-1] for f in self._driver_features
+            if (f.name.startswith("BOLT_")
+                and f.value.split(":")[-1] <= max_server_protocol_version)
+        ]
+        common_max_version = max(common_protocol_versions)
+        if common_max_version == "4.2":
             # Both versions are equivalent. Since 4.2 was introduced before
             # having version ranges in the handshake, we allow drivers to
             # negotiate bolt 4.1 with 4.2 to be able to fit support for more
@@ -145,11 +152,9 @@ class TestSummary(TestkitTestCase):
 
     @driver_feature(types.Feature.TMP_RESULT_KEYS,
                     types.Feature.TMP_FULL_SUMMARY)
+    @requires_multi_db_support
     @cluster_unsafe_test
     def test_summary_counters_case_2(self):
-        if not get_server_info().supports_multi_db:
-            self.skipTest("Needs multi DB support")
-
         self._session = self._driver.session("w", database="system")
 
         self._session.run("DROP DATABASE test IF EXISTS").consume()

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -228,7 +228,7 @@ class TestkitTestCase(unittest.TestCase):
         elif isinstance(version, str):
             m = re.match(r"\D*(\d+)(?:\D+(\d+))?", version)
             if not m:
-                raise ValueError("Invalid bolt version specidication")
+                raise ValueError("Invalid bolt version specification")
             version = tuple(map(int, m.groups("0")))
         else:
             version = tuple(version)

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -160,7 +160,7 @@ class TestkitTestCase(unittest.TestCase):
         self.addCleanup(self._backend.close)
         self._driver_features = get_driver_features(self._backend)
 
-        if self.required_features is not None:
+        if self.required_features:
             self.skip_if_missing_driver_features(*self.required_features)
 
         response = self._backend.sendAndReceive(protocol.StartTest(id_))

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -127,6 +127,17 @@ def get_driver_features(backend):
             features.add(protocol.Feature.TLS_1_2.value)
         if get_driver_name() in ["go"]:
             features.add(protocol.Feature.TLS_1_3.value)
+        if get_driver_name() in ["java", "javascript", "go", "dotnet"]:
+            features.add(
+                f.value for f in (
+                    protocol.Feature.BOLT_3_0,
+                    protocol.Feature.BOLT_4_0,
+                    protocol.Feature.BOLT_4_1,
+                    protocol.Feature.BOLT_4_2,
+                    protocol.Feature.BOLT_4_3,
+                    protocol.Feature.BOLT_4_4,
+                )
+            )
         print("features", features)
         return features
     except (OSError, protocol.BaseError) as e:
@@ -139,12 +150,19 @@ def get_driver_name():
 
 
 class TestkitTestCase(unittest.TestCase):
+
+    required_features = None
+
     def setUp(self):
         super().setUp()
         id_ = re.sub(r"^([^\.]+\.)*?tests\.", "", self.id())
         self._backend = new_backend()
         self.addCleanup(self._backend.close)
         self._driver_features = get_driver_features(self._backend)
+
+        if self.required_features is not None:
+            self.skip_if_missing_driver_features(*self.required_features)
+
         response = self._backend.sendAndReceive(protocol.StartTest(id_))
         if isinstance(response, protocol.SkipTest):
             self.skipTest(response.reason)
@@ -204,10 +222,39 @@ class TestkitTestCase(unittest.TestCase):
     def driver_supports_features(self, *features):
         return not self.driver_missing_features(*features)
 
+    def _bolt_version_to_feature(self, version):
+        if isinstance(version, protocol.Feature):
+            return self.driver_supports_features(version)
+        elif isinstance(version, str):
+            m = re.match(r"\D*(\d+)(?:\D+(\d+))?", version)
+            if not m:
+                raise ValueError("Invalid bolt version specidication")
+            version = tuple(map(int, m.groups("0")))
+        else:
+            version = tuple(version)
+        version = tuple(map(str, version))
+        if len(version) == 1:
+            version = (version[0], "0")
+        try:
+            return getattr(protocol.Feature, "_".join(("BOLT", *version)))
+        except AttributeError:
+            raise ValueError("Unknown bolt feature "
+                             + "_".join(("BOLT", *version)))
+
+    def driver_supports_bolt(self, version):
+        return self.driver_supports_features(
+            self._bolt_version_to_feature(version)
+        )
+
     def skip_if_missing_driver_features(self, *features):
         missing = self.driver_missing_features(*features)
         if missing:
             self.skipTest("Needs support for %s" % ", ".join(missing))
+
+    def skip_if_missing_bolt_support(self, version):
+        self.skip_if_missing_driver_features(
+            self._bolt_version_to_feature(version)
+        )
 
     def script_path(self, *path):
         base_path = os.path.dirname(inspect.getfile(self.__class__))

--- a/tests/stub/authorization/test_authorization.py
+++ b/tests/stub/authorization/test_authorization.py
@@ -96,6 +96,9 @@ class AuthorizationBase(TestkitTestCase):
 # TODO: re-write tests, where possible, to use only one server, utilizing
 #       on_send_RetryableNegative and potentially other hooks.
 class TestAuthorizationV4x3(AuthorizationBase):
+
+    required_features = types.Feature.BOLT_4_3,
+
     def setUp(self):
         super().setUp()
         self._routing_server1 = StubServer(9000)
@@ -799,6 +802,9 @@ class TestAuthorizationV4x3(AuthorizationBase):
 
 
 class TestAuthorizationV4x1(TestAuthorizationV4x3):
+
+    required_features = types.Feature.BOLT_4_1,
+
     def get_vars(self, host=None):
         if host is None:
             host = self._routing_server1.host
@@ -825,6 +831,9 @@ class TestAuthorizationV3(TestAuthorizationV4x3):
 
 
 class TestNoRoutingAuthorization(AuthorizationBase):
+
+    required_features = types.Feature.BOLT_4_0,
+
     def setUp(self):
         super().setUp()
         self._server = StubServer(9010)
@@ -905,6 +914,9 @@ class TestNoRoutingAuthorization(AuthorizationBase):
 
 
 class TestAuthenticationSchemes(AuthorizationBase):
+
+    required_features = types.Feature.BOLT_4_3,
+
     def get_vars(self):
         return {
             "#VERSION#": "4.3"

--- a/tests/stub/bookmarks/test_bookmarks_v3.py
+++ b/tests/stub/bookmarks/test_bookmarks_v3.py
@@ -1,5 +1,10 @@
+from nutkit import protocol as types
+
 from tests.stub.bookmarks.test_bookmarks_v4 import TestBookmarksV4
 
 
 class TestBookmarksV3(TestBookmarksV4):
+
+    required_features = types.Feature.BOLT_3_0,
+
     version_dir = "v3"

--- a/tests/stub/bookmarks/test_bookmarks_v4.py
+++ b/tests/stub/bookmarks/test_bookmarks_v4.py
@@ -1,4 +1,5 @@
 from nutkit.frontend import Driver
+from nutkit import protocol as types
 from nutkit.protocol import AuthorizationToken
 from tests.shared import TestkitTestCase
 from tests.stub.shared import StubServer
@@ -6,6 +7,9 @@ from tests.stub.shared import StubServer
 
 # Tests bookmarks from transaction
 class TestBookmarksV4(TestkitTestCase):
+
+    required_features = types.Feature.BOLT_4_0,
+
     version_dir = "v4"
 
     def setUp(self):

--- a/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
+++ b/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
@@ -13,6 +13,9 @@ from tests.stub.shared import (
 
 
 class TestDirectConnectionRecvTimeout(TestkitTestCase):
+
+    required_features = types.Feature.BOLT_4_3,
+
     def setUp(self):
         super().setUp()
         self._server = StubServer(9010)
@@ -129,7 +132,7 @@ class TestDirectConnectionRecvTimeout(TestkitTestCase):
         if get_driver_name() in ['go']:
             with self.assertRaises(types.DriverError) as exc:
                 tx.close()
-                
+
         # TODO Remove when explicit rollback requirement is removed
         if get_driver_name() in ['java']:
             tx.rollback()

--- a/tests/stub/disconnects/test_disconnects.py
+++ b/tests/stub/disconnects/test_disconnects.py
@@ -12,6 +12,9 @@ customUserAgent = "Modesty"
 
 
 class TestDisconnects(TestkitTestCase):
+
+    required_features = types.Feature.BOLT_4_3,
+
     def setUp(self):
         super().setUp()
         self._server = StubServer(9001)

--- a/tests/stub/homedb/test_homedb.py
+++ b/tests/stub/homedb/test_homedb.py
@@ -8,6 +8,9 @@ from tests.stub.shared import StubServer
 
 
 class TestHomeDb(TestkitTestCase):
+
+    required_features = types.Feature.BOLT_4_4,
+
     def setUp(self):
         super().setUp()
         self._router = StubServer(9000)

--- a/tests/stub/homedb/test_homedb.py
+++ b/tests/stub/homedb/test_homedb.py
@@ -26,7 +26,7 @@ class TestHomeDb(TestkitTestCase):
         self._router.reset()
         super().tearDown()
 
-    @driver_feature(types.Feature.IMPERSONATION, types.Feature.BOLT_4_4)
+    @driver_feature(types.Feature.IMPERSONATION)
     def test_should_resolve_db_per_session_session_run(self):
         def _test():
             self._router.start(
@@ -66,7 +66,7 @@ class TestHomeDb(TestkitTestCase):
             self._router.reset()
             self._reader1.reset()
 
-    @driver_feature(types.Feature.IMPERSONATION, types.Feature.BOLT_4_4)
+    @driver_feature(types.Feature.IMPERSONATION)
     def test_should_resolve_db_per_session_tx_run(self):
         def _test():
             self._router.start(
@@ -110,7 +110,7 @@ class TestHomeDb(TestkitTestCase):
             self._router.reset()
             self._reader1.reset()
 
-    @driver_feature(types.Feature.IMPERSONATION, types.Feature.BOLT_4_4)
+    @driver_feature(types.Feature.IMPERSONATION)
     def test_should_resolve_db_per_session_tx_func_run(self):
         def _test():
             def work(tx):
@@ -154,7 +154,7 @@ class TestHomeDb(TestkitTestCase):
             self._router.reset()
             self._reader1.reset()
 
-    @driver_feature(types.Feature.IMPERSONATION, types.Feature.BOLT_4_4)
+    @driver_feature(types.Feature.IMPERSONATION)
     def test_session_should_cache_home_db_despite_new_rt(self):
         i = 0
 

--- a/tests/stub/iteration/test_iteration_session_run.py
+++ b/tests/stub/iteration/test_iteration_session_run.py
@@ -8,6 +8,9 @@ from tests.stub.shared import StubServer
 
 
 class TestIterationSessionRun(TestkitTestCase):
+
+    required_features = types.Feature.BOLT_4_0,
+
     def setUp(self):
         super().setUp()
         self._server = StubServer(9001)

--- a/tests/stub/iteration/test_iteration_tx_run.py
+++ b/tests/stub/iteration/test_iteration_tx_run.py
@@ -8,6 +8,9 @@ from tests.stub.shared import StubServer
 
 
 class TestIterationTxRun(TestkitTestCase):
+
+    required_features = types.Feature.BOLT_4_0,
+
     def setUp(self):
         super().setUp()
         self._server = StubServer(9001)

--- a/tests/stub/iteration/test_result_peek.py
+++ b/tests/stub/iteration/test_result_peek.py
@@ -11,6 +11,9 @@ from tests.stub.shared import StubServer
 
 
 class TestResultPeek(TestkitTestCase):
+
+    required_features = types.Feature.BOLT_4_0,
+
     def setUp(self):
         super().setUp()
         self._server = StubServer(9001)

--- a/tests/stub/iteration/test_result_single.py
+++ b/tests/stub/iteration/test_result_single.py
@@ -11,6 +11,9 @@ from tests.stub.shared import StubServer
 
 
 class TestResultSingle(TestkitTestCase):
+
+    required_features = types.Feature.BOLT_4_0,
+
     def setUp(self):
         super().setUp()
         self._server = StubServer(9001)

--- a/tests/stub/optimizations/test_optimizations.py
+++ b/tests/stub/optimizations/test_optimizations.py
@@ -23,7 +23,8 @@ class TestOptimizations(TestkitTestCase):
         self._router.reset()
         super().tearDown()
 
-    @driver_feature(types.Feature.OPT_PULL_PIPELINING)
+    @driver_feature(types.Feature.OPT_PULL_PIPELINING,
+                    types.Feature.BOLT_4_3)
     def test_pull_pipelining(self):
         def test():
             script = "pull_pipeline{}.script".format("_tx" if use_tx else "")
@@ -130,7 +131,8 @@ class TestOptimizations(TestkitTestCase):
             self.assertEqual(self._server.count_requests("RESET"), 0)
             self.assertEqual(self._router.count_requests("RESET"), 0)
 
-    @driver_feature(types.Feature.OPT_CONNECTION_REUSE)
+    @driver_feature(types.Feature.OPT_CONNECTION_REUSE,
+                    types.Feature.BOLT_4_3)
     def test_reuses_connection(self):
         for routing in (False, True):
             for mode in ("read", "write"):
@@ -151,6 +153,8 @@ class TestOptimizations(TestkitTestCase):
     def test_no_reset_on_clean_connection(self):
         mode = "write"
         for version in ("v4x3", "v3"):
+            if not self.driver_supports_bolt(version):
+                continue
             for consume in (True, False):
                 if version == "v3" and consume:
                     # Drivers with types.Feature.OPT_PULL_PIPELINING will issue
@@ -214,6 +218,8 @@ class TestOptimizations(TestkitTestCase):
             self.assertEqual(reset_count, 1)
 
         for version in ("v3", "v4x3"):
+            if not self.driver_supports_bolt(version):
+                continue
             for use_tx in (False, True):
                 for routing in (False, True):
                     for fail_on in ("pull", "run", "begin"):
@@ -275,6 +281,8 @@ class TestOptimizations(TestkitTestCase):
                 self._router.done()
 
         for version in ("v4x3", "v4x4"):
+            if not self.driver_supports_bolt(version):
+                continue
             for use_tx in (True, False):
                 for consume in (True, False):
                     for routing in (True, False):
@@ -357,6 +365,8 @@ class TestOptimizations(TestkitTestCase):
             self._server.done()
 
         for version in ("v4x3", "v4x4"):
+            if not self.driver_supports_bolt(version):
+                continue
             for consume1 in (True, False):
                 for consume2 in (True, False):
                     with self.subTest(("discard1" if consume1 else "pull1")

--- a/tests/stub/retry/scripts/commit_disconnect.script
+++ b/tests/stub/retry/scripts/commit_disconnect.script
@@ -1,4 +1,4 @@
-!: BOLT 4
+!: BOLT 4.3
 
 A: HELLO {"{}": "*"}
 *: RESET

--- a/tests/stub/retry/scripts/read.script
+++ b/tests/stub/retry/scripts/read.script
@@ -1,4 +1,4 @@
-!: BOLT 4
+!: BOLT 4.3
 
 A: HELLO {"{}": "*"}
 *: RESET

--- a/tests/stub/retry/scripts/retry_with_fail_after_commit.script
+++ b/tests/stub/retry/scripts/retry_with_fail_after_commit.script
@@ -1,4 +1,4 @@
-!: BOLT 4
+!: BOLT 4.3
 
 A: HELLO {"{}": "*"}
 C: BEGIN {}

--- a/tests/stub/retry/scripts/retry_with_fail_after_pull.script
+++ b/tests/stub/retry/scripts/retry_with_fail_after_pull.script
@@ -1,4 +1,4 @@
-!: BOLT 4
+!: BOLT 4.3
 
 A: HELLO {"{}": "*"}
 C: BEGIN {}

--- a/tests/stub/retry/scripts/retry_with_fail_after_pull_server1.script
+++ b/tests/stub/retry/scripts/retry_with_fail_after_pull_server1.script
@@ -1,4 +1,4 @@
-!: BOLT 4
+!: BOLT 4.3
 
 A: HELLO {"{}": "*"}
 C: BEGIN {}

--- a/tests/stub/retry/scripts/retry_with_fail_after_pull_server2.script
+++ b/tests/stub/retry/scripts/retry_with_fail_after_pull_server2.script
@@ -1,4 +1,4 @@
-!: BOLT 4
+!: BOLT 4.3
 
 A: HELLO {"{}": "*"}
 C: BEGIN {}

--- a/tests/stub/retry/test_retry.py
+++ b/tests/stub/retry/test_retry.py
@@ -1,9 +1,6 @@
-from warnings import warn
-
 from nutkit.frontend import Driver
 import nutkit.protocol as types
 from tests.shared import (
-    driver_feature,
     get_driver_name,
     TestkitTestCase,
 )
@@ -11,6 +8,9 @@ from tests.stub.shared import StubServer
 
 
 class TestRetry(TestkitTestCase):
+
+    required_features = types.Feature.BOLT_4_3,
+
     def setUp(self):
         super().setUp()
         self._server = StubServer(9001)

--- a/tests/stub/retry/test_retry_clustering.py
+++ b/tests/stub/retry/test_retry_clustering.py
@@ -8,6 +8,9 @@ from tests.stub.shared import StubServer
 
 
 class TestRetryClustering(TestkitTestCase):
+
+    required_features = types.Feature.BOLT_4_3,
+
     def setUp(self):
         super().setUp()
         self._routingServer = StubServer(9001)

--- a/tests/stub/routing/_routing.py
+++ b/tests/stub/routing/_routing.py
@@ -17,12 +17,6 @@ from tests.stub.shared import StubServer
 class RoutingBase(TestkitTestCase):
     def setUp(self):
         super().setUp()
-        required_bolt_features = {
-            "4.4": (types.Feature.BOLT_4_4,),
-        }
-        self.skip_if_missing_driver_features(
-            *required_bolt_features.get(self.bolt_version, ())
-        )
         self._routingServer1 = StubServer(9000)
         self._routingServer2 = StubServer(9001)
         self._routingServer3 = StubServer(9002)

--- a/tests/stub/routing/test_no_routing_v3.py
+++ b/tests/stub/routing/test_no_routing_v3.py
@@ -1,7 +1,11 @@
+from nutkit import protocol as types
+
 from .test_no_routing_v4x1 import NoRoutingV4x1
 
 
 class NoRoutingV3(NoRoutingV4x1):
+
+    required_features = types.Feature.BOLT_3_0,
     bolt_version = "3"
     version_dir = "v3_no_routing"
     server_agent = "Neo4j/3.5.0"

--- a/tests/stub/routing/test_no_routing_v4x1.py
+++ b/tests/stub/routing/test_no_routing_v4x1.py
@@ -10,6 +10,8 @@ from tests.stub.shared import StubServer
 
 
 class NoRoutingV4x1(TestkitTestCase):
+
+    required_features = types.Feature.BOLT_4_1,
     bolt_version = "4.1"
     version_dir = "v4x1_no_routing"
     server_agent = "Neo4j/4.1.0"

--- a/tests/stub/routing/test_routing_v3.py
+++ b/tests/stub/routing/test_routing_v3.py
@@ -5,6 +5,8 @@ from .test_routing_v4x4 import RoutingV4x4
 
 
 class RoutingV3(RoutingV4x4):
+
+    required_features = types.Feature.BOLT_3_0,
     bolt_version = "3"
     server_agent = "Neo4j/3.5.0"
 

--- a/tests/stub/routing/test_routing_v4x1.py
+++ b/tests/stub/routing/test_routing_v4x1.py
@@ -1,10 +1,13 @@
 import json
 
+from nutkit import protocol as types
 from nutkit.frontend import Driver
 from .test_routing_v4x4 import RoutingV4x4
 
 
 class RoutingV4x1(RoutingV4x4):
+
+    required_features = types.Feature.BOLT_4_1,
     bolt_version = "4.1"
     server_agent = "Neo4j/4.1.0"
 

--- a/tests/stub/routing/test_routing_v4x3.py
+++ b/tests/stub/routing/test_routing_v4x3.py
@@ -6,6 +6,8 @@ from .test_routing_v4x4 import RoutingV4x4
 
 
 class RoutingV4x3(RoutingV4x4):
+
+    required_features = types.Feature.BOLT_4_3,
     bolt_version = "4.3"
     server_agent = "Neo4j/4.3.0"
     adb = "adb"

--- a/tests/stub/routing/test_routing_v4x4.py
+++ b/tests/stub/routing/test_routing_v4x4.py
@@ -12,6 +12,8 @@ from ._routing import RoutingBase
 
 
 class RoutingV4x4(RoutingBase):
+
+    required_features = types.Feature.BOLT_4_4,
     bolt_version = "4.4"
     server_agent = "Neo4j/4.4.0"
     adb = "adb"

--- a/tests/stub/server_side_routing/test_server_side_routing.py
+++ b/tests/stub/server_side_routing/test_server_side_routing.py
@@ -12,6 +12,8 @@ class TestServerSideRouting(TestkitTestCase):
     in Server Side Routing scenarios
     """
 
+    required_features = types.Feature.BOLT_4_1,
+
     def setUp(self):
         super().setUp()
         self._server = StubServer(9001)

--- a/tests/stub/session_run/test_session_run.py
+++ b/tests/stub/session_run/test_session_run.py
@@ -8,6 +8,9 @@ from tests.stub.shared import StubServer
 
 
 class TestSessionRun(TestkitTestCase):
+
+    required_features = types.Feature.BOLT_4_4,
+
     def setUp(self):
         super().setUp()
         self._server = StubServer(9001)

--- a/tests/stub/session_run_parameters/test_session_run_parameters.py
+++ b/tests/stub/session_run_parameters/test_session_run_parameters.py
@@ -17,9 +17,6 @@ from tests.stub.shared import StubServer
 #   Transaction timeout + write mode
 #   Read mode + transaction meta data + transaction timeout + bookmarks
 class TestSessionRunParameters(TestkitTestCase):
-
-    required_features = types.Feature.BOLT_4_4,
-
     def setUp(self):
         super().setUp()
         self._router = StubServer(9000)
@@ -83,18 +80,21 @@ class TestSessionRunParameters(TestkitTestCase):
             session.close()
             self._driver.close()
 
+    @driver_feature(types.Feature.BOLT_4_4)
     def test_access_mode_read(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
                 self._run("access_mode_read", routing,
                           session_args=("r",))
 
+    @driver_feature(types.Feature.BOLT_4_4)
     def test_access_mode_write(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
                 self._run("access_mode_write", routing,
                           session_args=("w",))
 
+    @driver_feature(types.Feature.BOLT_4_4)
     def test_parameters(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -102,6 +102,7 @@ class TestSessionRunParameters(TestkitTestCase):
                           session_args=("w",),
                           run_kwargs={"params": {"p": types.CypherInt(1)}})
 
+    @driver_feature(types.Feature.BOLT_4_4)
     def test_bookmarks(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -109,6 +110,7 @@ class TestSessionRunParameters(TestkitTestCase):
                           session_args=("w",),
                           session_kwargs={"bookmarks": ["b1", "b2"]})
 
+    @driver_feature(types.Feature.BOLT_4_4)
     def test_tx_meta(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -116,12 +118,15 @@ class TestSessionRunParameters(TestkitTestCase):
                           session_args=("w",),
                           run_kwargs={"txMeta": {"akey": "aval"}})
 
+    @driver_feature(types.Feature.BOLT_4_4)
     def test_timeout(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
                 self._run("timeout", routing,
                           session_args=("w",), run_kwargs={"timeout": 17})
 
+    @driver_feature(types.Feature.IMPERSONATION,
+                    types.Feature.BOLT_4_4)
     def test_database(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -165,7 +170,8 @@ class TestSessionRunParameters(TestkitTestCase):
                 elif self._driver_name in ["go"]:
                     self.assertIn("impersonation", exc.exception.msg)
 
-    @driver_feature(types.Feature.IMPERSONATION)
+    @driver_feature(types.Feature.IMPERSONATION,
+                    types.Feature.BOLT_4_4)
     def test_combined(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -181,6 +187,7 @@ class TestSessionRunParameters(TestkitTestCase):
                               "txMeta": {"k": "v"}, "timeout": 11
                           })
 
+    @driver_feature(types.Feature.BOLT_4_4)
     def test_empty_query(self):
         # Driver should pass empty string to server
         # TODO remove this block once all languages work

--- a/tests/stub/session_run_parameters/test_session_run_parameters.py
+++ b/tests/stub/session_run_parameters/test_session_run_parameters.py
@@ -17,6 +17,9 @@ from tests.stub.shared import StubServer
 #   Transaction timeout + write mode
 #   Read mode + transaction meta data + transaction timeout + bookmarks
 class TestSessionRunParameters(TestkitTestCase):
+
+    required_features = types.Feature.BOLT_4_4,
+
     def setUp(self):
         super().setUp()
         self._router = StubServer(9000)
@@ -80,21 +83,18 @@ class TestSessionRunParameters(TestkitTestCase):
             session.close()
             self._driver.close()
 
-    @driver_feature(types.Feature.BOLT_4_4)
     def test_access_mode_read(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
                 self._run("access_mode_read", routing,
                           session_args=("r",))
 
-    @driver_feature(types.Feature.BOLT_4_4)
     def test_access_mode_write(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
                 self._run("access_mode_write", routing,
                           session_args=("w",))
 
-    @driver_feature(types.Feature.BOLT_4_4)
     def test_parameters(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -102,7 +102,6 @@ class TestSessionRunParameters(TestkitTestCase):
                           session_args=("w",),
                           run_kwargs={"params": {"p": types.CypherInt(1)}})
 
-    @driver_feature(types.Feature.BOLT_4_4)
     def test_bookmarks(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -110,7 +109,6 @@ class TestSessionRunParameters(TestkitTestCase):
                           session_args=("w",),
                           session_kwargs={"bookmarks": ["b1", "b2"]})
 
-    @driver_feature(types.Feature.BOLT_4_4)
     def test_tx_meta(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -118,14 +116,12 @@ class TestSessionRunParameters(TestkitTestCase):
                           session_args=("w",),
                           run_kwargs={"txMeta": {"akey": "aval"}})
 
-    @driver_feature(types.Feature.BOLT_4_4)
     def test_timeout(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
                 self._run("timeout", routing,
                           session_args=("w",), run_kwargs={"timeout": 17})
 
-    @driver_feature(types.Feature.BOLT_4_4)
     def test_database(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -145,7 +141,7 @@ class TestSessionRunParameters(TestkitTestCase):
                           })
 
     @driver_feature(types.Feature.IMPERSONATION,
-                    types.Feature.BOLT_4_4)
+                    types.Feature.BOLT_4_3)
     def test_impersonation_fails_on_v4x3(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -169,8 +165,7 @@ class TestSessionRunParameters(TestkitTestCase):
                 elif self._driver_name in ["go"]:
                     self.assertIn("impersonation", exc.exception.msg)
 
-    @driver_feature(types.Feature.IMPERSONATION,
-                    types.Feature.BOLT_4_4)
+    @driver_feature(types.Feature.IMPERSONATION)
     def test_combined(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -186,7 +181,6 @@ class TestSessionRunParameters(TestkitTestCase):
                               "txMeta": {"k": "v"}, "timeout": 11
                           })
 
-    @driver_feature(types.Feature.BOLT_4_4)
     def test_empty_query(self):
         # Driver should pass empty string to server
         # TODO remove this block once all languages work

--- a/tests/stub/summary/test_summary.py
+++ b/tests/stub/summary/test_summary.py
@@ -17,6 +17,8 @@ class TestSummary(TestkitTestCase):
     bolt protocol version.
     """
 
+    required_features = types.Feature.BOLT_4_4,
+
     def setUp(self):
         super().setUp()
         self._server = StubServer(9000)

--- a/tests/stub/transport/test_transport.py
+++ b/tests/stub/transport/test_transport.py
@@ -9,6 +9,9 @@ from tests.stub.shared import StubServer
 
 # Low-level network transport tests
 class TestTransport(TestkitTestCase):
+
+    required_features = types.Feature.BOLT_4_1,
+
     def setUp(self):
         super().setUp()
         self._server = StubServer(9001)

--- a/tests/stub/tx_begin_parameters/test_tx_begin_parameters.py
+++ b/tests/stub/tx_begin_parameters/test_tx_begin_parameters.py
@@ -17,9 +17,6 @@ from tests.stub.shared import StubServer
 #   Transaction timeout + write mode
 #   Read mode + transaction meta data + transaction timeout + bookmarks
 class TestTxBeginParameters(TestkitTestCase):
-
-    required_features = types.Feature.BOLT_4_4,
-
     def setUp(self):
         super().setUp()
         self._router = StubServer(9000)
@@ -101,12 +98,14 @@ class TestTxBeginParameters(TestkitTestCase):
             session.close()
             self._driver.close()
 
+    @driver_feature(types.Feature.BOLT_4_4)
     def test_access_mode_read(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
                 self._run("access_mode_read", routing, session_args=("r",))
                 self._server.done()
 
+    @driver_feature(types.Feature.BOLT_4_4)
     def test_tx_func_access_mode_read(self):
         for routing in (True, False):
             for session_access_mode in ("r", "w"):
@@ -116,6 +115,7 @@ class TestTxBeginParameters(TestkitTestCase):
                               session_args=(session_access_mode[0],),
                               tx_func_access_mode="r")
 
+    @driver_feature(types.Feature.BOLT_4_4)
     def test_access_mode_write(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -123,6 +123,7 @@ class TestTxBeginParameters(TestkitTestCase):
                           session_args=("w",))
                 self._server.done()
 
+    @driver_feature(types.Feature.BOLT_4_4)
     def test_tx_func_access_mode(self):
         for routing in (True, False):
             for session_access_mode in ("r", "w"):
@@ -131,6 +132,7 @@ class TestTxBeginParameters(TestkitTestCase):
                               session_args=(session_access_mode[0],),
                               tx_func_access_mode="w")
 
+    @driver_feature(types.Feature.BOLT_4_4)
     def test_parameters(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -138,6 +140,7 @@ class TestTxBeginParameters(TestkitTestCase):
                           session_args=("w",),
                           run_kwargs={"params": {"p": types.CypherInt(1)}})
 
+    @driver_feature(types.Feature.BOLT_4_4)
     def test_bookmarks(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -145,6 +148,7 @@ class TestTxBeginParameters(TestkitTestCase):
                           session_args=("w",),
                           session_kwargs={"bookmarks": ["b1", "b2"]})
 
+    @driver_feature(types.Feature.BOLT_4_4)
     def test_tx_meta(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -152,12 +156,14 @@ class TestTxBeginParameters(TestkitTestCase):
                           session_args=("w",),
                           tx_kwargs={"txMeta": {"akey": "aval"}})
 
+    @driver_feature(types.Feature.BOLT_4_4)
     def test_timeout(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
                 self._run("timeout", routing,
                           session_args=("w",), tx_kwargs={"timeout": 17})
 
+    @driver_feature(types.Feature.BOLT_4_4)
     def test_database(self):
         for routing in (True, False)[1:]:
             with self.subTest("routing" if routing else "direct"):
@@ -165,7 +171,8 @@ class TestTxBeginParameters(TestkitTestCase):
                           session_args=("w",),
                           session_kwargs={"database": "adb"})
 
-    @driver_feature(types.Feature.IMPERSONATION)
+    @driver_feature(types.Feature.IMPERSONATION,
+                    types.Feature.BOLT_4_4)
     def test_impersonation(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -200,7 +207,8 @@ class TestTxBeginParameters(TestkitTestCase):
                 elif self._driver_name in ["go"]:
                     self.assertIn("impersonation", exc.exception.msg)
 
-    @driver_feature(types.Feature.IMPERSONATION)
+    @driver_feature(types.Feature.IMPERSONATION,
+                    types.Feature.BOLT_4_4)
     def test_combined(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):

--- a/tests/stub/tx_begin_parameters/test_tx_begin_parameters.py
+++ b/tests/stub/tx_begin_parameters/test_tx_begin_parameters.py
@@ -17,6 +17,9 @@ from tests.stub.shared import StubServer
 #   Transaction timeout + write mode
 #   Read mode + transaction meta data + transaction timeout + bookmarks
 class TestTxBeginParameters(TestkitTestCase):
+
+    required_features = types.Feature.BOLT_4_4,
+
     def setUp(self):
         super().setUp()
         self._router = StubServer(9000)
@@ -98,14 +101,12 @@ class TestTxBeginParameters(TestkitTestCase):
             session.close()
             self._driver.close()
 
-    @driver_feature(types.Feature.BOLT_4_4)
     def test_access_mode_read(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
                 self._run("access_mode_read", routing, session_args=("r",))
                 self._server.done()
 
-    @driver_feature(types.Feature.BOLT_4_4)
     def test_tx_func_access_mode_read(self):
         for routing in (True, False):
             for session_access_mode in ("r", "w"):
@@ -115,7 +116,6 @@ class TestTxBeginParameters(TestkitTestCase):
                               session_args=(session_access_mode[0],),
                               tx_func_access_mode="r")
 
-    @driver_feature(types.Feature.BOLT_4_4)
     def test_access_mode_write(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -123,7 +123,6 @@ class TestTxBeginParameters(TestkitTestCase):
                           session_args=("w",))
                 self._server.done()
 
-    @driver_feature(types.Feature.BOLT_4_4)
     def test_tx_func_access_mode(self):
         for routing in (True, False):
             for session_access_mode in ("r", "w"):
@@ -132,7 +131,6 @@ class TestTxBeginParameters(TestkitTestCase):
                               session_args=(session_access_mode[0],),
                               tx_func_access_mode="w")
 
-    @driver_feature(types.Feature.BOLT_4_4)
     def test_parameters(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -140,7 +138,6 @@ class TestTxBeginParameters(TestkitTestCase):
                           session_args=("w",),
                           run_kwargs={"params": {"p": types.CypherInt(1)}})
 
-    @driver_feature(types.Feature.BOLT_4_4)
     def test_bookmarks(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -148,7 +145,6 @@ class TestTxBeginParameters(TestkitTestCase):
                           session_args=("w",),
                           session_kwargs={"bookmarks": ["b1", "b2"]})
 
-    @driver_feature(types.Feature.BOLT_4_4)
     def test_tx_meta(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -156,14 +152,12 @@ class TestTxBeginParameters(TestkitTestCase):
                           session_args=("w",),
                           tx_kwargs={"txMeta": {"akey": "aval"}})
 
-    @driver_feature(types.Feature.BOLT_4_4)
     def test_timeout(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
                 self._run("timeout", routing,
                           session_args=("w",), tx_kwargs={"timeout": 17})
 
-    @driver_feature(types.Feature.BOLT_4_4)
     def test_database(self):
         for routing in (True, False)[1:]:
             with self.subTest("routing" if routing else "direct"):
@@ -171,8 +165,7 @@ class TestTxBeginParameters(TestkitTestCase):
                           session_args=("w",),
                           session_kwargs={"database": "adb"})
 
-    @driver_feature(types.Feature.IMPERSONATION,
-                    types.Feature.BOLT_4_4)
+    @driver_feature(types.Feature.IMPERSONATION)
     def test_impersonation(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -183,7 +176,7 @@ class TestTxBeginParameters(TestkitTestCase):
                           })
 
     @driver_feature(types.Feature.IMPERSONATION,
-                    types.Feature.BOLT_4_4)
+                    types.Feature.BOLT_4_3)
     def test_impersonation_fails_on_v4x3(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):
@@ -207,8 +200,7 @@ class TestTxBeginParameters(TestkitTestCase):
                 elif self._driver_name in ["go"]:
                     self.assertIn("impersonation", exc.exception.msg)
 
-    @driver_feature(types.Feature.IMPERSONATION,
-                    types.Feature.BOLT_4_4)
+    @driver_feature(types.Feature.IMPERSONATION)
     def test_combined(self):
         for routing in (True, False):
             with self.subTest("routing" if routing else "direct"):

--- a/tests/stub/tx_run/test_tx_run.py
+++ b/tests/stub/tx_run/test_tx_run.py
@@ -9,6 +9,9 @@ from tests.stub.shared import StubServer
 
 
 class TestTxRun(TestkitTestCase):
+
+    required_features = types.Feature.BOLT_4_4,
+
     def setUp(self):
         super().setUp()
         self._router = StubServer(9000)

--- a/tests/stub/versions/test_versions.py
+++ b/tests/stub/versions/test_versions.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from nutkit.frontend import Driver
 from nutkit import protocol as types
 from tests.shared import (
+    driver_feature,
     get_dns_resolved_server_address,
     get_driver_name,
     TestkitTestCase,
@@ -103,26 +104,34 @@ class TestProtocolVersions(TestkitTestCase):
                     self.fail("Driver should have rejected the server agent")
             self._server.done()
 
-    def test_supports_bolt_4x0(self):
-        self._run("4x0")
-
-    def test_supports_bolt_4x1(self):
-        self._run("4x1")
-
-    def test_supports_bolt_4x2(self):
-        self._run("4x2")
-
-    def test_supports_bolt_4x3(self):
-        self._run("4x3")
-
-    def test_supports_bolt4x4(self):
-        self._run("4x4")
-
+    @driver_feature(types.Feature.BOLT_3_0)
     def test_supports_bolt_3x0(self):
         self._run("3")
 
+    @driver_feature(types.Feature.BOLT_4_0)
+    def test_supports_bolt_4x0(self):
+        self._run("4x0")
+
+    @driver_feature(types.Feature.BOLT_4_1)
+    def test_supports_bolt_4x1(self):
+        self._run("4x1")
+
+    @driver_feature(types.Feature.BOLT_4_2)
+    def test_supports_bolt_4x2(self):
+        self._run("4x2")
+
+    @driver_feature(types.Feature.BOLT_4_3)
+    def test_supports_bolt_4x3(self):
+        self._run("4x3")
+
+    @driver_feature(types.Feature.BOLT_4_4)
+    def test_supports_bolt4x4(self):
+        self._run("4x4")
+
     def test_server_version(self):
         for version in ("4x4", "4x3", "4x2", "4x1", "4x0", "3"):
+            if not self.driver_supports_bolt(version):
+                continue
             with self.subTest(version):
                 self._run(version, check_version=True)
 
@@ -157,6 +166,8 @@ class TestProtocolVersions(TestkitTestCase):
         if get_driver_name() in ["java", "javascript", "go", "dotnet"]:
             self.skipTest("Backend doesn't support server address in summary")
         for version in ("4x3", "4x2", "4x1", "4x0", "3"):
+            if not self.driver_supports_bolt(version):
+                continue
             with self.subTest(version):
                 self._run(version, check_server_address=True)
 
@@ -178,36 +189,42 @@ class TestProtocolVersions(TestkitTestCase):
         self.assertEqual(summary.server_info.address,
                          get_dns_resolved_server_address(self._server))
 
+    @driver_feature(types.Feature.BOLT_3_0)
     def test_should_reject_server_using_verify_connectivity_bolt_3x0(self):
         # TODO remove this block once fixed
         if get_driver_name() in ["dotnet", "go", "javascript"]:
             self.skipTest("Skipped because it needs investigation")
         self._test_should_reject_server_using_verify_connectivity(version="3")
 
+    @driver_feature(types.Feature.BOLT_4_0)
     def test_should_reject_server_using_verify_connectivity_bolt_4x0(self):
         # TODO remove this block once fixed
         if get_driver_name() in ["java", "dotnet", "go", "javascript"]:
             self.skipTest("Skipped because it needs investigation")
         self._test_should_reject_server_using_verify_connectivity(version="4.0")
 
+    @driver_feature(types.Feature.BOLT_4_1)
     def test_should_reject_server_using_verify_connectivity_bolt_4x1(self):
         # TODO remove this block once fixed
         if get_driver_name() in ["java", "dotnet", "go", "javascript"]:
             self.skipTest("Skipped because it needs investigation")
         self._test_should_reject_server_using_verify_connectivity(version="4.1")
 
+    @driver_feature(types.Feature.BOLT_4_2)
     def test_should_reject_server_using_verify_connectivity_bolt_4x2(self):
         # TODO remove this block once fixed
         if get_driver_name() in ["java", "dotnet", "go", "javascript"]:
             self.skipTest("Skipped because it needs investigation")
         self._test_should_reject_server_using_verify_connectivity(version="4.2")
 
+    @driver_feature(types.Feature.BOLT_4_3)
     def test_should_reject_server_using_verify_connectivity_bolt_4x3(self):
         # TODO remove this block once fixed
         if get_driver_name() in ["java", "dotnet", "go", "javascript"]:
             self.skipTest("Skipped because it needs investigation")
         self._test_should_reject_server_using_verify_connectivity(version="4.3")
 
+    @driver_feature(types.Feature.BOLT_4_4)
     def test_should_reject_server_using_verify_connectivity_bolt_4x4(self):
         # TODO remove this block once fixed
         if get_driver_name() in ["java", "dotnet", "go", "javascript"]:


### PR DESCRIPTION
Introduced feature flags:
 - `BOLT_3_0 = "Feature:Bolt:3.0"`
 - `BOLT_4_0 = "Feature:Bolt:4.0"`
 - `BOLT_4_1 = "Feature:Bolt:4.1"`
 - `BOLT_4_2 = "Feature:Bolt:4.2"`
 - `BOLT_4_3 = "Feature:Bolt:4.3"`
 - `BOLT_4_4 = "Feature:Bolt:4.4"`