### PR TITLE
Migrate Java IT test

### DIFF
--- a/tests/stub/routing/scripts/v3/reader_tx_with_unexpected_interruption_on_second_run.script
+++ b/tests/stub/routing/scripts/v3/reader_tx_with_unexpected_interruption_on_second_run.script
@@ -16,4 +16,3 @@ C: BEGIN {"mode": "r"}
 S: SUCCESS {}
 C: RUN "RETURN 1 as n" {} {}
 S: <EXIT>
-?: GOODBYE

--- a/tests/stub/routing/scripts/v3/reader_tx_with_unexpected_interruption_on_second_run.script
+++ b/tests/stub/routing/scripts/v3/reader_tx_with_unexpected_interruption_on_second_run.script
@@ -1,0 +1,19 @@
+!: BOLT #VERSION#
+
+A: HELLO {"{}": "*"}
+*: RESET
+C: BEGIN {"mode": "r"}
+S: SUCCESS {}
+C: RUN "RETURN 1 as n" {} {}
+S: SUCCESS {"fields": ["n"]}
+C: PULL_ALL
+S: RECORD [1]
+   SUCCESS {"type": "r"}
+C: COMMIT
+S: SUCCESS {}
+*: RESET
+C: BEGIN {"mode": "r"}
+S: SUCCESS {}
+C: RUN "RETURN 1 as n" {} {}
+S: <EXIT>
+?: GOODBYE

