### PR TITLE
[4.4] Add test for in-use stale connection

### DIFF
--- a/tests/stub/authorization/scripts/v4x0/reader_return_1_failure_return_2_3_4_and_5_succeed.script
+++ b/tests/stub/authorization/scripts/v4x0/reader_return_1_failure_return_2_3_4_and_5_succeed.script
@@ -5,13 +5,13 @@ A: HELLO {"{}": "*"}
 *: RESET
 {+
     {{
-        C: RUN "RETURN 1 as n" {} {"mode": "r"}
+        C: RUN "AuthorizationExpired" {} {"mode": "r"}
         S: SUCCESS {"fields": ["n"]}
         C: PULL {"n": 1000}
         S: FAILURE {"code": "Neo.ClientError.Security.AuthorizationExpired", "message": "Authorization expired"}
            <EXIT>
     ----
-        C: RUN "RETURN 2 as n" {} {"mode": "r"}
+        C: RUN "INFINITE RECORDS UNTIL DISCARD" {} {"mode": "r"}
         S: SUCCESS {"fields": ["n"]}
         {+
             C: PULL {"n": 1}
@@ -21,7 +21,7 @@ A: HELLO {"{}": "*"}
         C: DISCARD {"n": -1}
         S: SUCCESS {}
     ----
-        C: RUN "RETURN 3 as n" {} {"mode": "r"}
+        C: RUN "ONE RECORD" {} {"mode": "r"}
         S: SUCCESS {"fields": ["n"]}
         C: PULL {"n": "*"}
         S: RECORD [1]

--- a/tests/stub/authorization/scripts/v4x0/reader_return_1_failure_return_2_3_4_and_5_succeed.script
+++ b/tests/stub/authorization/scripts/v4x0/reader_return_1_failure_return_2_3_4_and_5_succeed.script
@@ -30,26 +30,36 @@ A: HELLO {"{}": "*"}
         C: BEGIN {"mode": "r"}
         S: SUCCESS {}
 
-        C: RUN "RETURN 4 as n" {} {}
-        S: SUCCESS {"fields": ["n"]}
-        C: PULL {"n": "*"}
-        S: RECORD [1]
-           SUCCESS {"type": "r"}
+        {{
+            C: RUN "TX RUN 1/3 ONE RECORD" {} {}
+            S: SUCCESS {"fields": ["n"]}
+            C: PULL {"n": "*"}
+            S: RECORD [1]
+               SUCCESS {"type": "r"}
 
-        C: RUN "RETURN 4 as n" {} {}
-        S: SUCCESS {"fields": ["n"]}
-        C: PULL {"n": "*"}
-        S: RECORD [1]
-           SUCCESS {"type": "r"}
+            C: RUN "TX RUN 2/3 ONE RECORD" {} {}
+            S: SUCCESS {"fields": ["n"]}
+            C: PULL {"n": "*"}
+            S: RECORD [1]
+               SUCCESS {"type": "r"}
 
-        C: RUN "RETURN 4 as n" {} {}
-        S: SUCCESS {"fields": ["n"]}
-        C: PULL {"n": "*"}
-        S: RECORD [1]
-           SUCCESS {"type": "r"}
+            C: RUN "TX RUN 3/3 ONE RECORD" {} {}
+            S: SUCCESS {"fields": ["n"]}
+            C: PULL {"n": "*"}
+            S: RECORD [1]
+               SUCCESS {"type": "r"}
 
-        C: COMMIT
-        S: SUCCESS {}
+            C: COMMIT
+            S: SUCCESS {}
+        ----
+            C: RUN "TX RUN ONE RECORD" {} {}
+            S: SUCCESS {"fields": ["n"]}
+            C: PULL {"n": "*"}
+            S: RECORD [1]
+               SUCCESS {"type": "r"}
+            C: COMMIT
+            S: SUCCESS {}
+        }}
     }}
 
     *: RESET

--- a/tests/stub/authorization/scripts/v4x0/reader_return_1_failure_return_2_3_and_4_succeed.script
+++ b/tests/stub/authorization/scripts/v4x0/reader_return_1_failure_return_2_3_and_4_succeed.script
@@ -26,7 +26,32 @@ A: HELLO {"{}": "*"}
         C: PULL {"n": "*"}
         S: RECORD [1]
            SUCCESS {"type": "r"}
+    ----
+        C: BEGIN {"mode": "r"}
+        S: SUCCESS {}
+
+        C: RUN "RETURN 4 as n" {} {}
+        S: SUCCESS {"fields": ["n"]}
+        C: PULL {"n": "*"}
+        S: RECORD [1]
+           SUCCESS {"type": "r"}
+
+        C: RUN "RETURN 4 as n" {} {}
+        S: SUCCESS {"fields": ["n"]}
+        C: PULL {"n": "*"}
+        S: RECORD [1]
+           SUCCESS {"type": "r"}
+
+        C: RUN "RETURN 4 as n" {} {}
+        S: SUCCESS {"fields": ["n"]}
+        C: PULL {"n": "*"}
+        S: RECORD [1]
+           SUCCESS {"type": "r"}
+
+        C: COMMIT
+        S: SUCCESS {}
     }}
