### PR TITLE
Migrate cluster tests from Java driver

### DIFF
--- a/tests/stub/routing/scripts/v3/router_yielding_no_writers_adb_sequentially.script
+++ b/tests/stub/routing/scripts/v3/router_yielding_no_writers_adb_sequentially.script
@@ -1,0 +1,15 @@
+!: BOLT #VERSION#
+!: ALLOW RESTART
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007"#EXTR_HELLO_ROUTING_PROPS#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+{+
+    C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": #ROUTINGCTX#} {"[mode]": "r"}
+    S: SUCCESS {"fields": ["ttl", "servers"]}
+    C: PULL_ALL
+    S: RECORD [1000, [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": [], "role":"WRITE"}]]
+       SUCCESS {"type": "r"}
+    *: RESET
++}
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x1/router_yielding_no_writers_adb_sequentially.script
+++ b/tests/stub/routing/scripts/v4x1/router_yielding_no_writers_adb_sequentially.script
@@ -1,0 +1,15 @@
+!: BOLT #VERSION#
+!: ALLOW RESTART
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+{+
+    C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {"[mode]": "r", "db": "system", "[bookmarks]": []}
+    S: SUCCESS {"fields": ["ttl", "servers"]}
+    C: PULL {"n": -1}
+    S: RECORD [1000, [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": [], "role":"WRITE"}]]
+       SUCCESS {"type": "r"}
+    *: RESET
++}
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x3/router_yielding_no_writers_adb_sequentially.script
+++ b/tests/stub/routing/scripts/v4x3/router_yielding_no_writers_adb_sequentially.script
@@ -1,0 +1,12 @@
+!: BOLT #VERSION#
+!: ALLOW RESTART
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+{+
+    C: ROUTE #ROUTINGCTX# [] "adb"
+    S: SUCCESS {"rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": [], "role":"WRITE"}]}}
+    *: RESET
++}
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x4/router_yielding_no_writers_adb_sequentially.script
+++ b/tests/stub/routing/scripts/v4x4/router_yielding_no_writers_adb_sequentially.script
@@ -1,0 +1,12 @@
+!: BOLT #VERSION#
+!: ALLOW RESTART
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+{+
+    C: ROUTE #ROUTINGCTX# [] {"db": "adb"}
+    S: SUCCESS {"rt": { "ttl": 1000, "db": "adb", "servers": [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": [], "role":"WRITE"}]}}
+    *: RESET
++}
+?: GOODBYE


### PR DESCRIPTION
Cherry-pick: #316

* Migrate cluster tests from Java driver

The following ITs have been converted to Testkit stub tests:
- `CausalClusteringIT.shouldNotServeWritesWhenMajorityOfCoresAreDead` -> `RoutingV4x4.test_should_fail_when_writing_without_writers_using_session_run`
- `CausalClusteringIT.shouldServeReadsWhenMajorityOfCoresAreDead` -> `RoutingV4x4.test_should_serve_reads_and_fail_writes_when_no_writers_available` (existing)
- `CausalClusteringIT.shouldHandleGracefulLeaderSwitch` -> `RoutingV4x4.test_should_write_successfully_after_leader_switch_using_tx_run`

* Replace auto reset and remove unnecessary whitespace

* Move reset in stub scripts