### PR TITLE
Migrate Java IT tests to Testkit

### DIFF
--- a/nutkit/frontend/driver.py
+++ b/nutkit/frontend/driver.py
@@ -7,7 +7,9 @@ class Driver:
                  resolver_fn=None, domain_name_resolver_fn=None,
                  connection_timeout_ms=None, fetch_size=None,
                  max_tx_retry_time_ms=None, encrypted=None,
-                 trusted_certificates=None):
+                 trusted_certificates=None, liveness_check_timeout_ms=None,
+                 max_connection_pool_size=None,
+                 connection_acquisition_timeout_ms=None):
         self._backend = backend
         self._resolver_fn = resolver_fn
         self._domain_name_resolver_fn = domain_name_resolver_fn
@@ -17,7 +19,11 @@ class Driver:
             domainNameResolverRegistered=domain_name_resolver_fn is not None,
             connectionTimeoutMs=connection_timeout_ms,
             fetchSize=fetch_size, maxTxRetryTimeMs=max_tx_retry_time_ms,
-            encrypted=encrypted, trustedCertificates=trusted_certificates)
+            encrypted=encrypted, trustedCertificates=trusted_certificates,
+            liveness_check_timeout_ms=liveness_check_timeout_ms,
+            max_connection_pool_size=max_connection_pool_size,
+            connection_acquisition_timeout_ms=connection_acquisition_timeout_ms
+        )
         res = backend.send_and_receive(req)
         if not isinstance(res, protocol.Driver):
             raise Exception("Should be Driver but was %s" % res)
@@ -85,4 +91,11 @@ class Driver:
         res = self._backend.send_and_receive(req)
         if not isinstance(res, protocol.RoutingTable):
             raise Exception("Should be RoutingTable")
+        return res
+
+    def get_connection_pool_metrics(self, address):
+        req = protocol.GetConnectionPoolMetrics(self._driver.id, address)
+        res = self._backend.send_and_receive(req)
+        if not isinstance(res, protocol.ConnectionPoolMetrics):
+            raise Exception("Should be ConnectionPoolMetrics")
         return res

--- a/nutkit/protocol/feature.py
+++ b/nutkit/protocol/feature.py
@@ -24,6 +24,8 @@ class Feature(Enum):
     # ...+s: enforce SSL + verify  server's signature with system's trust store
     # ...+ssc: enforce SSL but do not verify the server's signature at all
     API_SSL_SCHEMES = "Feature:API:SSLSchemes"
+    # The driver supports connection liveness check.
+    API_LIVENESS_CHECK = "Feature:API:Liveness.Check"
     # The driver supports single-sign-on (SSO) by providing a bearer auth token
     # API.
     AUTH_BEARER = "Feature:Auth:Bearer"
@@ -127,3 +129,15 @@ class Feature(Enum):
     # Temporary driver feature that will be removed when all official driver
     # backends have implemented the TransactionClose request
     TMP_TRANSACTION_CLOSE = "Temporary:TransactionClose"
+    # Temporary driver feature that will be removed when all official driver
+    # backends have implemented the max connection pool size config.
+    TMP_DRIVER_MAX_CONNECTION_POOL_SIZE = \
+        "Temporary:DriverMaxConnectionPoolSize"
+    # Temporary driver feature that will be removed when all official driver
+    # backends have implemented the connection acquisition timeout config.
+    TMP_CONNECTION_ACQUISITION_TIMEOUT = \
+        "Temporary:ConnectionAcquisitionTimeout"
+    # Temporary driver feature that will be removed when all official driver
+    # backends have implemented the GetConnectionPoolMetrics request.
+    TMP_GET_CONNECTION_POOL_METRICS = \
+        "Temporary:GetConnectionPoolMetrics"

--- a/nutkit/protocol/requests.py
+++ b/nutkit/protocol/requests.py
@@ -49,7 +49,9 @@ class NewDriver:
         self, uri, authToken, userAgent=None, resolverRegistered=False,
         domainNameResolverRegistered=False, connectionTimeoutMs=None,
         fetchSize=None, maxTxRetryTimeMs=None, encrypted=None,
