### PR TITLE
Allow discard in 4.1 writer_yielding_db_unavailable_error_on_rollback and unskip 1 java test

### DIFF
--- a/tests/neo4j/test_datatypes.py
+++ b/tests/neo4j/test_datatypes.py
@@ -193,10 +193,6 @@ class TestDataTypes(TestkitTestCase):
         )
 
     def test_should_echo_relationship(self):
-        # TODO: remove this block once all languages work
-        if get_driver_name() in ["java"]:
-            self.skipTest("Backend does not serialize relationships.")
-
         def work(tx):
             result = tx.run("CREATE (a)-[r:KNOWS {since:1999}]->(b) "
                             "RETURN a, b, r")

--- a/tests/stub/routing/scripts/v4x1_no_routing/writer_yielding_db_unavailable_error_on_rollback.script
+++ b/tests/stub/routing/scripts/v4x1_no_routing/writer_yielding_db_unavailable_error_on_rollback.script
@@ -8,9 +8,13 @@ C: BEGIN {"db": "adb"}
 S: SUCCESS {}
 C: RUN "RETURN 1 as n" {} {}
 S: SUCCESS {"fields": ["n"]}
-C: PULL {"n": 1000}
-S: RECORD [1]
-   SUCCESS {"type": "r"}
+{{
+    C: PULL {"n": 1000}
+    S: RECORD [1]
+----
+    C: DISCARD {"n": -1}
+}}
+S: SUCCESS {"type": "r"}
 C: ROLLBACK
 S: FAILURE {"code": "Neo.TransientError.General.DatabaseUnavailable", "message": "Unable to rollback"}
 +: RESET


### PR DESCRIPTION
Cherry-picks: #367, #363.