--- a/tests/stub/routing/scripts/v3/router_yielding_writer1_sequentially.script
+++ b/tests/stub/routing/scripts/v3/router_yielding_writer1_sequentially.script
@@ -1,0 +1,15 @@
+!: BOLT #VERSION#
+!: ALLOW RESTART
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007"#EXTR_HELLO_ROUTING_PROPS#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+{+
+    C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": #ROUTINGCTX#} {"[mode]": "r"}
+    S: SUCCESS {"fields": ["ttl", "servers"]}
+    C: PULL_ALL
+    S: RECORD [1000, [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020"], "role":"WRITE"}]]
+       SUCCESS {"type": "r"}
+    *: RESET
++}
+?: GOODBYE

--- a/tests/stub/routing/scripts/v3/writer_with_unexpected_interruption_on_second_run.script
+++ b/tests/stub/routing/scripts/v3/writer_with_unexpected_interruption_on_second_run.script
@@ -1,0 +1,12 @@
+!: BOLT #VERSION#
+
+A: HELLO {"{}": "*"}
+*: RESET
+C: RUN "RETURN 1 as n" {} {}
+S: SUCCESS {"fields": ["n"]}
+C: PULL_ALL
+S: SUCCESS {"type": "w"}
+*: RESET
+C: RUN "RETURN 1 as n" {} {}
+S: <EXIT>
+?: GOODBYE

--- a/tests/stub/routing/scripts/v3/writer_with_unexpected_interruption_on_second_run.script
+++ b/tests/stub/routing/scripts/v3/writer_with_unexpected_interruption_on_second_run.script
@@ -9,4 +9,3 @@ S: SUCCESS {"type": "w"}
 *: RESET
 C: RUN "RETURN 1 as n" {} {}
 S: <EXIT>
-?: GOODBYE

--- a/tests/stub/routing/scripts/v4x1/router_yielding_writer1_sequentially.script
+++ b/tests/stub/routing/scripts/v4x1/router_yielding_writer1_sequentially.script
@@ -1,0 +1,15 @@
+!: BOLT #VERSION#
+!: ALLOW RESTART
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+{+
+    C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {"[mode]": "r", "db": "system", "[bookmarks]": []}
+    S: SUCCESS {"fields": ["ttl", "servers"]}
+    C: PULL {"n": -1}
+    S: RECORD [1000, [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020"], "role":"WRITE"}]]
+       SUCCESS {"type": "r"}
+    *: RESET
++}
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x3/router_yielding_writer1_sequentially.script
+++ b/tests/stub/routing/scripts/v4x3/router_yielding_writer1_sequentially.script
@@ -1,0 +1,12 @@
+!: BOLT #VERSION#
+!: ALLOW RESTART
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+{+
+    C: ROUTE #ROUTINGCTX# [] "adb"
+    S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020"], "role":"WRITE"}]}}
+    *: RESET
++}
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x4/reader_tx_with_unexpected_interruption_on_second_run.script
+++ b/tests/stub/routing/scripts/v4x4/reader_tx_with_unexpected_interruption_on_second_run.script
@@ -1,0 +1,19 @@
+!: BOLT #VERSION#
+
+A: HELLO {"{}": "*"}
+*: RESET
+C: BEGIN {"mode": "r", "db": "adb"}
+S: SUCCESS {}
+C: RUN "RETURN 1 as n" {} {}
+S: SUCCESS {"fields": ["n"]}
+C: PULL {"n": 1000}
+S: RECORD [1]
+   SUCCESS {"type": "r"}
+C: COMMIT
+S: SUCCESS {}
+*: RESET
+C: BEGIN {"mode": "r", "db": "adb"}
+S: SUCCESS {}
+C: RUN "RETURN 1 as n" {} {}
+S: <EXIT>
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x4/reader_tx_with_unexpected_interruption_on_second_run.script
+++ b/tests/stub/routing/scripts/v4x4/reader_tx_with_unexpected_interruption_on_second_run.script
@@ -16,4 +16,3 @@ C: BEGIN {"mode": "r", "db": "adb"}
 S: SUCCESS {}
 C: RUN "RETURN 1 as n" {} {}
 S: <EXIT>
-?: GOODBYE

--- a/tests/stub/routing/scripts/v4x4/router_yielding_writer1_sequentially.script
+++ b/tests/stub/routing/scripts/v4x4/router_yielding_writer1_sequentially.script
@@ -1,0 +1,12 @@
+!: BOLT #VERSION#
+!: ALLOW RESTART
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+{+
+    C: ROUTE #ROUTINGCTX# [] {"db": "adb"}
+    S: SUCCESS { "rt": { "ttl": 1000, "db": "adb", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020"], "role":"WRITE"}]}}
+    *: RESET
++}
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x4/writer_with_unexpected_interruption_on_second_run.script
+++ b/tests/stub/routing/scripts/v4x4/writer_with_unexpected_interruption_on_second_run.script
@@ -1,0 +1,13 @@
+!: BOLT #VERSION#
+
+A: HELLO {"{}": "*"}
+*: RESET
+C: RUN "RETURN 1 as n" {} {"db": "adb"}
+S: SUCCESS {"fields": ["n"]}
+C: PULL {"n": 1000}
+S: RECORD [1]
+   SUCCESS {"type": "w"}
+*: RESET
+C: RUN "RETURN 1 as n" {} {"db": "adb"}
+S: <EXIT>
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x4/writer_with_unexpected_interruption_on_second_run.script
+++ b/tests/stub/routing/scripts/v4x4/writer_with_unexpected_interruption_on_second_run.script
@@ -10,4 +10,3 @@ S: RECORD [1]
 *: RESET
 C: RUN "RETURN 1 as n" {} {"db": "adb"}
 S: <EXIT>
-?: GOODBYE

--- a/tests/stub/routing/test_routing_v4x4.py
+++ b/tests/stub/routing/test_routing_v4x4.py
@@ -2587,21 +2587,21 @@ class RoutingV4x4(RoutingBase):
                 result = runner.run("RETURN 1 as n")
                 # drivers doing lazy loading should fail here
                 result.next()
-            
+
             if get_driver_name() in ["java"]:
                 self.assertEqual(
                     "org.neo4j.driver.exceptions.SessionExpiredException",
-                    exc.errorType
+                    exc.exception.errorType
                 )
             elif get_driver_name() in ["python"]:
                 self.assertEqual(
                     "<class 'neo4j.exceptions.SessionExpired'>",
-                    exc.errorType
+                    exc.exception.errorType
                 )
             elif get_driver_name() in ["ruby"]:
                 self.assertEqual(
                     "Neo4j::Driver::Exceptions::SessionExpiredException",
-                    exc.errorType
+                    exc.exception.errorType
                 )
 
         run_and_assert_error(write_session)
@@ -2612,7 +2612,6 @@ class RoutingV4x4(RoutingBase):
         read_session1.close()
         read_session2.close()
         route_count1 = self.route_call_count(self._routingServer1)
-        self.assertTrue(route_count1 > 0)
         self._writeServer1.done()
         self._readServer1.done()
         self._readServer2.done()
@@ -2628,7 +2627,7 @@ class RoutingV4x4(RoutingBase):
 
         driver.close()
         route_count2 = self.route_call_count(self._routingServer1)
-        self.assertTrue(route_count2 > route_count1)
+        self.assertTrue(route_count2 > route_count1 > 0)
         self._routingServer1.done()
         self._writeServer1.done()
         self._readServer1.done()

--- a/tests/stub/routing/test_routing_v4x4.py
+++ b/tests/stub/routing/test_routing_v4x4.py
@@ -2626,8 +2626,8 @@ class RoutingV4x4(RoutingBase):
         list(read_session1.run("RETURN 1 as n"))
 
         driver.close()
+        self._routingServer1.done()
         route_count2 = self.route_call_count(self._routingServer1)
         self.assertTrue(route_count2 > route_count1 > 0)
-        self._routingServer1.done()
         self._writeServer1.done()
         self._readServer1.done()


### PR DESCRIPTION
The following integration test has been converted to stub test:
`CausalClusteringIT.shouldRediscoverWhenConnectionsToAllCoresBreak` -> `Routing.test_should_rediscover_when_all_connections_fail_using_s_and_tx_run`