### PR TITLE
Fixed error in a v4x3 routing script (#335)

### DIFF
--- a/tests/stub/routing/scripts/v4x3/router_and_writer_with_sequential_access_and_bookmark.script
+++ b/tests/stub/routing/scripts/v4x3/router_and_writer_with_sequential_access_and_bookmark.script
@@ -6,7 +6,7 @@ S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 *: RESET
 {?
     C: ROUTE #ROUTINGCTX# "*" "adb"
-    S: SUCCESS { "rt": { "ttl": 1000, "db": "adb", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9000"], "role":"WRITE"}]}}
+    S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9000"], "role":"WRITE"}]}}
     *: RESET
 ?}
 {?


### PR DESCRIPTION
* Fixed error in a v4x3 routing script

router_and_writer_with_sequential_access_and_bookmark.script had a routing table returned that contained a "db" 
key and value. This is incorrect for the 4.3 protocol, the "db" field was added in 4.4 as part of the impersonation implementation.