### PR TITLE
Use TeamCity's REST API for downloading artifacts

### DIFF
--- a/main.py
+++ b/main.py
@@ -85,9 +85,7 @@ def initialise_configurations():
             cluster=cluster,
             suite=version_without_drop,
             scheme=scheme,
-            download=teamcity.DockerImage(
-                "neo4j-%s-%s-docker-loadable.tar" % (edition, version)
-            ),
+            download=teamcity.DockerImage("neo4j-%s-%s" % (edition, version)),
             stress_test_duration=stress_test
         )
 
@@ -116,13 +114,13 @@ def initialise_configurations():
                            stress_test_)
         for (version_, enterprise_, cluster_, scheme_, stress_test_) in (
             # nightly build of official backwards-compatible version
-            ("4.3.7",     True,     True,     "neo4j", 60),
+            ("4.3",    True,        True,     "neo4j", 60),
             # latest version
-            ("4.4.0-dev", False,    False,    "bolt",   0),
-            ("4.4.0-dev", False,    False,    "neo4j",  0),
-            ("4.4.0-dev", True,     False,    "bolt",  90),
-            ("4.4.0-dev", True,     False,    "neo4j",  0),
-            ("4.4.0-dev", True,     True,     "neo4j", 90),
+            ("4.4",    False,       False,    "bolt",   0),
+            ("4.4",    False,       False,    "neo4j",  0),
+            ("4.4",    True,        False,    "bolt",  90),
+            ("4.4",    True,        False,    "neo4j",  0),
+            ("4.4",    True,        True,     "neo4j", 90),
         )
     ]
 

--- a/teamcity/download.py
+++ b/teamcity/download.py
@@ -1,31 +1,86 @@
+import json
 from os import getenv
 from urllib import request
 
+_ROOT = "https://live.neo4j-build.io"
+_API_ROOT = f"{_ROOT}/app/rest"
+_BUILD_LOCATOR = "buildType:DriversTestkitNeo4jDockers"
 
-def download_artifact(build_id, build_spec, path):
+
+class _JsonHandler(request.BaseHandler):
+    def http_request(self, req):
+        if not req.has_header("Accept"):
+            req.add_header("Accept", "application/json")
+        return req
+
+    @staticmethod
+    def _res_as_json(res):
+        def read():
+            if (
+                "Content-Type" not in res.headers
+                or res.headers["Content-Type"].lower() != "application/json"
+            ):
+                raise ValueError("Response is not json")
+            encoding = res.info().get_content_charset("utf-8")
+            data = res.read()
+            return json.loads(data.decode(encoding))
+        return read
+
+    def http_response(self, req, res):
+        res.read_json = self._res_as_json(res)
+        return res
+
+    https_request = http_request
+    https_response = http_response
+
+
+def _get_opener(json_=False):
+    handlers = []
+
+    if json_:
+        handlers.append(_JsonHandler())
+
+    password_manager = request.HTTPPasswordMgrWithDefaultRealm()
+    password_manager.add_password(
+        None, _ROOT, getenv("TEAMCITY_USER"), getenv("TEAMCITY_PASSWORD")
+    )
+    handlers.append(request.HTTPBasicAuthHandler(password_manager))
+    return request.build_opener(*handlers)
+
+
+def _list_artifacts(filters=None):
+    if filters is None:
+        filters = ()
+    path = \
+        f"{_API_ROOT}/builds/{_BUILD_LOCATOR}/artifacts/children/neo4j-docker"
+    artifacts = _get_opener(json_=True).open(path).read_json()
+    return [
+        artifact["content"]["href"]
+        for artifact in artifacts["file"]
+        if all(filter_ in artifact["name"] for filter_ in filters)
+    ]
+
+
+def _download_artifact(path):
     """
     Download a neo4j artifact from TeamCity.
 
     @returns: http response
     """
-    root = "https://live.neo4j-build.io"
-    path = "{}/repository/download/{}/{}/{}".format(root, build_id, build_spec,
-                                                    path)
-    user = getenv("TEAMCITY_USER")
-    pasw = getenv("TEAMCITY_PASSWORD")
-    password_mgr = request.HTTPPasswordMgrWithDefaultRealm()
-    password_mgr.add_password(None, root, user, pasw)
-    handler = request.HTTPBasicAuthHandler(password_mgr)
-    opener = request.build_opener(handler)
-    return opener.open(path)
+    path = _ROOT + path
+    return _get_opener().open(path)
 
 
 class DockerImage:
-    def __init__(self, name):
-        self.name = name
+    def __init__(self, *filters):
+        self.filters = filters
 
     def get(self):
-        return download_artifact(
-            "DriversTestkitNeo4jDockers", ".lastSuccessful",
-            "neo4j-docker/" + self.name
-        )
+        artifacts = _list_artifacts(filters=self.filters)
+        if not len(artifacts) == 1:
+            raise ValueError(
+                "Filter matched not exactly one image.\n"
+                f"Filters: {self.filters}\n"
+                f"Matches: {artifacts}"
+            )
+        return _download_artifact(artifacts[0])


### PR DESCRIPTION
This has the main advantage that TestKit does not break every time the nightly
Neo4j builds move to a new patch version.