### PR TITLE
Add support for build args for Driver Docker Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,3 +207,23 @@ Environment variables:
     Username used to connect, defaults to neo4j
   * `TEST_NEO4J_PASS`  
     Password used to connect
+
+## Sending build args for the Driver Docker Image
+
+Testkit is able to send diffent `--build-arg` for building the driver docker image.
+This configuration is done by setting environment variables prefixed by
+`TESTKIT_DRIVER_BUILD_ARG_`, driver build will called with all build args defined
+removing the prefix from the name.
+
+For example:
+
+```console
+export TESTKIT_DRIVER_BUILD_ARG_NODE_VERSION=12
+export TESTKIT_DRIVER_BUILD_ARG_NPM_VERSION=7
+python main.py
+```
+It should result in a build command line like this:
+
+```console
+['docker', 'build', '--build-arg', 'NODE_VERSION=12','--build-arg', 'NPM_VERSION=7', '--tag', 'drivers-javascript:local', '/driver/path/testkit']
+```

--- a/README.md
+++ b/README.md
@@ -210,10 +210,10 @@ Environment variables:
 
 ## Sending build args for the Driver Docker Image
 
-Testkit is able to send diffent `--build-arg` for building the driver docker image.
-This configuration is done by setting environment variables prefixed by
-`TESTKIT_DRIVER_BUILD_ARG_`, driver build will called with all build args defined
-removing the prefix from the name.
+TestKit is able to send different `--build-arg`s for building the driver docker image.
+This configuration is done by setting environment variables prefixed with
+`TESTKIT_DRIVER_BUILD_ARG_`. The driver build will called with all build args
+minus the prefix.
 
 For example:
 
@@ -222,8 +222,8 @@ export TESTKIT_DRIVER_BUILD_ARG_NODE_VERSION=12
 export TESTKIT_DRIVER_BUILD_ARG_NPM_VERSION=7
 python main.py
 ```
-It should result in a build command line like this:
+will result in the following build command:
 
 ```console
