### PR TITLE
Fix TestMaxConnectionPoolSize side effects in Javascript/Firefox

### DIFF
--- a/tests/stub/driver_parameters/test_max_connection_pool_size.py
+++ b/tests/stub/driver_parameters/test_max_connection_pool_size.py
@@ -16,7 +16,7 @@ class TestMaxConnectionPoolSize(TestkitTestCase):
 
     def setUp(self):
         super().setUp()
-        self._server = StubServer(9010)
+        self._server = StubServer(9999)
         self._server.start(
             self.script_path("tx_without_commit_or_rollback.script")
         )


### PR DESCRIPTION
The high number of connections created and closed to the same address during theses tests trigger security policies in Firefox, which blocks connection for the address for some minutes.

The avoid this impact in other tests, the port of the server in these test suite was change to 9999 (which is not used in other tests)