### PR TITLE
Introduce Support for Websocket in Bolt Stub

### DIFF
--- a/boltstub/__init__.py
+++ b/boltstub/__init__.py
@@ -32,6 +32,7 @@ from threading import (
 )
 import time
 import traceback
+
 from .addressing import Address
 from .channel import Channel
 from .errors import ServerExit
@@ -41,8 +42,8 @@ from .parsing import (
     ScriptFailure,
 )
 from .wiring import (
-    ReadWakeup,
     create_wire,
+    ReadWakeup,
 )
 
 log = getLogger(__name__)

--- a/boltstub/__init__.py
+++ b/boltstub/__init__.py
@@ -111,13 +111,9 @@ class WebSocket (socket):
         payload_len = frame[1] & 0b0111_1111
 
         if payload_len == 126:
-            payload_len = struct.unpack(">H", self._socket.recv(2))
-            # print(payload_len)
-            # raise Exception('16bit')
+            payload_len, = struct.unpack(">H", self._socket.recv(2))
         elif payload_len == 127:
-            payload_len = struct.unpack(">Q", self._socket.recv(8))
-            # print(payload_len)
-            # raise Exception('64bit')
+            payload_len, = struct.unpack(">Q", self._socket.recv(8))
 
         if masked == 1:
             mask = self._socket.recv(4)
@@ -128,7 +124,10 @@ class WebSocket (socket):
             if mask == 0 \
             else bytearray([masked_payload[i] ^ mask[i % 4]
                             for i in range(payload_len)])
-
+        if opcode & 0b0000_1000 == 0b0000_1000:
+            return self.recv(__bufsize)
+        elif opcode == 0 and fin == 0:
+            return payload + self.recv(__bufsize)
         return payload
 
     def send(self, payload) -> int:

--- a/boltstub/tests/requirements.txt
+++ b/boltstub/tests/requirements.txt
@@ -1,3 +1,2 @@
 pytest
 pytest-mock
-random

--- a/boltstub/tests/requirements.txt
+++ b/boltstub/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-mock
+random

--- a/boltstub/tests/test_wiring.py
+++ b/boltstub/tests/test_wiring.py
@@ -184,6 +184,26 @@ class TestWebSocket:
         socket_mock.sendall.assert_called_once()
         socket_mock.sendall.assert_called_with(pong)
 
