### PR TITLE
Add timeout to http integration test

### DIFF
--- a/tests/neo4j/test_direct_driver.py
+++ b/tests/neo4j/test_direct_driver.py
@@ -69,7 +69,8 @@ class TestDirectDriver(TestkitTestCase):
         scheme = get_neo4j_scheme()
         host, port = get_neo4j_host_and_http_port()
         uri = "%s://%s:%d" % (scheme, host, port)
-        self._driver = get_driver(self._backend, uri=uri)
+        self._driver = get_driver(self._backend, uri=uri,
+                                  connection_timeout_ms=500)
         with self.assertRaises(types.DriverError) as e:
             self._driver.verify_connectivity()
         if get_driver_name() in ["python"]:


### PR DESCRIPTION
Depending on the network configuration the connection attempt against the http
endpoint using bolt might not fail immediately but only after the set timeout.
Since that timeout is longer than the TestKit protocol timeout and longer than
we rally should take for one test, we should reduce the timeout in the driver
config.