### PR TITLE
Migrate Java IT tests

### DIFF
--- a/tests/neo4j/test_bookmarks.py
+++ b/tests/neo4j/test_bookmarks.py
@@ -113,7 +113,7 @@ class TestBookmarks(TestkitTestCase):
                 params={"uuid": types.CypherString(test_execution_id)})
             result.consume()
 
-        for _i in range(0, expected_node_count):
+        for _ in range(expected_node_count):
             self._session = self._driver.session("w")
             self._session.write_transaction(create_node)
             bookmarks.append(self._session.last_bookmarks())

--- a/tests/neo4j/test_bookmarks.py
+++ b/tests/neo4j/test_bookmarks.py
@@ -48,7 +48,7 @@ class TestBookmarks(TestkitTestCase):
         self.assertEqual(len(bookmarks), 1)
 
         self._session.close()
-        self._session = self._driver.session("r")
+        self._session = self._driver.session("r", bookmarks)
         tx = self._session.begin_transaction()
         result = tx.run("MATCH (a:Thing {uuid:$uuid}) RETURN a",
                         params={"uuid": types.CypherString(unique_id)})
@@ -72,3 +72,136 @@ class TestBookmarks(TestkitTestCase):
 
         bookmarks = self._session.last_bookmarks()
         self.assertEqual(len(bookmarks), 0)
+
+    @cluster_unsafe_test
+    def test_fails_on_invalid_bookmark(self):
+        # TODO: remove this block once all languages work
+        if get_driver_name() in ["javascript"]:
+            self.skipTest("Fails the exception code assertion")
+        self._session = self._driver.session(
+            "w", ["hi, this is an invalid bookmark"])
+        with self.assertRaises(types.DriverError) as exc:
+            tx = self._session.begin_transaction()
+            result = tx.run("RETURN 1")
+            result.next()
+        if get_driver_name() in ["java"]:
+            self.assertEqual(
+                "org.neo4j.driver.exceptions.ClientException",
+                exc.exception.errorType
+            )
+        elif get_driver_name() in ["python"]:
+            self.assertEqual(
+                "<class 'neo4j.exceptions.ClientError'>",
+                exc.exception.errorType
+            )
+        elif get_driver_name() in ["ruby"]:
+            self.assertEqual(
+                "Neo4j::Driver::Exceptions::ClientException",
+                exc.exception.errorType
+            )
+        self.assertEqual("Neo.ClientError.Transaction.InvalidBookmark",
+                         exc.exception.code)
+
+    def test_can_handle_multiple_bookmarks(self):
+        bookmarks = []
+        expected_node_count = 5
+        test_execution_id = uuid4().hex
+
+        def create_node(tx):
+            result = tx.run(
+                "CREATE (t:MultipleBookmarksTest {testId:$uuid})",
+                params={"uuid": types.CypherString(test_execution_id)})
+            result.consume()
+
+        for _i in range(0, expected_node_count):
+            self._session = self._driver.session("w")
+            self._session.write_transaction(create_node)
+            bookmarks.append(self._session.last_bookmarks())
+            self._session.close()
+
+        bookmarks = [bookmark for sublist in bookmarks for bookmark in sublist]
+        self._session = self._driver.session("r", bookmarks)
+
+        def get_node_count(tx):
+            result = tx.run(
+                "MATCH (t:MultipleBookmarksTest {testId:$uuid})"
+                " RETURN count(t)",
+                params={"uuid": types.CypherString(test_execution_id)})
+            record = result.next()
+            return record.values[0]
+
+        count = self._session.read_transaction(get_node_count)
+        self.assertEqual(types.CypherInt(expected_node_count), count)
+
+    @cluster_unsafe_test
+    def test_can_pass_write_bookmark_into_write_session(self):
+        test_execution_id = uuid4().hex
+        self._session = self._driver.session("w")
+        tx = self._session.begin_transaction()
+        result = tx.run(
+            "CREATE (t:AccessModeTest {testId:$uuid})",
+            params={"uuid": types.CypherString(test_execution_id)})
+        result.consume()
+        tx.commit()
+        bookmarks = self._session.last_bookmarks()
+        self._session.close()
+
+        self._session = self._driver.session("w", bookmarks)
+        tx = self._session.begin_transaction()
+        result = tx.run(
+            "MATCH (t:AccessModeTest {testId:$uuid})"
+            " RETURN count(t)",
+            params={"uuid": types.CypherString(test_execution_id)})
+        record = result.next()
+        node_count = record.values[0]
+        tx.commit()
+
+        self.assertEqual(types.CypherInt(1), node_count)
+
+    @cluster_unsafe_test
+    def test_can_pass_read_bookmark_into_write_session(self):
+        test_execution_id = uuid4().hex
+        self._session = self._driver.session("w")
+        tx = self._session.begin_transaction()
+        result = tx.run(
+            "CREATE (t:AccessModeTest {testId:$uuid})",
+            params={"uuid": types.CypherString(test_execution_id)})
+        result.consume()
+        tx.commit()
+        bookmarks = self._session.last_bookmarks()
+        self._session.close()
+
+        self._session = self._driver.session("r", bookmarks)
+        tx = self._session.begin_transaction()
+        result = tx.run(
+            "MATCH (t:AccessModeTest {testId:$uuid})"
+            " RETURN count(t)",
+            params={"uuid": types.CypherString(test_execution_id)})
+        record = result.next()
+        node_count1 = record.values[0]
+        tx.commit()
+        bookmarks = self._session.last_bookmarks()
+        self._session.close()
+
+        self._session = self._driver.session("w", bookmarks)
+        tx = self._session.begin_transaction()
+        result = tx.run(
+            "CREATE (t:AccessModeTest {testId:$uuid})",
+            params={"uuid": types.CypherString(test_execution_id)})
+        result.consume()
+        tx.commit()
+        bookmarks = self._session.last_bookmarks()
+        self._session.close()
+
+        self._session = self._driver.session("r", bookmarks)
+        tx = self._session.begin_transaction()
+        result = tx.run(
+            "MATCH (t:AccessModeTest {testId:$uuid})"
+            " RETURN count(t)",
+            params={"uuid": types.CypherString(test_execution_id)})
+        record = result.next()
+        node_count2 = record.values[0]
+        tx.commit()
+
+        self.assertEqual(types.CypherInt(1), node_count1)
+        self.assertEqual(types.CypherInt(2), node_count2)