+    @pytest.mark.parametrize("reserved_control_frame", [
+        (b"\x0B\x00"),
+        (b"\x0C\x00"),
+        (b"\x0D\x00"),
+        (b"\x0E\x00"),
+        (b"\x0F\x00"),
+    ])
+    def test_recv_reserved_control_frame(self, reserved_control_frame, mocker):
+        socket_mock = mocker.Mock()
+        frame = b"\x82\x7E\x00\x7E"
+        payload = randbytes(126)
+        framed_payload = reserved_control_frame + frame + payload
+        socket_mock.recv.side_effect = TestWebSocket.mock_recv(framed_payload)
+
+        websocket = WebSocket(socket_mock)
+
+        received_payload = websocket.recv(1234)
+
+        assert received_payload == payload
+
     def test_recv_multiple_frames(self, mocker):
         payload_list = [
             (randbytes(0), b"\x02\x00"),

--- a/boltstub/tests/test_wiring.py
+++ b/boltstub/tests/test_wiring.py
@@ -6,6 +6,7 @@ import pytest
 
 from ..wiring import (
     create_wire,
+    negotiate_socket,
     RegularSocket,
     WebSocket,
 )
@@ -287,3 +288,16 @@ def test_create_wire(mocker):
 
     assert wire._socket == regular_socket
     wrap_socket.assert_called_with(socket)
+
+
+def test_negotiate_socket_negotiate_regular_socket(mocker):
+    payload = b"\x60\x60\xB0\x17\x00\x00\x01\x04\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x00"  # noqa: E501
+    socket = mocker.Mock()
+    socket.recv.return_value = payload
+
+    negotiated_socket = negotiate_socket(socket)
+
+    assert isinstance(negotiated_socket,  RegularSocket)
+    assert negotiated_socket._socket == socket
+    assert negotiated_socket._cache == payload
+    socket.recv.assert_called_once()

--- a/boltstub/tests/test_wiring.py
+++ b/boltstub/tests/test_wiring.py
@@ -1,6 +1,6 @@
 
 from functools import reduce
-from random import randbytes
+from random import getrandbits
 
 import pytest
 
@@ -10,6 +10,10 @@ from ..wiring import (
     RegularSocket,
     WebSocket,
 )
+
+
+def randbytes(size):
+    return bytearray(getrandbits(8) for _ in range(size))
 
 
 class TestRegularSocket:

--- a/boltstub/tests/test_wiring.py
+++ b/boltstub/tests/test_wiring.py
@@ -38,7 +38,7 @@ class TestRegularSocket:
             socket_mock.recv.return_value = expected
             regular_socket = RegularSocket(socket_mock, cache)
 
-            _ = regular_socket.recv(1024)
+            regular_socket.recv(1024)
             actual = regular_socket.recv(1024)
 
             assert actual == expected
@@ -295,7 +295,8 @@ def test_create_wire(mocker):
 
 
 def test_negotiate_socket_negotiate_regular_socket(mocker):
-    payload = b"\x60\x60\xB0\x17\x00\x00\x01\x04\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x00"  # noqa: E501
+    payload = (b"\x60\x60\xB0\x17\x00\x00\x01\x04\x00\x00\x00\x04\x00\x00\x00"
+               b"\x03\x00\x00\x00\x00")
     socket = mocker.Mock()
     socket.recv.return_value = payload
 
@@ -318,10 +319,12 @@ def test_negotiate_socket_negotiate_web_socket(mocker):
                     + "Sec-WebSocket-Version: 13\r\n\r\n")
     payload = payload_text.encode("utf-8")
 
-    response_payload_text = ("HTTP/1.1 101 Switching Protocols\r\n"
-                             + "Upgrade: websocket\r\n"
-                             + "Connection: Upgrade\r\n"
-                             + "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n")  # noqa: E501
+    response_payload_text = (
+        "HTTP/1.1 101 Switching Protocols\r\n"
+        + "Upgrade: websocket\r\n"
+        + "Connection: Upgrade\r\n"
+        + "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n"
+    )
 
     socket = mocker.Mock()
     socket.recv.return_value = payload

