### PR TITLE
Introduce Support for Websocket in Bolt Stub (#319)

### DIFF
--- a/boltstub/__init__.py
+++ b/boltstub/__init__.py
@@ -36,15 +36,14 @@ import traceback
 from .addressing import Address
 from .channel import Channel
 from .errors import ServerExit
-from .packstream import PackStream
 from .parsing import (
     parse_file,
     Script,
     ScriptFailure,
 )
 from .wiring import (
+    create_wire,
     ReadWakeup,
-    Wire,
 )
 
 log = getLogger(__name__)
@@ -106,7 +105,7 @@ class BoltStubService:
             server_address = None
 
             def setup(self):
-                self.wire = Wire(self.request, read_wake_up=True)
+                self.wire = create_wire(self.request, read_wake_up=True)
                 self.client_address = self.wire.remote_address
                 self.server_address = self.wire.local_address
                 log.info("[#%04X>#%04X]  S: <ACCEPT> %s -> %s",
@@ -114,7 +113,7 @@ class BoltStubService:
                          self.server_address.port_number,
                          self.client_address, self.server_address)
 
-            def handle(self):
+            def handle(self) -> None:
                 with service.actors_lock:
                     actor = BoltActor(deepcopy(script), self.wire)
                     service.actors.append(actor)

--- a/boltstub/tests/test_wiring.py
+++ b/boltstub/tests/test_wiring.py
@@ -1,4 +1,3 @@
-
 from functools import reduce
 from random import getrandbits
 
@@ -47,8 +46,8 @@ class TestRegularSocket:
     class TestWhenCacheIsEmpty:
 
         @pytest.mark.parametrize("empty_cache", [
-            (None),
-            (b"")
+            None,
+            b"",
         ])
         def test_accessing_the_socket(self, empty_cache, mocker):
             expected = b"barcelos"
@@ -63,12 +62,12 @@ class TestRegularSocket:
             socket_mock.recv.assert_called_with(1024)
 
     @pytest.mark.parametrize("method_name", [
-        ("close"),
-        ("send"),
-        ("sendall"),
-        ("settimeout"),
-        ("getsockname"),
-        ("getpeername")
+        "close",
+        "send",
+        "sendall",
+        "settimeout",
+        "getsockname",
+        "getpeername",
     ])
     def test_proxying_sockets_members(self, method_name, mocker):
         socket_mock = mocker.Mock()
@@ -95,7 +94,7 @@ class TestWebSocket:
         (randbytes(126), b"\x82\x7E\x00\x7E"),
         (randbytes(65535), b"\x82\x7E\xFF\xFF"),
         (randbytes(65536), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x00"),
-        (randbytes(65537), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x01")
+        (randbytes(65537), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x01"),
     ])
     def test_send(self, payload, frame, mocker):
         socket_mock = mocker.Mock()
@@ -114,7 +113,7 @@ class TestWebSocket:
         (randbytes(126), b"\x82\x7E\x00\x7E"),
         (randbytes(65535), b"\x82\x7E\xFF\xFF"),
         (randbytes(65536), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x00"),
-        (randbytes(65537), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x01")
+        (randbytes(65537), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x01"),
     ])
     def test_sendall(self, payload, frame, mocker):
         socket_mock = mocker.Mock()
@@ -132,7 +131,7 @@ class TestWebSocket:
         (randbytes(126), b"\x82\x7E\x00\x7E"),
         (randbytes(65535), b"\x82\x7E\xFF\xFF"),
         (randbytes(65536), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x00"),
-        (randbytes(65537), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x01")
+        (randbytes(65537), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x01"),
     ])
     def test_recv(self, payload, frame, mocker):
         socket_mock = mocker.Mock()
@@ -152,7 +151,7 @@ class TestWebSocket:
         (randbytes(126), b"\x82\x7E\x00\x7E"),
         (randbytes(65535), b"\x82\x7E\xFF\xFF"),
         (randbytes(65536), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x00"),
-        (randbytes(65537), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x01")
+        (randbytes(65537), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x01"),
     ])
     def test_recv_pong(self, payload, frame, mocker):
         socket_mock = mocker.Mock()
@@ -173,7 +172,7 @@ class TestWebSocket:
         (randbytes(126), b"\x82\x7E\x00\x7E"),
         (randbytes(65535), b"\x82\x7E\xFF\xFF"),
         (randbytes(65536), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x00"),
-        (randbytes(65537), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x01")
+        (randbytes(65537), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x01"),
     ])
     def test_recv_ping(self, payload, frame, mocker):
         socket_mock = mocker.Mock()
@@ -191,11 +190,11 @@ class TestWebSocket:
         socket_mock.sendall.assert_called_with(pong)
 
     @pytest.mark.parametrize("reserved_control_frame", [
-        (b"\x0B\x00"),
-        (b"\x0C\x00"),
-        (b"\x0D\x00"),
-        (b"\x0E\x00"),
-        (b"\x0F\x00"),
+        b"\x0B\x00",
+        b"\x0C\x00",
+        b"\x0D\x00",
+        b"\x0E\x00",
+        b"\x0F\x00",
     ])
     def test_recv_reserved_control_frame(self, reserved_control_frame, mocker):
         socket_mock = mocker.Mock()
@@ -253,10 +252,10 @@ class TestWebSocket:
         assert received_payload == full_payload
 
     @pytest.mark.parametrize("method_name", [
-        ("close"),
-        ("settimeout"),
-        ("getsockname"),
-        ("getpeername")
+        "close",
+        "settimeout",
+        "getsockname",
+        "getpeername",
     ])
     def test_proxying_sockets_members(self, method_name, mocker):
         socket_mock = mocker.Mock()

--- a/boltstub/tests/test_wiring.py
+++ b/boltstub/tests/test_wiring.py
@@ -79,12 +79,6 @@ class TestRegularSocket:
         assert wrapped_method == original_method
 
 
-def duplicate(obj, times):
-    if times == 1:
-        return obj
-    return duplicate(obj + obj, times - 1)
-
-
 class TestWebSocket:
 
     @pytest.mark.parametrize("payload,frame", [

--- a/boltstub/tests/test_wiring.py
+++ b/boltstub/tests/test_wiring.py
@@ -1,0 +1,341 @@
+
+from functools import reduce
+from random import getrandbits
+
+import pytest
+
+from ..wiring import (
+    create_wire,
+    negotiate_socket,
+    RegularSocket,
+    WebSocket,
+)
+
+
+def randbytes(size):
+    return bytearray(getrandbits(8) for _ in range(size))
+
+
+class TestRegularSocket:
+    class TestWhenCacheIsSupplied:
+
+        def test_recv_should_return_cache(self, mocker):
+            cache = b"abc"
+
+            socket_mock = mocker.Mock()
+            regular_socket = RegularSocket(socket_mock, cache)
+
+            received = regular_socket.recv(1024)
+
+            assert received == cache
+            socket_mock.recv.assert_not_called()
+
+        def test_accessing_the_socket_during_second_call(self, mocker):
+            cache = b"abc"
+            expected = b"barcelos"
+
+            socket_mock = mocker.Mock()
+            socket_mock.recv.return_value = expected
+            regular_socket = RegularSocket(socket_mock, cache)
+
+            regular_socket.recv(1024)
+            actual = regular_socket.recv(1024)
+
+            assert actual == expected
+            socket_mock.recv.assert_called_with(1024)
+
+    class TestWhenCacheIsEmpty:
+
+        @pytest.mark.parametrize("empty_cache", [
+            (None),
+            (b"")
+        ])
+        def test_accessing_the_socket(self, empty_cache, mocker):
+            expected = b"barcelos"
+
+            socket_mock = mocker.Mock()
+            socket_mock.recv.return_value = expected
+            regular_socket = RegularSocket(socket_mock, empty_cache)
+
+            actual = regular_socket.recv(1024)
+
+            assert actual == expected
+            socket_mock.recv.assert_called_with(1024)
+
+    @pytest.mark.parametrize("method_name", [
+        ("close"),
+        ("send"),
+        ("sendall"),
+        ("settimeout"),
+        ("getsockname"),
+        ("getpeername")
+    ])
+    def test_proxying_sockets_members(self, method_name, mocker):
+        socket_mock = mocker.Mock()
+        regular_socket = RegularSocket(socket_mock, None)
+
+        wrapped_method = getattr(regular_socket, method_name)
+        original_method = getattr(socket_mock, method_name)
+
+        assert wrapped_method == original_method
+
+
+def duplicate(obj, times):
+    if times == 1:
+        return obj
+    return duplicate(obj + obj, times - 1)
+
+
+class TestWebSocket:
+
+    @pytest.mark.parametrize("payload,frame", [
+        (randbytes(0), b"\x82\x00"),
+        (randbytes(7), b"\x82\x07"),
+        (randbytes(125), b"\x82\x7D"),
+        (randbytes(126), b"\x82\x7E\x00\x7E"),
+        (randbytes(65535), b"\x82\x7E\xFF\xFF"),
+        (randbytes(65536), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x00"),
+        (randbytes(65537), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x01")
+    ])
+    def test_send(self, payload, frame, mocker):
+        socket_mock = mocker.Mock()
+        websocket = WebSocket(socket_mock)
+
+        bytes_sent = websocket.send(payload)
+
+        assert len(payload) == bytes_sent
+        socket_mock.sendall.assert_called_once()
+        socket_mock.sendall.assert_called_with(frame + payload)
+
+    @pytest.mark.parametrize("payload,frame", [
+        (randbytes(0), b"\x82\x00"),
+        (randbytes(7), b"\x82\x07"),
+        (randbytes(125), b"\x82\x7D"),
+        (randbytes(126), b"\x82\x7E\x00\x7E"),
+        (randbytes(65535), b"\x82\x7E\xFF\xFF"),
+        (randbytes(65536), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x00"),
+        (randbytes(65537), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x01")
+    ])
+    def test_sendall(self, payload, frame, mocker):
+        socket_mock = mocker.Mock()
+        websocket = WebSocket(socket_mock)
+
+        websocket.sendall(payload)
+
+        socket_mock.sendall.assert_called_once()
+        socket_mock.sendall.assert_called_with(frame + payload)
+
+    @pytest.mark.parametrize("payload,frame", [
+        (randbytes(0), b"\x82\x00"),
+        (randbytes(7), b"\x82\x07"),
+        (randbytes(125), b"\x82\x7D"),
+        (randbytes(126), b"\x82\x7E\x00\x7E"),
+        (randbytes(65535), b"\x82\x7E\xFF\xFF"),
+        (randbytes(65536), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x00"),
+        (randbytes(65537), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x01")
+    ])
+    def test_recv(self, payload, frame, mocker):
+        socket_mock = mocker.Mock()
+        framed_payload = frame + payload
+        socket_mock.recv.side_effect = TestWebSocket.mock_recv(framed_payload)
+
+        websocket = WebSocket(socket_mock)
+
+        received_payload = websocket.recv(1234)
+
+        assert received_payload == payload
+
+    @pytest.mark.parametrize("payload,frame", [
+        (randbytes(0), b"\x82\x00"),
+        (randbytes(7), b"\x82\x07"),
+        (randbytes(125), b"\x82\x7D"),
+        (randbytes(126), b"\x82\x7E\x00\x7E"),
+        (randbytes(65535), b"\x82\x7E\xFF\xFF"),
+        (randbytes(65536), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x00"),
+        (randbytes(65537), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x01")
+    ])
+    def test_recv_pong(self, payload, frame, mocker):
+        socket_mock = mocker.Mock()
+        pong = b"\x0A\x00"
+        framed_payload = pong + frame + payload
+        socket_mock.recv.side_effect = TestWebSocket.mock_recv(framed_payload)
+
+        websocket = WebSocket(socket_mock)
+
+        received_payload = websocket.recv(1234)
+
+        assert received_payload == payload
+
+    @pytest.mark.parametrize("payload,frame", [
+        (randbytes(0), b"\x82\x00"),
+        (randbytes(7), b"\x82\x07"),
+        (randbytes(125), b"\x82\x7D"),
+        (randbytes(126), b"\x82\x7E\x00\x7E"),
+        (randbytes(65535), b"\x82\x7E\xFF\xFF"),
+        (randbytes(65536), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x00"),
+        (randbytes(65537), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x01")
+    ])
+    def test_recv_ping(self, payload, frame, mocker):
+        socket_mock = mocker.Mock()
+        ping = b"\x09\x00"
+        pong = b"\x0A\x00"
+        framed_payload = ping + frame + payload
+        socket_mock.recv.side_effect = TestWebSocket.mock_recv(framed_payload)
+
+        websocket = WebSocket(socket_mock)
+
+        received_payload = websocket.recv(1234)
+
+        assert received_payload == payload
+        socket_mock.sendall.assert_called_once()
+        socket_mock.sendall.assert_called_with(pong)
+
+    @pytest.mark.parametrize("reserved_control_frame", [
+        (b"\x0B\x00"),
+        (b"\x0C\x00"),
+        (b"\x0D\x00"),
+        (b"\x0E\x00"),
+        (b"\x0F\x00"),
+    ])
+    def test_recv_reserved_control_frame(self, reserved_control_frame, mocker):
+        socket_mock = mocker.Mock()
+        frame = b"\x82\x7E\x00\x7E"
+        payload = randbytes(126)
+        framed_payload = reserved_control_frame + frame + payload
+        socket_mock.recv.side_effect = TestWebSocket.mock_recv(framed_payload)
+
+        websocket = WebSocket(socket_mock)
+
+        received_payload = websocket.recv(1234)
+
+        assert received_payload == payload
+
+    def test_recv_masked_frame(self, mocker):
+        payload = bytearray(125)
+        mask = b"\x0A\x0B\x0C\x0C"
+        frame = b"\x82\xFD" + mask
+        masked_payload = bytearray(
+            [payload[i] ^ mask[i % 4] for i in range(125)])
+
+        framed_payload = frame + masked_payload
+
+        socket_mock = mocker.Mock()
+        socket_mock.recv.side_effect = TestWebSocket.mock_recv(framed_payload)
+
+        websocket = WebSocket(socket_mock)
+
+        received_payload = websocket.recv(1234)
+
+        assert received_payload == payload
+
+    def test_recv_multiple_frames(self, mocker):
+        payload_list = [
+            (randbytes(0), b"\x02\x00"),
+            (randbytes(7), b"\x00\x07"),
+            (randbytes(125), b"\x00\x7D"),
+            (randbytes(126), b"\x00\x7E\x00\x7E"),
+            (randbytes(65535), b"\x00\x7E\xFF\xFF"),
+            (randbytes(65536), b"\x00\x7F\x00\x00\x00\x00\x00\x01\x00\x00"),
+            (randbytes(65537), b"\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x01")
+        ]
+        framed_payload = reduce(lambda x, y: x + y,
+                                map(lambda p: p[1] + p[0], payload_list))
+        full_payload = reduce(lambda x, y: x + y,
+                              map(lambda p: p[0], payload_list))
+
+        socket_mock = mocker.Mock()
+        socket_mock.recv.side_effect = TestWebSocket.mock_recv(framed_payload)
+
+        websocket = WebSocket(socket_mock)
+
+        received_payload = websocket.recv(1234)
+
+        assert received_payload == full_payload
+
+    @pytest.mark.parametrize("method_name", [
+        ("close"),
+        ("settimeout"),
+        ("getsockname"),
+        ("getpeername")
+    ])
+    def test_proxying_sockets_members(self, method_name, mocker):
+        socket_mock = mocker.Mock()
+        regular_socket = WebSocket(socket_mock)
+
+        wrapped_method = getattr(regular_socket, method_name)
+        original_method = getattr(socket_mock, method_name)
+
+        assert wrapped_method == original_method
+
+    @staticmethod
+    def mock_recv(payload_):
+        state = {"pos": 0}
+
+        def recv(*args, **kwargs):
+            size = args[0]
+            start = state.get("pos")
+            end = start + size
+            state["pos"] = end
+            return payload_[start:end]
+        return recv
+
+
+def test_create_wire(mocker):
+    socket = mocker.Mock()
+    read_wake_up = False
+    wrap_socket = mocker.Mock()
+
+    regular_socket = RegularSocket(socket, None)
+    wrap_socket.return_value = regular_socket
+
+    wire = create_wire(socket, read_wake_up, wrap_socket)
+
+    assert wire._socket == regular_socket
+    wrap_socket.assert_called_with(socket)
+
+
+def test_negotiate_socket_negotiate_regular_socket(mocker):
+    payload = (b"\x60\x60\xB0\x17\x00\x00\x01\x04\x00\x00\x00\x04\x00\x00\x00"
+               b"\x03\x00\x00\x00\x00")
+    socket = mocker.Mock()
+    socket.recv.return_value = payload
+
+    negotiated_socket = negotiate_socket(socket)
+
+    assert isinstance(negotiated_socket,  RegularSocket)
+    assert negotiated_socket._socket == socket
+    assert negotiated_socket._cache == payload
+    socket.recv.assert_called_once()
+
+
+def test_negotiate_socket_negotiate_web_socket(mocker):
+    payload_text = ("GET /chat HTTP/1.1\r\n"
+                    + "Host: server.example.com\r\n"
+                    + "Upgrade: websocket\r\n"
+                    + "Connection: Upgrade\r\n"
+                    + "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                    + "Origin: http://example.com\r\n"
+                    + "Sec-WebSocket-Protocol: chat, superchat\r\n"
+                    + "Sec-WebSocket-Version: 13\r\n\r\n")
+    payload = payload_text.encode("utf-8")
+
+    response_payload_text = (
+        "HTTP/1.1 101 Switching Protocols\r\n"
+        + "Upgrade: websocket\r\n"
+        + "Connection: Upgrade\r\n"
+        + "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n"
+    )
+
+    socket = mocker.Mock()
+    socket.recv.return_value = payload
+
+    negotiated_socket = negotiate_socket(socket)
+
+    assert isinstance(negotiated_socket,  WebSocket)
+    assert negotiated_socket._socket == socket
+    socket.recv.assert_called_once()
+    socket.sendall.assert_called_once()
+
+    encoded_sent_response, = socket.sendall.call_args.args
+    decoded_sent_response = encoded_sent_response.decode("utf-8")
+    assert decoded_sent_response == response_payload_text


### PR DESCRIPTION
The support for Websockets in the Bolt Stub is need for testing the javascript driver in the browser.

The socket negotiation is done during the `BoltStubRequestHandler.setup` creating the wire using the `create_wire` function. This function handles the WebSocket negotiation and return the Wire with the correct socket negotiated.

The `WebSocket` implements read and receive data using the websockets frames and handle the control frames. This class doesn't not fulfil the whole `rfc6455` implementation because it always treat the payload as binary (which is the only kind of payload we use). The `negotiate_protocol` function also doesn't implement the whole `rfc6455` for negotiate websocket, It doesn't support extensions since It isn't needed for BoltStub use case.

PS: `RegularSocket` and `WebSocket` only implement and test the methods used by `Wire`