+
     *: RESET
 +}
 ?: GOODBYE

--- a/tests/stub/authorization/test_authorization.py
+++ b/tests/stub/authorization/test_authorization.py
@@ -808,7 +808,7 @@ class TestNoRoutingAuthorization(AuthorizationBase):
         accept_count = self._server.count_responses("<ACCEPT>")
 
         # fetching another connection and run a query to force
-        # drivers which lazy close the connection do it
+        # drivers which lazily close the connection do it
         session3 = driver.session("r")
         session3.run("RETURN 3 as n").next()
         session3.close()
@@ -880,14 +880,13 @@ class TestNoRoutingAuthorization(AuthorizationBase):
 
         list(tx1.run("RETURN 4 as n"))
 
-        tx1.commit()
-
         # now, when session1 has releases its connection, the driver should
         # remove the connection
         hangup_count_pre = self._server.count_responses("<HANGUP>")
+        tx1.commit()
         session1.close()
         # fetching another connection and run a query to force
-        # drivers which lazy close the connection do it
+        # drivers which lazily close the connection do it
         list(driver.session("r").run("RETURN 3 as n"))
         hangup_count_post = self._server.count_responses("<HANGUP>")
         self.assertEqual(hangup_count_pre + 1, hangup_count_post)

--- a/tests/stub/authorization/test_authorization.py
+++ b/tests/stub/authorization/test_authorization.py
@@ -788,7 +788,7 @@ class TestNoRoutingAuthorization(AuthorizationBase):
     def test_should_drop_connection_after_AuthorizationExpired(self):  # noqa: N802,E501
         self.start_server(
             self._server,
-            "reader_return_1_failure_return_2_3_and_4_succeed.script"
+            "reader_return_1_failure_return_2_3_4_and_5_succeed.script"
         )
         driver = Driver(self._backend, self._uri, self._auth,
                         user_agent=self._userAgent)
@@ -796,10 +796,10 @@ class TestNoRoutingAuthorization(AuthorizationBase):
         session1 = driver.session("r", fetch_size=1)
         session2 = driver.session("r")
 
-        session1.run("RETURN 2 as n").next()
+        session1.run("INFINITE RECORDS UNTIL DISCARD").next()
 
         with self.assertRaises(types.DriverError) as exc:
-            session2.run("RETURN 1 as n").next()
+            session2.run("AuthorizationExpired").next()
         self.assert_is_authorization_error(exc.exception)
 
         session2.close()
@@ -810,7 +810,7 @@ class TestNoRoutingAuthorization(AuthorizationBase):
         # fetching another connection and run a query to force
         # drivers which lazily close the connection do it
         session3 = driver.session("r")
-        session3.run("RETURN 3 as n").next()
+        session3.run("ONE RECORD").next()
         session3.close()
 
         hangup_count = self._server.count_responses("<HANGUP>")