--- a/boltstub/tests/test_wiring.py
+++ b/boltstub/tests/test_wiring.py
@@ -141,7 +141,7 @@ class TestWebSocket:
 
     def test_recv_multiple_frames(self, mocker):
         payload_list = [
-            (randbytes(0), b"\x00\x00"),
+            (randbytes(0), b"\x02\x00"),
             (randbytes(7), b"\x00\x07"),
             (randbytes(125), b"\x00\x7D"),
             (randbytes(126), b"\x00\x7E\x00\x7E"),

--- a/boltstub/tests/test_wiring.py
+++ b/boltstub/tests/test_wiring.py
@@ -1,0 +1,68 @@
+
+import pytest
+
+from ..wiring import RegularSocket
+
+
+class TestRegularSocket:
+    class TestWhenCacheIsSupplied:
+
+        def test_recv_should_return_cache(self, mocker):
+            cache = b"abc"
+
+            socket_mock = mocker.Mock()
+            regular_socket = RegularSocket(socket_mock, cache)
+
+            received = regular_socket.recv(1024)
+
+            assert received == cache
+            socket_mock.recv.assert_not_called()
+
+        def test_accessing_the_socket_during_second_call(self, mocker):
+            cache = b"abc"
+            expected = b"barcelos"
+
+            socket_mock = mocker.Mock()
+            socket_mock.recv.return_value = expected
+            regular_socket = RegularSocket(socket_mock, cache)
+
+            _ = regular_socket.recv(1024)
+            actual = regular_socket.recv(1024)
+
+            assert actual == expected
+            socket_mock.recv.assert_called_with(1024)
+
+    class TestWhenCacheIsEmpty:
+
+        @pytest.mark.parametrize("empty_cache", [
+            (None),
+            (b"")
+        ])
+        def test_accessing_the_socket(self, empty_cache, mocker):
+            expected = b"barcelos"
+
+            socket_mock = mocker.Mock()
+            socket_mock.recv.return_value = expected
+            regular_socket = RegularSocket(socket_mock, empty_cache)
+
+            actual = regular_socket.recv(1024)
+
+            assert actual == expected
+            socket_mock.recv.assert_called_with(1024)
+
+    @pytest.mark.parametrize("method_name", [
+        ("close"),
+        ("send"),
+        ("sendall"),
+        ("settimeout"),
+        ("getsockname"),
+        ("getpeername")
+    ])
+    def test_proxying_sockets_members(self, method_name, mocker):
+        socket_mock = mocker.Mock()
+        regular_socket = RegularSocket(socket_mock, None)
+
+        wrapped_method = getattr(regular_socket, method_name)
+        original_method = getattr(socket_mock, method_name)
+
+        assert wrapped_method == original_method

--- a/boltstub/tests/test_wiring.py
+++ b/boltstub/tests/test_wiring.py
@@ -204,6 +204,24 @@ class TestWebSocket:
 
         assert received_payload == payload
 
+    def test_recv_masked_frame(self, mocker):
+        payload = bytearray(125)
+        mask = b"\x0A\x0B\x0C\x0C"
+        frame = b"\x82\xFD" + mask
+        masked_payload = bytearray(
+            [payload[i] ^ mask[i % 4] for i in range(125)])
+
+        framed_payload = frame + masked_payload
+
+        socket_mock = mocker.Mock()
+        socket_mock.recv.side_effect = TestWebSocket.mock_recv(framed_payload)
+
+        websocket = WebSocket(socket_mock)
+
+        received_payload = websocket.recv(1234)
+
+        assert received_payload == payload
+
     def test_recv_multiple_frames(self, mocker):
         payload_list = [
             (randbytes(0), b"\x02\x00"),

--- a/boltstub/tests/test_wiring.py
+++ b/boltstub/tests/test_wiring.py
@@ -139,6 +139,27 @@ class TestWebSocket:
 
         assert received_payload == payload
 
+    @pytest.mark.parametrize("payload,frame", [
+        (randbytes(0), b"\x82\x00"),
+        (randbytes(7), b"\x82\x07"),
+        (randbytes(125), b"\x82\x7D"),
+        (randbytes(126), b"\x82\x7E\x00\x7E"),
+        (randbytes(65535), b"\x82\x7E\xFF\xFF"),
+        (randbytes(65536), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x00"),
+        (randbytes(65537), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x01")
+    ])
+    def test_recv_pong(self, payload, frame, mocker):
+        socket_mock = mocker.Mock()
+        pong = b"\x0A\x00"
+        framed_payload = pong + frame + payload
+        socket_mock.recv.side_effect = TestWebSocket.mock_recv(framed_payload)
+
+        websocket = WebSocket(socket_mock)
+
+        received_payload = websocket.recv(1234)
+
+        assert received_payload == payload
+
     def test_recv_multiple_frames(self, mocker):
         payload_list = [
             (randbytes(0), b"\x02\x00"),

--- a/boltstub/tests/test_wiring.py
+++ b/boltstub/tests/test_wiring.py
@@ -5,6 +5,7 @@ from random import randbytes
 import pytest
 
 from ..wiring import (
+    create_wire,
     RegularSocket,
     WebSocket,
 )
@@ -272,3 +273,17 @@ class TestWebSocket:
             state["pos"] = end
             return payload_[start:end]
         return recv
+
+
+def test_create_wire(mocker):
+    socket = mocker.Mock()
+    read_wake_up = False
+    wrap_socket = mocker.Mock()
+
+    regular_socket = RegularSocket(socket, None)
+    wrap_socket.return_value = regular_socket
+
+    wire = create_wire(socket, read_wake_up, wrap_socket)
+
+    assert wire._socket == regular_socket
+    wrap_socket.assert_called_with(socket)

--- a/boltstub/wiring.py
+++ b/boltstub/wiring.py
@@ -166,7 +166,7 @@ class WebSocket:
         return getattr(self._socket, item)
 
     def recv(self, __bufsize) -> bytes:
-        """Receives data from the socket.
+        """Receive data from the socket.
 
         The `__bufsize` parameter is ignored. This method returns the entire
         frame payload and handles control frames doing the needed actions.
@@ -225,9 +225,7 @@ class WebSocket:
 
         return len(payload)
 
-    def sendall(self, payload):
-        """Send the payload over the socket inside a Websocket frame."""
-        self.send(payload)
+    sendall = send
 
 
 class Wire(object):

--- a/boltstub/wiring.py
+++ b/boltstub/wiring.py
@@ -182,7 +182,7 @@ class WebSocket:
         masked_payload = self._socket.recv(payload_len)
 
         payload = masked_payload \
-            if mask == 0 \
+            if masked == 0 \
             else bytearray([masked_payload[i] ^ mask[i % 4]
                             for i in range(payload_len)])
         if opcode & 0b0000_1000 == 0b0000_1000:
@@ -196,7 +196,7 @@ class WebSocket:
         payload_len = len(payload)
         if (payload_len < 126):
             frame += [payload_len]
-        elif payload_len <= 0x10000:
+        elif payload_len < 0x10000:
             frame += [126]
             frame += bytearray(struct.pack(">H", payload_len))
         else:
@@ -208,6 +208,9 @@ class WebSocket:
         self._socket.sendall(frame_to_send)
 
         return len(payload)
+
+    def sendall(self, payload):
+        self.send(payload)
 
 
 class Wire(object):

--- a/boltstub/wiring.py
+++ b/boltstub/wiring.py
@@ -23,7 +23,9 @@ as well as classes for modelling IP addresses, based on tuples.
 """
 
 
+import base64
 from functools import cached_property
+import hashlib
 from socket import (
     AF_INET,
     AF_INET6,
@@ -31,8 +33,6 @@ from socket import (
     timeout,
 )
 import struct
-import base64
-import hashlib
 
 BOLT_PORT_NUMBER = 7687
 HTTP_HEADER_MIN_SIZE = 26  # BYTES
@@ -346,7 +346,7 @@ def negotiate_socket(_socket):
         encoding = "utf-8"
         encoded = __buffer.strip().decode(encoding)
         headers = encoded.strip().split("\r\n")
-        if 'Upgrade: websocket' not in headers:
+        if "Upgrade: websocket" not in headers:
             return False
         for h in headers:
             if "Sec-WebSocket-Key" in h:

--- a/boltstub/wiring.py
+++ b/boltstub/wiring.py
@@ -138,9 +138,9 @@ class IPv6Address(Address):
 class RegularSocket:
     """A socket with an already receive cached value."""
 
-    def __init__(self, socket_, cache_) -> None:
+    def __init__(self, socket_, cache) -> None:
         self._socket = socket_
-        self._cache = cache_
+        self._cache = cache
 
     def __getattr__(self, item):
         return getattr(self._socket, item)
@@ -364,7 +364,7 @@ class BrokenWireError(WireError):
 
 
 def negotiate_socket(socket_):
-    def try_to_negotiate_websocket(socket_, buffer_):
+    def try_to_negotiate_websocket(socket__, buffer_):
         encoding = "utf-8"
         encoded = buffer_.strip().decode(encoding)
         headers = encoded.strip().split("\r\n")
@@ -382,7 +382,7 @@ def negotiate_socket(socket_):
                     + "Connection: Upgrade\r\n"
                     + "Sec-WebSocket-Accept: %s\r\n\r\n") % (base64_key)
         encoded_response = response.encode(encoding)
-        socket_.sendall(encoded_response)
+        socket__.sendall(encoded_response)
         return True
 
     buffer = socket_.recv(1024)

--- a/boltstub/wiring.py
+++ b/boltstub/wiring.py
@@ -187,7 +187,7 @@ class WebSocket:
                             for i in range(payload_len)])
         if opcode & 0b0000_1000 == 0b0000_1000:
             return self.recv(__bufsize)
-        elif opcode == 0 and fin == 0:
+        elif fin == 0:
             return payload + self.recv(__bufsize)
         return payload
 

--- a/boltstub/wiring.py
+++ b/boltstub/wiring.py
@@ -136,6 +136,8 @@ class IPv6Address(Address):
 
 
 class RegularSocket:
+    """A socket with an already receive cached value."""
+
     def __init__(self, _socket, _cache) -> None:
         self._socket = _socket
         self._cache = _cache
@@ -152,6 +154,11 @@ class RegularSocket:
 
 
 class WebSocket:
+    """Implementation of Websockets [rfc6455].
+
+    This implementation doesn't support extensions
+    """
+
     def __init__(self, _socket) -> None:
         self._socket = _socket
 
@@ -159,6 +166,11 @@ class WebSocket:
         return getattr(self._socket, item)
 
     def recv(self, __bufsize) -> bytes:
+        """Receives data from the socket.
+
+        The `__bufsize` parameter is ignored. This method returns the entire
+        frame payload and handles control frames doing the needed actions.
+        """
         frame = self._socket.recv(2)
         if len(frame) == 0:
             return None
@@ -195,6 +207,7 @@ class WebSocket:
         return payload
 
     def send(self, payload) -> int:
+        """Send the payload over the socket inside a Websocket frame."""
         frame = [0b1000_0010]
         payload_len = len(payload)
         if (payload_len < 126):
@@ -213,6 +226,7 @@ class WebSocket:
         return len(payload)
 
     def sendall(self, payload):
+        """Send the payload over the socket inside a Websocket frame."""
         self.send(payload)
 
 

--- a/boltstub/wiring.py
+++ b/boltstub/wiring.py
@@ -37,6 +37,7 @@ import struct
 BOLT_PORT_NUMBER = 7687
 HTTP_HEADER_MIN_SIZE = 26  # BYTES
 MAGIC_WS_STRING = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+PONG = b"\x0A\x00"
 
 
 class ReadWakeup(timeout):
@@ -186,6 +187,8 @@ class WebSocket:
             else bytearray([masked_payload[i] ^ mask[i % 4]
                             for i in range(payload_len)])
         if opcode & 0b0000_1000 == 0b0000_1000:
+            if opcode == 0x09:  # PING
+                self._socket.sendall(PONG)
             return self.recv(__bufsize)
         elif fin == 0:
             return payload + self.recv(__bufsize)

--- a/boltstub/wiring.py
+++ b/boltstub/wiring.py
@@ -338,6 +338,10 @@ class Wire(object):
         """
         return Address(self.__socket.getpeername())
 
+    @property
+    def _socket(self):
+        return self.__socket
+
 
 class WireError(OSError):
     """Raised when a connection error occurs."""


### PR DESCRIPTION
The support for Websockets in the Bolt Stub is need for testing the javascript driver in the browser.

The socket negotiation is done during the `BoltStubRequestHandler.setup` creating the wire using the `create_wire` function. This function handles the WebSocket negotiation and return the Wire with the correct socket negotiated.

The `WebSocket` implements read and receive data using the websockets frames and handle the control frames. This class doesn't not fulfil the whole `rfc6455` implementation because it always treat the payload as binary (which is the only kind of payload we use). The `negotiate_protocol` function also doesn't implement the whole `rfc6455` for negotiate websocket, It doesn't support extensions since it's not needed for BoltStub usecase.

PS: `RegularSocket` and `WebSocket` only implement and test the methods used by `Wire`  