-        trustedCertificates=None
+        trustedCertificates=None, liveness_check_timeout_ms=None,
+        max_connection_pool_size=None,
+        connection_acquisition_timeout_ms=None
     ):
         # Neo4j URI to connect to
         self.uri = uri
@@ -71,6 +73,19 @@ class NewDriver:
         assert hasattr(Feature, "TMP_DRIVER_MAX_TX_RETRY_TIME")
         if maxTxRetryTimeMs is not None:
             self.maxTxRetryTimeMs = maxTxRetryTimeMs
+        if liveness_check_timeout_ms is not None:
+            self.livenessCheckTimeoutMs = liveness_check_timeout_ms
+        # TODO: remove assertion and condition as soon as all drivers support
+        #       driver-scoped max connection pool size config
+        assert hasattr(Feature, "TMP_DRIVER_MAX_CONNECTION_POOL_SIZE")
+        if max_connection_pool_size is not None:
+            self.maxConnectionPoolSize = max_connection_pool_size
+        # TODO: remove assertion and condition as soon as all drivers support
+        #       driver-scoped connection acquisition timeout config
+        assert hasattr(Feature, "TMP_CONNECTION_ACQUISITION_TIMEOUT")
+        if connection_acquisition_timeout_ms is not None:
+            self.connectionAcquisitionTimeoutMs = \
+                connection_acquisition_timeout_ms
         # (bool) whether to enable or disable encryption
         # field missing in message: use driver default (should be False)
         if encrypted is not None:
@@ -453,3 +468,17 @@ class GetRoutingTable:
     def __init__(self, driverId, database=None):
         self.driverId = driverId
         self.database = database
+
+
+class GetConnectionPoolMetrics:
+    """
+    Request the backend to return connection pool metrics for given address.
+
+    Note that depending on implementation driver might keep connection pools
+    indexed by domain names or resolved ip addresses.
+    The Backend should respond with a ConnectionPoolMetrics response.
+    """
+
+    def __init__(self, driverId, address):
+        self.driverId = driverId
+        self.address = address

--- a/nutkit/protocol/responses.py
+++ b/nutkit/protocol/responses.py
@@ -203,7 +203,7 @@ class Summary:
                 return True
 
         from tests.shared import get_driver_name