-['docker', 'build', '--build-arg', 'NODE_VERSION=12','--build-arg', 'NPM_VERSION=7', '--tag', 'drivers-javascript:local', '/driver/path/testkit']
+docker build --build-arg NODE_VERSION=12 --build-arg NPM_VERSION=7 --tag <some_tag> /driver/path/testkit
 ```

--- a/docker.py
+++ b/docker.py
@@ -1,3 +1,4 @@
+from functools import reduce
 import os
 import pathlib
 import re
@@ -193,12 +194,19 @@ def load(readable):
     return loaded_image
 
 
-def build_and_tag(tag_name, dockerfile_path, cwd=None, log_path=None):
-    print("Building runner Docker image %s from %s" % (tag_name,
-                                                       dockerfile_path))
+def build_and_tag(tag_name, dockerfile_path, cwd=None,
+                  log_path=None, args=None):
+    if args is None:
+        args = {}
+    build_args = list(reduce(lambda a, b: a + b,
+                             map(lambda k: [
+                                 "--build-arg",
+                                 "%s=%s" % (k, args[k])
+                             ], args), []))
+
     if not log_path:
         subprocess.check_call([
-            "docker", "build", "--tag", tag_name, dockerfile_path
+            "docker", "build", *build_args, "--tag", tag_name, dockerfile_path
         ], cwd=cwd)
     else:
         clean_tag = re.sub(r"\W", "_", tag_name)
@@ -206,9 +214,11 @@ def build_and_tag(tag_name, dockerfile_path, cwd=None, log_path=None):
         err_path = os.path.join(log_path, "build_{}_err.log".format(clean_tag))
         with open(out_path, "w") as out_fd:
             with open(err_path, "w") as err_fd:
-                print(["docker", "build", "--tag", tag_name, dockerfile_path])
+                print(["docker", "build", *build_args,
+                       "--tag", tag_name, dockerfile_path])
                 subprocess.check_call([
-                    "docker", "build", "--tag", tag_name, dockerfile_path
+                    "docker", "build", *build_args,
+                    "--tag", tag_name, dockerfile_path
                 ], cwd=cwd, stdout=out_fd, stderr=err_fd)
     _created_tags.add(tag_name)
     remove_dangling()

--- a/docker.py
+++ b/docker.py
@@ -198,11 +198,8 @@ def build_and_tag(tag_name, dockerfile_path, cwd=None,
                   log_path=None, args=None):
     if args is None:
         args = {}
-    build_args = list(reduce(lambda a, b: a + b,
-                             map(lambda k: [
-                                 "--build-arg",
-                                 "%s=%s" % (k, args[k])
-                             ], args), []))
+    build_args = [e for k, v in args.items()
+                  for e in ("--build-args", f"{k}={v}")]
 
     if not log_path:
         subprocess.check_call([

--- a/docker.py
+++ b/docker.py
@@ -1,4 +1,3 @@
-from functools import reduce
 import os
 import pathlib
 import re
@@ -199,24 +198,21 @@ def build_and_tag(tag_name, dockerfile_path, cwd=None,
     if args is None:
         args = {}
     build_args = [e for k, v in args.items()
-                  for e in ("--build-args", f"{k}={v}")]
+                  for e in ("--build-arg", f"{k}={v}")]
+
+    cmd = ["docker", "build", *build_args, "--tag", tag_name, dockerfile_path]
+    print(cmd)
 
     if not log_path:
-        subprocess.check_call([
-            "docker", "build", *build_args, "--tag", tag_name, dockerfile_path
-        ], cwd=cwd)
+        subprocess.check_call(cmd, cwd=cwd)
     else:
         clean_tag = re.sub(r"\W", "_", tag_name)
         out_path = os.path.join(log_path, "build_{}_out.log".format(clean_tag))
         err_path = os.path.join(log_path, "build_{}_err.log".format(clean_tag))
         with open(out_path, "w") as out_fd:
             with open(err_path, "w") as err_fd:
-                print(["docker", "build", *build_args,
-                       "--tag", tag_name, dockerfile_path])
-                subprocess.check_call([
-                    "docker", "build", *build_args,
-                    "--tag", tag_name, dockerfile_path
-                ], cwd=cwd, stdout=out_fd, stderr=err_fd)
+                subprocess.check_call(cmd,
+                                      cwd=cwd, stdout=out_fd, stderr=err_fd)
     _created_tags.add(tag_name)
     remove_dangling()
 

--- a/driver.py
+++ b/driver.py
@@ -4,6 +4,8 @@ import shutil
 import docker
 import neo4j
 
+BUILD_ARG_PREFIX = "TESTKIT_DRIVER_BUILD_ARG_"
+
 
 def _get_glue(this_path, driver_name, driver_repo):
     """Locate where driver has it's docker image and Python "glue" scripts.
@@ -25,7 +27,7 @@ def _get_glue(this_path, driver_name, driver_repo):
 
 
 def _ensure_image(testkit_path, docker_image_path, branch_name, driver_name,
-                  artifacts_path):
+                  artifacts_path, build_args):
     """Ensure that an up to date Docker image exists for the driver."""
     # Construct Docker image name from driver name (i.e drivers-go) and
     # branch name (i.e 4.2, go-1.14-image)
@@ -47,9 +49,15 @@ def _ensure_image(testkit_path, docker_image_path, branch_name, driver_name,
 
     # This will use the driver folder as build context.
     docker.build_and_tag(image_name, docker_image_path,
-                         log_path=artifacts_path)
+                         log_path=artifacts_path, args=build_args)
 
     return image_name
+
+
+def _get_build_args():
+    return {k.removeprefix(BUILD_ARG_PREFIX): v
+            for (k, v) in os.environ.items()
+            if k.startswith(BUILD_ARG_PREFIX)}
 
 
 def start_container(testkit_path, branch_name, driver_name, driver_path,
@@ -59,7 +67,8 @@ def start_container(testkit_path, branch_name, driver_name, driver_path,
     host_glue_path, driver_glue_path = _get_glue(testkit_path, driver_name,
                                                  driver_path)
     image = _ensure_image(testkit_path, host_glue_path,
-                          branch_name, driver_name, artifacts_path_build)
+                          branch_name, driver_name, artifacts_path_build,
+                          build_args=_get_build_args())
     container_name = "driver"
     # Configure volume map for the driver container
     mount_map = {

--- a/driver.py
+++ b/driver.py
@@ -55,7 +55,7 @@ def _ensure_image(testkit_path, docker_image_path, branch_name, driver_name,
 
 
 def _get_build_args():
-    return {k.removeprefix(BUILD_ARG_PREFIX): v
+    return {k[len(BUILD_ARG_PREFIX):]: v
             for (k, v) in os.environ.items()
             if k.startswith(BUILD_ARG_PREFIX)}
 


### PR DESCRIPTION
This feature solves problems like select the version of languages runtimes or libraries present in the driver docker image during the test.
Sending `--build-arg`s to the image makes easier to handle this kind of configuration on the image level instead of changing the version using other scripts in a post process.

The first use-case of this feature will be the selection of Nodejs version in the Javascript Driver.

More info about how to use it in the updated docs.