@@ -825,7 +825,7 @@ class TestNoRoutingAuthorization(AuthorizationBase):
             self):
         self.start_server(
             self._server,
-            "reader_return_1_failure_return_2_3_and_4_succeed.script"
+            "reader_return_1_failure_return_2_3_4_and_5_succeed.script"
         )
 
         driver = Driver(self._backend, self._uri, self._auth,
@@ -834,15 +834,15 @@ class TestNoRoutingAuthorization(AuthorizationBase):
         session1 = driver.session("r", fetch_size=1)
         session2 = driver.session("r")
 
-        list(session1.run("RETURN 3 as n"))
+        list(session1.run("ONE RECORD"))
 
         with self.assertRaises(types.DriverError) as exc:
-            session2.run("RETURN 1 as n").next()
+            session2.run("AuthorizationExpired").next()
         self.assert_is_authorization_error(exc.exception)
 
         session2.close()
 
-        session1.run("RETURN 2 as n").next()
+        session1.run("INFINITE RECORDS UNTIL DISCARD").next()
         session1.close()
 
     @driver_feature(types.Feature.OPT_AUTHORIZATION_EXPIRED_TREATMENT)
@@ -850,8 +850,15 @@ class TestNoRoutingAuthorization(AuthorizationBase):
             self):
         self.start_server(
             self._server,
-            "reader_return_1_failure_return_2_3_and_4_succeed.script"
+            "reader_return_1_failure_return_2_3_4_and_5_succeed.script"
         )
+
+        def allocate_connections(n):
+            sessions = [driver.session("r") for _ in range(n)]
+            txs = [s.beginTransaction() for s in sessions]
+            [list(tx.run("TX RUN ONE RECORD")) for tx in txs]
+            [tx.commit() for tx in txs]
+            [s.close() for s in sessions]
 
         driver = Driver(self._backend, self._uri, self._auth,
                         user_agent=self._userAgent)
@@ -860,25 +867,28 @@ class TestNoRoutingAuthorization(AuthorizationBase):
         session2 = driver.session("r")
 
         tx1 = session1.begin_transaction()
-        list(tx1.run("RETURN 4 as n"))
+        list(tx1.run("TX RUN 1/3 ONE RECORD"))
 
         with self.assertRaises(types.DriverError) as exc:
-            session2.run("RETURN 1 as n").next()
+            session2.run("AuthorizationExpired").next()
         self.assert_is_authorization_error(exc.exception)
 
-        list(tx1.run("RETURN 4 as n"))
+        list(tx1.run("TX RUN 2/3 ONE RECORD"))
         # running a query in a session to make sure drivers that close
         # connections lazily, will encounter session1's connection which after
         # the AuthorizationExpired is flagged to be removed. BUT: it's still
         # in use by session1, so is must survive.
-        list(driver.session("r").run("RETURN 3 as n"))
+        allocate_connections(1)
 
         session2.close()
 
         # same as above!
-        list(driver.session("r").run("RETURN 3 as n"))
+        # allocating increasing number of connections makes sure the driver has
+        # to run through all existing connections and potentially clean them up
+        # before eventually deciding a new connection must be created
+        allocate_connections(2)
 
-        list(tx1.run("RETURN 4 as n"))
+        list(tx1.run("TX RUN 3/3 ONE RECORD"))
 
         # now, when session1 has releases its connection, the driver should
         # remove the connection
@@ -887,8 +897,10 @@ class TestNoRoutingAuthorization(AuthorizationBase):
         session1.close()
         # fetching another connection and run a query to force
         # drivers which lazily close the connection do it
-        list(driver.session("r").run("RETURN 3 as n"))
+        allocate_connections(3)
         hangup_count_post = self._server.count_responses("<HANGUP>")
+
+        self._server._dump()
         self.assertEqual(hangup_count_pre + 1, hangup_count_post)
 
 


### PR DESCRIPTION
The driver should close connections to the same address on encountering
`AuthorizationExpired` on any connection to that address. However, it should
not do this if the connection is still in use by another session/transaction/...