--- a/tests/neo4j/test_bookmarks.py
+++ b/tests/neo4j/test_bookmarks.py
@@ -174,8 +174,8 @@ class TestBookmarks(TestkitTestCase):
         self._session = self._driver.session("r", bookmarks)
         tx = self._session.begin_transaction()
         result = tx.run(
-            "MATCH (t:AccessModeTest {testId:$uuid})"
-            " RETURN count(t)",
+            "MATCH (t:AccessModeTest {testId:$uuid}) "
+            "RETURN count(t)",
             params={"uuid": types.CypherString(test_execution_id)})
         record = result.next()
         node_count1 = record.values[0]

--- a/tests/neo4j/test_bookmarks.py
+++ b/tests/neo4j/test_bookmarks.py
@@ -196,8 +196,8 @@ class TestBookmarks(TestkitTestCase):
         self._session = self._driver.session("r", bookmarks)
         tx = self._session.begin_transaction()
         result = tx.run(
-            "MATCH (t:AccessModeTest {testId:$uuid})"
-            " RETURN count(t)",
+            "MATCH (t:AccessModeTest {testId:$uuid}) "
+            "RETURN count(t)",
             params={"uuid": types.CypherString(test_execution_id)})
         record = result.next()
         node_count2 = record.values[0]


### PR DESCRIPTION
Tests:
- `CausalClusteringIT.beginTransactionThrowsForInvalidBookmark` -> `TestBookmarks.test_fails_on_invalid_bookmark`, a similar case is also covered by `Routing.test_should_fail_with_routing_failure_on_invalid_bookmark_discovery_failure`
- `CausalClusteringIT.shouldAcceptMultipleBookmarks` -> `TestBookmarks.test_can_handle_multiple_bookmarks`
- `CausalClusteringIT.bookmarksShouldWorkWithDriverPinnedToSingleServer` -> `TestBookmarks.test_can_pass_write_bookmark_into_write_session` (Similar test, the original had dependency on constant leader. The suggested test seems to closely match expectation of bookmark behaviour on a single node.)
- `CausalClusteringIT.shouldUseBookmarkFromAReadSessionInAWriteSession` -> `TestBookmarks.test_can_pass_read_bookmark_into_write_session` (Similar test, the original had dependency on constant leader. The suggested test seems to closely match expectation of bookmark behaviour on a single node.)
- `CausalClusteringIT.sessionCreationShouldFailIfCallingDiscoveryProcedureOnEdgeServer` -> `Routing.test_should_fail_discovery_when_router_fails_with_procedure_not_found_code` (Similar test, the original was actually skipped because builds run with 4.x series.)