-        if get_driver_name() in ["java", "javascript", "go", "dotnet", "ruby"]:
+        if get_driver_name() in ["javascript", "go", "dotnet", "ruby"]:
             if "address" in data["serverInfo"]:
                 import warnings
                 warnings.warn(
@@ -373,6 +373,13 @@ class RoutingTable:
         self.routers = routers
         self.readers = readers
         self.writers = writers
+
+
+class ConnectionPoolMetrics:
+    def __init__(self, inUse, idle):
+        """Sent from the backend in response to GetConnectionPoolMetrics."""
+        self.in_use = inUse
+        self.idle = idle
 
 
 class BaseError(Exception):

--- a/tests/neo4j/test_bookmarks.py
+++ b/tests/neo4j/test_bookmarks.py
@@ -4,6 +4,7 @@ import nutkit.protocol as types
 from tests.neo4j.shared import (
     cluster_unsafe_test,
     get_driver,
+    get_server_info,
 )
 from tests.shared import (
     get_driver_name,
@@ -239,3 +240,29 @@ class TestBookmarks(TestkitTestCase):
 
         self.assertEqual(types.CypherInt(1), node_count1)
         self.assertEqual(types.CypherInt(2), node_count2)
+
+    def test_does_not_use_read_connection_for_write(self):
+        # TODO: remove this block once all languages work
+        if get_driver_name() in ["javascript", "go", "dotnet", "ruby"]:
+            self.skipTest("Requires address field in summary")
+        if not get_server_info().cluster:
+            self.skipTest("Not applicable to single node")
+
+        test_execution_id = uuid4().hex
+
+        def read(tx):
+            return tx.run("RETURN 1").consume()
+
+        def write(tx):
+            return tx.run(
+                "CREATE (t:RWConnectionTest {testId:$uuid})",
+                params={"uuid": types.CypherString(test_execution_id)}
+            ).consume()
+
+        self._session = self._driver.session("w")
+
+        read_summary = self._session.read_transaction(read)
+        create_summary = self._session.write_transaction(write)
+
+        self.assertNotEqual(read_summary.server_info.address,
+                            create_summary.server_info.address)

--- a/tests/neo4j/test_summary.py
+++ b/tests/neo4j/test_summary.py
@@ -8,6 +8,7 @@ from ..shared import (
 from .shared import (
     cluster_unsafe_test,
     get_driver,
+    get_neo4j_host_and_port,
     get_neo4j_resolved_host_and_port,
     get_server_info,
     requires_multi_db_support,
@@ -122,8 +123,9 @@ class TestSummary(TestkitTestCase):
         summary = self.get_summary("RETURN 1 AS number")
         if isinstance(summary, dict) and get_driver_name() in ["java"]:
             self.skipTest("Java 4.2 backend does not support summary")
-        self.assertEqual(summary.server_info.address,
-                         "%s:%s" % get_neo4j_resolved_host_and_port())
+        self.assertTrue(summary.server_info.address in
+                        ["%s:%s" % get_neo4j_resolved_host_and_port(),
+                         "%s:%s" % get_neo4j_host_and_port()])
 
     def _assert_counters(self, summary, nodes_created=0, nodes_deleted=0,
                          relationships_created=0, relationships_deleted=0,

--- a/tests/stub/routing/scripts/v3/router_and_writer_with_sequential_access_and_bookmark.script
+++ b/tests/stub/routing/scripts/v3/router_and_writer_with_sequential_access_and_bookmark.script
@@ -1,0 +1,28 @@
+!: BOLT #VERSION#
+!: ALLOW CONCURRENT
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007"#EXTR_HELLO_ROUTING_PROPS#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+{?
+    C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": #ROUTINGCTX#} {"[mode]": "r"}
+    S: SUCCESS {"fields": ["ttl", "servers"]}
+    C: PULL_ALL
+    S: RECORD [1000, [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9000"], "role":"WRITE"}]]
+       SUCCESS {"type": "r"}
+?}
+*: RESET
+{?
+    C: RUN "RETURN 1 as n" {} {}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL_ALL
+    S: SUCCESS {"type": "w", "bookmark": "NewBookmark"}
+    *: RESET
+    C: RUN "RETURN 1 as n" {} {"bookmarks": ["NewBookmark"]}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL_ALL
+    S: RECORD [1]
+       SUCCESS {"type": "r"}
+?}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v3/writer_tx_with_unexpected_interruption_on_status_check.script
+++ b/tests/stub/routing/scripts/v3/writer_tx_with_unexpected_interruption_on_status_check.script
@@ -1,0 +1,27 @@
+!: BOLT #VERSION#
+!: ALLOW CONCURRENT
+
+A: HELLO {"{}": "*"}
+*: RESET
+{{
+    C: BEGIN {}
+    S: SUCCESS {}
+    C: RUN "RETURN 1 as n" {} {}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL_ALL
+    S: SUCCESS {"type": "w"}
+    C: COMMIT
+    S: SUCCESS {}
+    C: RESET
+    S: SUCCESS {}
+    C: RESET
+    S: <EXIT>
+----
+    C: RUN "RETURN 1 as n" {} {}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL_ALL
+    S: RECORD [1]
+       SUCCESS {"type": "w"}
+    *: RESET
+    ?: GOODBYE
+}}

--- a/tests/stub/routing/scripts/v3/writer_with_sequential_access_and_bookmark.script
+++ b/tests/stub/routing/scripts/v3/writer_with_sequential_access_and_bookmark.script
@@ -1,0 +1,16 @@
+!: BOLT #VERSION#
+
+A: HELLO {"{}": "*"}
+*: RESET
+C: RUN "RETURN 1 as n" {} {}
+S: SUCCESS {"fields": ["n"]}
+C: PULL_ALL
+S: SUCCESS {"type": "w", "bookmark": "NewBookmark"}
+*: RESET
+C: RUN "RETURN 1 as n" {} {"bookmarks": ["NewBookmark"]}
+S: SUCCESS {"fields": ["n"]}
+C: PULL_ALL
+S: RECORD [1]
+   SUCCESS {"type": "r"}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x1/router_and_writer_with_sequential_access_and_bookmark.script
+++ b/tests/stub/routing/scripts/v4x1/router_and_writer_with_sequential_access_and_bookmark.script
@@ -1,0 +1,28 @@
+!: BOLT #VERSION#
+!: ALLOW CONCURRENT
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+{?
+    C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "database": "adb"} {"[mode]": "r", "db": "system", "[bookmarks]": "*"}
+    S: SUCCESS {"fields": ["ttl", "servers"]}
+    C: PULL {"n": -1}
+    S: RECORD [1000, [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9000"], "role":"WRITE"}]]
+       SUCCESS {"type": "r"}
+?}
+*: RESET
+{?
+    C: RUN "RETURN 1 as n" {} {"db": "adb"}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL {"n": 1000}
+    S: SUCCESS {"type": "w", "bookmark": "NewBookmark"}
+    *: RESET
+    C: RUN "RETURN 1 as n" {} {"db": "adb", "bookmarks": ["NewBookmark"]}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL {"n": 1000}
+    S: RECORD [1]
+       SUCCESS {"type": "r"}
+?}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x3/router_and_writer_with_sequential_access_and_bookmark.script
+++ b/tests/stub/routing/scripts/v4x3/router_and_writer_with_sequential_access_and_bookmark.script
@@ -1,0 +1,25 @@
+!: BOLT #VERSION#
+!: ALLOW CONCURRENT
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+{?
+    C: ROUTE #ROUTINGCTX# "*" "adb"
+    S: SUCCESS { "rt": { "ttl": 1000, "db": "adb", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9000"], "role":"WRITE"}]}}
+?}
+*: RESET
+{?
+    C: RUN "RETURN 1 as n" {} {"db": "adb"}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL {"n": 1000}
+    S: SUCCESS {"type": "w", "bookmark": "NewBookmark"}
+    *: RESET
+    C: RUN "RETURN 1 as n" {} {"db": "adb", "bookmarks": ["NewBookmark"]}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL {"n": 1000}
+    S: RECORD [1]
+       SUCCESS {"type": "r"}
+?}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x4/router_and_writer_with_sequential_access_and_bookmark.script
+++ b/tests/stub/routing/scripts/v4x4/router_and_writer_with_sequential_access_and_bookmark.script
@@ -1,0 +1,25 @@
+!: BOLT #VERSION#
+!: ALLOW CONCURRENT
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+{?
+    C: ROUTE #ROUTINGCTX# [] {"db": "adb"}
+    S: SUCCESS { "rt": { "ttl": 1000, "db": "adb", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9000"], "role":"WRITE"}]}}
+?}
+*: RESET
+{?
+    C: RUN "RETURN 1 as n" {} {"db": "adb"}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL {"n": 1000}
+    S: SUCCESS {"type": "w", "bookmark": "NewBookmark"}
+    *: RESET
+    C: RUN "RETURN 1 as n" {} {"db": "adb", "bookmarks": ["NewBookmark"]}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL {"n": 1000}
+    S: RECORD [1]
+       SUCCESS {"type": "r"}
+?}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x4/writer_tx_with_unexpected_interruption_on_status_check.script
+++ b/tests/stub/routing/scripts/v4x4/writer_tx_with_unexpected_interruption_on_status_check.script
@@ -1,0 +1,27 @@
+!: BOLT #VERSION#
+!: ALLOW CONCURRENT
+
+A: HELLO {"{}": "*"}
+*: RESET
+{{
+    C: BEGIN {"db": "adb"}
+    S: SUCCESS {}
+    C: RUN "RETURN 1 as n" {} {}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL {"n": 1000}
+    S: SUCCESS {"type": "w"}
+    C: COMMIT
+    S: SUCCESS {}
+    C: RESET
+    S: SUCCESS {}
+    C: RESET
+    S: <EXIT>
+----
+    C: RUN "RETURN 1 as n" {} {"db": "adb"}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL {"n": 1000}
+    S: RECORD [1]
+       SUCCESS {"type": "w"}
+    *: RESET
+    ?: GOODBYE
+}}

--- a/tests/stub/routing/scripts/v4x4/writer_with_sequential_access_and_bookmark.script
+++ b/tests/stub/routing/scripts/v4x4/writer_with_sequential_access_and_bookmark.script
@@ -1,0 +1,16 @@
+!: BOLT #VERSION#
+
+A: HELLO {"{}": "*"}
+*: RESET
+C: RUN "RETURN 1 as n" {} {"db": "adb"}
+S: SUCCESS {"fields": ["n"]}
+C: PULL {"n": 1000}
+S: SUCCESS {"type": "w", "bookmark": "NewBookmark"}
+*: RESET
+C: RUN "RETURN 1 as n" {} {"db": "adb", "bookmarks": ["NewBookmark"]}
+S: SUCCESS {"fields": ["n"]}
+C: PULL {"n": 1000}
+S: RECORD [1]
+   SUCCESS {"type": "r"}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/test_no_routing_v4x1.py
+++ b/tests/stub/routing/test_no_routing_v4x1.py
@@ -60,8 +60,9 @@ class NoRoutingV4x1(TestkitTestCase):
         session.close()
         driver.close()
 
-        self.assertEqual(summary.server_info.address,
-                         get_dns_resolved_server_address(self._server))
+        self.assertTrue(summary.server_info.address in
+                        [get_dns_resolved_server_address(self._server),
+                         self._server.address])
         self._server.done()
 
     def test_should_read_successfully_using_write_session_run(self):
@@ -84,8 +85,9 @@ class NoRoutingV4x1(TestkitTestCase):
         session.close()
         driver.close()
 
-        self.assertEqual(summary.server_info.address,
-                         get_dns_resolved_server_address(self._server))
+        self.assertTrue(summary.server_info.address in
+                        [get_dns_resolved_server_address(self._server),
+                         self._server.address])
         self._server.done()
 
     def test_should_exclude_routing_context(self):
@@ -114,8 +116,9 @@ class NoRoutingV4x1(TestkitTestCase):
         session.close()
         driver.close()
 
-        self.assertEqual(summary.server_info.address,
-                         get_dns_resolved_server_address(self._server))
+        self.assertTrue(summary.server_info.address in
+                        [get_dns_resolved_server_address(self._server),
+                         self._server.address])
         self._server.done()
 
     def test_should_send_custom_user_agent_using_write_session_run(self):
@@ -142,8 +145,9 @@ class NoRoutingV4x1(TestkitTestCase):
         session.close()
         driver.close()
 
-        self.assertEqual(summary.server_info.address,
-                         get_dns_resolved_server_address(self._server))
+        self.assertTrue(summary.server_info.address in
+                        [get_dns_resolved_server_address(self._server),
+                         self._server.address])
         self._server.done()
 
     def test_should_error_on_rollback_failure_using_tx_rollback(self):
@@ -176,8 +180,9 @@ class NoRoutingV4x1(TestkitTestCase):
         driver.close()
 
         self._assert_is_transient_rollback_exception(exc.exception)
-        self.assertEqual(summary.server_info.address,
-                         get_dns_resolved_server_address(self._server))
+        self.assertTrue(summary.server_info.address in
+                        [get_dns_resolved_server_address(self._server),
+                         self._server.address])
         self._server.done()
 
     @driver_feature(types.Feature.TMP_TRANSACTION_CLOSE)
@@ -206,8 +211,9 @@ class NoRoutingV4x1(TestkitTestCase):
         driver.close()
 
         self._assert_is_transient_rollback_exception(exc.exception)
-        self.assertEqual(summary.server_info.address,
-                         get_dns_resolved_server_address(self._server))
+        self.assertTrue(summary.server_info.address in
+                        [get_dns_resolved_server_address(self._server),
+                         self._server.address])
         self._server.done()
 
     def test_should_error_on_rollback_failure_using_session_close(
@@ -241,8 +247,9 @@ class NoRoutingV4x1(TestkitTestCase):
         driver.close()
 
         self._assert_is_transient_rollback_exception(exc.exception)
-        self.assertEqual(summary.server_info.address,
-                         get_dns_resolved_server_address(self._server))
+        self.assertTrue(summary.server_info.address in
+                        [get_dns_resolved_server_address(self._server),
+                         self._server.address])
         self._server.done()
 
     @driver_feature(types.Feature.TMP_DRIVER_FETCH_SIZE)
@@ -383,8 +390,9 @@ class NoRoutingV4x1(TestkitTestCase):
         driver.close()
 
         self._assert_is_transient_commit_exception(exc.exception)
-        self.assertEqual(summary.server_info.address,
-                         get_dns_resolved_server_address(self._server))
+        self.assertTrue(summary.server_info.address in
+                        [get_dns_resolved_server_address(self._server),
+                         self._server.address])
         self._server.done()
 
     def test_should_check_multi_db_support(self):
@@ -462,8 +470,9 @@ class NoRoutingV4x1(TestkitTestCase):
 
         self._assert_is_transient_commit_exception(
             exc.exception, expected_msg="Database shut down.")
-        self.assertEqual(summary.server_info.address,
-                         get_dns_resolved_server_address(self._server))
+        self.assertTrue(summary.server_info.address in
+                        [get_dns_resolved_server_address(self._server),
+                         self._server.address])
         self._server.done()
 
     def test_should_error_on_database_shutdown_using_tx_run(self):

--- a/tests/stub/routing/test_routing_v4x4.py
+++ b/tests/stub/routing/test_routing_v4x4.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import time
 
 from nutkit.frontend import Driver
 import nutkit.protocol as types
@@ -80,8 +81,9 @@ class RoutingV4x4(RoutingBase):
 
         self._routingServer1.done()
         self._readServer1.done()
-        self.assertEqual(summary.server_info.address,
-                         get_dns_resolved_server_address(self._readServer1))
+        self.assertTrue(summary.server_info.address in
+                        [get_dns_resolved_server_address(self._readServer1),
+                         self._readServer1.address])
         self.assertEqual([1], sequence)
 
     def test_should_read_successfully_from_reader_using_session_run_with_default_db_driver(  # noqa: E501
@@ -100,8 +102,9 @@ class RoutingV4x4(RoutingBase):
 
         self._routingServer1.done()
         self._readServer1.done()
-        self.assertEqual(summary.server_info.address,
-                         get_dns_resolved_server_address(self._readServer1))
+        self.assertTrue(summary.server_info.address in
+                        [get_dns_resolved_server_address(self._readServer1),
+                         self._readServer1.address])
         self.assertEqual([1], sequence)
 
     # Same test as for session.run but for transaction run.
@@ -122,8 +125,9 @@ class RoutingV4x4(RoutingBase):
 
         self._routingServer1.done()
         self._readServer1.done()
-        self.assertEqual(summary.server_info.address,
-                         get_dns_resolved_server_address(self._readServer1))
+        self.assertTrue(summary.server_info.address in
+                        [get_dns_resolved_server_address(self._readServer1),
+                         self._readServer1.address])
         self.assertEqual([1], sequence)
 
     def test_should_read_successfully_from_reader_using_tx_run_default_db(
@@ -144,8 +148,9 @@ class RoutingV4x4(RoutingBase):
 
         self._routingServer1.done()
         self._readServer1.done()
-        self.assertEqual(summary.server_info.address,
-                         get_dns_resolved_server_address(self._readServer1))
+        self.assertTrue(summary.server_info.address in
+                        [get_dns_resolved_server_address(self._readServer1),
+                         self._readServer1.address])
         self.assertEqual([1], sequence)
 
     def test_should_send_system_bookmark_with_route(self):
@@ -203,8 +208,9 @@ class RoutingV4x4(RoutingBase):
         self._readServer1.done()
         self.assertEqual([[1]], sequences)
         self.assertEqual(len(summaries), 1)
-        self.assertEqual(summaries[0].server_info.address,
-                         get_dns_resolved_server_address(self._readServer1))
+        self.assertTrue(summaries[0].server_info.address in
+                        [get_dns_resolved_server_address(self._readServer1),
+                         self._readServer1.address])
 
     def _should_fail_when_reading_from_unexpectedly_interrupting_reader_using_session_run(  # noqa: E501
             self, interrupting_reader_script):
@@ -434,8 +440,9 @@ class RoutingV4x4(RoutingBase):
 
         self._routingServer1.done()
         self._writeServer1.done()
-        assert (summary.server_info.address
-                == get_dns_resolved_server_address(self._writeServer1))
+        self.assertTrue(summary.server_info.address in
+                        [get_dns_resolved_server_address(self._writeServer1),
+                         self._writeServer1.address])
 
     # Checks that write server is used
     def test_should_write_successfully_on_writer_using_tx_run(self):
@@ -456,8 +463,9 @@ class RoutingV4x4(RoutingBase):
 
         self._routingServer1.done()
         self._writeServer1.done()
-        assert (summary.server_info.address
-                == get_dns_resolved_server_address(self._writeServer1))
+        self.assertTrue(summary.server_info.address in
+                        [get_dns_resolved_server_address(self._writeServer1),
+                         self._writeServer1.address])
 
     def test_should_write_successfully_on_writer_using_tx_function(self):
         # TODO remove this block once all languages work
@@ -485,8 +493,9 @@ class RoutingV4x4(RoutingBase):
         self._routingServer1.done()
         self._writeServer1.done()
         self.assertIsNotNone(res)
-        assert (summary.server_info.address
-                == get_dns_resolved_server_address(self._writeServer1))
+        self.assertTrue(summary.server_info.address in
+                        [get_dns_resolved_server_address(self._writeServer1),
+                         self._writeServer1.address])
 
     def test_should_write_successfully_on_leader_switch_using_tx_function(
             self):
@@ -2445,8 +2454,9 @@ class RoutingV4x4(RoutingBase):
         self.assertTrue(failed_on_run)
         self._routingServer1.done()
         self._readServer1.done()
-        self.assertEqual(summary.server_info.address,
-                         get_dns_resolved_server_address(self._readServer1))
+        self.assertTrue(summary.server_info.address in
+                        [get_dns_resolved_server_address(self._readServer1),
+                         self._readServer1.address])
         self.assertEqual([1], sequence)
 
     def test_should_fail_when_writing_without_writers_using_session_run(self):
@@ -2695,3 +2705,146 @@ class RoutingV4x4(RoutingBase):
         route_count2 = self.route_call_count(self._routingServer1)
         self.assertTrue(route_count2 > route_count1 > 0)
         self._writeServer1.done()
+
+    def test_should_get_rt_from_leader_w_and_r_via_leader_using_session_run(
+            self):
+        driver = Driver(self._backend, self._uri_with_context, self._auth,
+                        self._userAgent)
+        self.start_server(
+            self._routingServer1,
+            "router_and_writer_with_sequential_access_and_bookmark.script"
+        )
+
+        session = driver.session("w", database=self.adb)
+        session.run("RETURN 1 as n").consume()
+        records = list(session.run("RETURN 1 as n"))
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self.assertEqual([types.Record(values=[types.CypherInt(1)])], records)
+
+    def test_should_get_rt_from_follower_w_and_r_via_leader_using_session_run(
+            self):
+        # TODO remove this block once fixed
+        if get_driver_name() in ["javascript"]:
+            self.skipTest("Requires investigation")
+        driver = Driver(self._backend, self._uri_with_context, self._auth,
+                        self._userAgent)
+        self.start_server(self._routingServer1, "router_adb.script")
+        self.start_server(
+            self._writeServer1,
+            "writer_with_sequential_access_and_bookmark.script"
+        )
+
+        session = driver.session("w", database=self.adb)
+        session.run("RETURN 1 as n").consume()
+        records = list(session.run("RETURN 1 as n"))
+        session.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self.assertEqual([types.Record(values=[types.CypherInt(1)])], records)
+
+    @driver_feature(types.Feature.API_LIVENESS_CHECK,
+                    types.Feature.TMP_GET_CONNECTION_POOL_METRICS)
+    def test_should_drop_connections_failing_liveness_check(self):
+        driver = Driver(self._backend, self._uri_with_context, self._auth,
+                        self._userAgent, liveness_check_timeout_ms=0)
+        self.start_server(self._routingServer1,
+                          "router_adb_multi_no_bookmarks.script")
+        self.start_server(
+            self._writeServer1,
+            "writer_tx_with_unexpected_interruption_on_status_check.script"
+        )
+
+        sessions = []
+        txs = []
+
+        for _ in range(5):
+            session = driver.session("w", database=self.adb)
+            tx = session.begin_transaction()
+            sessions.append(session)
+            txs.append(tx)
+
+        for tx in txs:
+            tx.run("RETURN 1 as n").consume()
+            tx.commit()
+
+        for session in sessions:
+            session.close()
+
+        self._wait_for_idle_connections(driver, 5)
+
+        session = driver.session("w", database=self.adb)
+        session.run("RETURN 1 as n").consume()
+        session.close()
+
+        self._wait_for_idle_connections(driver, 1)
+        driver.close()
+        self._routingServer1.done()
+        self._writeServer1.done()
+
+    @driver_feature(types.Feature.TMP_DRIVER_MAX_CONNECTION_POOL_SIZE,
+                    types.Feature.TMP_CONNECTION_ACQUISITION_TIMEOUT)
+    def test_should_enforce_pool_size_per_cluster_member(self):
+        driver = Driver(self._backend, self._uri_with_context, self._auth,
+                        self._userAgent, max_connection_pool_size=1,
+                        connection_acquisition_timeout_ms=10)
+        self.start_server(self._routingServer1,
+                          "router_adb_multi_no_bookmarks.script")
+        self.start_server(self._writeServer1, "writer_tx.script")
+        self.start_server(self._writeServer2, "writer_tx.script")
+        self.start_server(self._readServer1, "reader_tx.script")
+
+        session0 = driver.session("w", database=self.adb)
+        tx0 = session0.begin_transaction()
+
+        session1 = driver.session("w", database=self.adb)
+        tx1 = session1.begin_transaction()
+
+        session2 = driver.session("w", database=self.adb)
+
+        with self.assertRaises(types.DriverError) as exc:
+            session2.begin_transaction()
+
+        if get_driver_name() in ["java"]:
+            self.assertEqual(
+                "org.neo4j.driver.exceptions.ClientException",
+                exc.exception.errorType
+            )
+            self.assertTrue("Unable to acquire connection from the "
+                            "pool within configured maximum time of 10ms"
+                            in exc.exception.msg)
+
+        session2.close()
+
+        session3 = driver.session("r", database=self.adb)
+        tx3 = session3.begin_transaction()
+        tx3.run("RETURN 1 as n").consume()
+        tx3.commit()
+        session3.close()
+
+        tx0.run("RETURN 1 as n").consume()
+        tx0.commit()
+        session0.close()
+        tx1.run("RETURN 1 as n").consume()
+        tx1.commit()
+        session1.close()
+        driver.close()
+
+        self._routingServer1.done()
+        self._writeServer1.done()
+        self._readServer1.done()
+
+    def _wait_for_idle_connections(self, driver, expected_idle_connections):
+        attempts = 0
+        while True:
+            metrics = driver.get_connection_pool_metrics(
+                self._writeServer1.address)
+            if metrics.idle == expected_idle_connections:
+                break
+            attempts += 1
+            if attempts == 10:
+                self.fail("Timeout out waiting for idle connections")
+            time.sleep(.1)


### PR DESCRIPTION
Migrated tests:
    - `CausalClusteringIT.shouldNotReuseReadConnectionForWriteTransaction` -> `TestBookmarks.test_does_not_use_read_connection_for_write`
    - `CausalClusteringIT.shouldExecuteReadAndWritesWhenDriverSuppliedWithAddressOfLeader` -> `Routing.test_should_get_rt_from_leader_w_and_r_via_leader_using_session_run`
    - `CausalClusteringIT.shouldExecuteReadAndWritesWhenDriverSuppliedWithAddressOfFollower` -> `Routing.test_should_get_rt_from_follower_w_and_r_via_leader_using_session_run`
    - `CausalClusteringIT.shouldDropBrokenOldConnections` -> `Routing.test_should_drop_connections_failing_liveness_check`
    - `CausalClusteringIT.shouldRespectMaxConnectionPoolSizePerClusterMember` -> `Routing.test_should_enforce_pool_size_per_cluster_member`

New Testkit features:
- `Feature:API:Liveness.Check`
- `Temporary:DriverMaxConnectionPoolSize`
- `Temporary:ConnectionAcquisitionTimeoutNanos`
- `Temporary:GetConnectionPoolMetrics`
