### PR TITLE
Take away hard-coded SSL feature flag for Python

### DIFF
--- a/tests/shared.py
+++ b/tests/shared.py
@@ -138,7 +138,7 @@ def get_driver_features(backend):
             ))
         # TODO: remove this block once all drivers list this feature
         #       they all support the functionality already
-        if get_driver_name() in ["python", "go", "dotnet"]:
+        if get_driver_name() in ["go", "dotnet"]:
             assert protocol.Feature.API_SSL_SCHEMES not in features
             features.add(protocol.Feature.API_SSL_SCHEMES)
         print("features", features)

--- a/tests/tls/test_secure_scheme.py
+++ b/tests/tls/test_secure_scheme.py
@@ -146,6 +146,8 @@ class TestTrustCustomCertsConfig(TestTrustSystemCertsConfig):
         {"encrypted": True, "trusted_certificates": ["customRoot.crt"]},
         {"encrypted": True,
          "trusted_certificates": ["customRoot2.crt", "customRoot.crt"]},
+        {"encrypted": True,
+         "trusted_certificates": ["customRoot.crt", "customRoot2.crt"]},
     )
     cert_prefix = "customRoot_"
 


### PR DESCRIPTION
Also expand the SSL test suite by testing reversed list of custom SSL CA certs