### PR TITLE
Improvements for stub server

### DIFF
--- a/boltstub/__init__.py
+++ b/boltstub/__init__.py
@@ -167,7 +167,9 @@ class BoltStubService:
         try:
             self.server.serve_forever()
         except OSError:
-            print("caught OS Error")
+            msg = ("caught OS Error in stub._server_forever" +
+                   "this may be expected")
+            print(msg)
 
     def _stop_server(self):
         if self.script.context.restarting or self.script.context.concurrent:

--- a/boltstub/__init__.py
+++ b/boltstub/__init__.py
@@ -20,6 +20,7 @@
 
 from copy import deepcopy
 from logging import getLogger
+import os
 from socketserver import (
     BaseRequestHandler,
     TCPServer,
@@ -160,7 +161,13 @@ class BoltStubService:
             self.server.server_close()
 
     def _close_socket(self):
-        self.server.socket.close()
+        if os.name == "nt":
+            try:
+                self.server.socket.detach()
+            except OSError as err:
+                pass
+        else:
+            self.server.socket.close()
 
     def _stop_server(self):
         if self.script.context.restarting or self.script.context.concurrent:

--- a/boltstub/__init__.py
+++ b/boltstub/__init__.py
@@ -20,7 +20,6 @@
 
 from copy import deepcopy
 from logging import getLogger
-import os
 from socketserver import (
     BaseRequestHandler,
     TCPServer,
@@ -167,8 +166,7 @@ class BoltStubService:
         try:
             self.server.serve_forever()
         except OSError:
-            msg = ("caught OS Error in stub._server_forever" +
-                   "this may be expected")
+            msg = "caught OS Error in stub._server_forever"
             print(msg)
 
     def _stop_server(self):

--- a/boltstub/__init__.py
+++ b/boltstub/__init__.py
@@ -155,19 +155,19 @@ class BoltStubService:
 
     def start(self):
         if self.script.context.restarting or self.script.context.concurrent:
-            self.server.serve_forever()
+            self._serve_forever()
         else:
             self.server.handle_request()
             self.server.server_close()
 
     def _close_socket(self):
-        if os.name == "nt":
-            try:
-                self.server.socket.detach()
-            except OSError as err:
-                pass
-        else:
-            self.server.socket.close()
+        self.server.socket.close()
+
+    def _serve_forever(self):
+        try:
+            self.server.serve_forever()
+        except OSError:
+            print("caught OS Error")
 
     def _stop_server(self):
         if self.script.context.restarting or self.script.context.concurrent:

--- a/boltstub/__main__.py
+++ b/boltstub/__main__.py
@@ -26,6 +26,7 @@ import signal
 import sys
 import threading
 import time
+import traceback
 
 from . import BoltStubService
 from .parsing import (
@@ -107,6 +108,7 @@ def main():
             service.start()
         except Exception as e:
             log.error(" ".join(map(str, e.args)))
+            log.error(traceback.format_exc())
             log.error("\r\n")
             return exit_(99)
 

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -46,10 +46,14 @@ def get_ip_addresses(exclude_loopback=True):
 
     ips = []
     for adapter in ifaddr.get_adapters():
-        if exclude_loopback:
-            name = adapter.nice_name.lower()
-            if name == "lo" or "loopback" in name:
-                continue
+        name = adapter.nice_name.lower()
+        if ("virtual" in name
+                or "docker" in name
+                or name.startswith("br-")
+                or name.startswith("veth")):
+            continue
+        if exclude_loopback and name == "lo" or "loopback" in name:
+            continue
         address = pick_address(adapter)
         if address:
             ips.append(address)

--- a/tests/stub/shared.py
+++ b/tests/stub/shared.py
@@ -12,6 +12,7 @@ from queue import (
 )
 import re
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
@@ -89,6 +90,13 @@ class StubServer:
                 f.flush()
                 os.fsync(f)
             self._script_path = path
+
+        socket_check = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            if socket_check.connect_ex((self.host, self.port)) == 0:
+                raise OSError(f"port in use {self.host}:{self.port}")
+        finally:
+            socket_check.close()
 
         self._process = subprocess.Popen(
             [

--- a/tests/stub/shared.py
+++ b/tests/stub/shared.py
@@ -31,6 +31,7 @@ else:
 
 clean_ports = set()
 
+
 class StubServerError(Exception):
     pass
 


### PR DESCRIPTION
- When stub servers start they will check if the port is in use on the host. (cached as this uses a lot of time)
- When stub servers throw an exception they will include their call stack
- When disconnecting a stubServers socket, use detach on windows
    - https://docs.python.org/3/library/socket.html#socket.socket.detach