### PR TITLE
Fix script invalid server messages sequence

### DIFF
--- a/tests/stub/routing/scripts/v4x1/router_yielding_any_security_failure.script
+++ b/tests/stub/routing/scripts/v4x1/router_yielding_any_security_failure.script
@@ -4,7 +4,6 @@ C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent":
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 *: RESET
 C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "*"} {"[mode]": "r", "db": "system", "[bookmarks]": ["foobar"]}
-S: SUCCESS {"fields": ["ttl", "servers"]}
 S: FAILURE {"code": "Neo.ClientError.Security.MadeUpSecurityError", "message": "I don't know what happened; it's classified as top secret :/"}
 {?
     C: PULL {"n": {"Z": "*"}}


### PR DESCRIPTION
The `routing/v4x1/router_yielding_any_security_failure.script` was cause a invalid scenario by given a `FAILURE` after a `SUCCESS` in response to a `RUN` command.

This sequence could only happen if the driver pipeline the `RUN` followed by `PULL` which is not the case in the script.