### PR TITLE
javascript: Enable 'Temporary:DriverMaxConnectionPoolSize'

### DIFF
--- a/tests/stub/routing/test_routing_v4x4.py
+++ b/tests/stub/routing/test_routing_v4x4.py
@@ -2813,7 +2813,8 @@ class RoutingV4x4(RoutingBase):
         session2 = driver.session("w", database=self.adb)
 
         with self.assertRaises(types.DriverError) as exc:
-            session2.begin_transaction()
+            tx = session2.begin_transaction()
+            list(tx.run("RETURN 1 as n"))
 
         if get_driver_name() in ["java"]:
             self.assertEqual(

--- a/tests/stub/routing/test_routing_v4x4.py
+++ b/tests/stub/routing/test_routing_v4x4.py
@@ -2812,9 +2812,13 @@ class RoutingV4x4(RoutingBase):
 
         session2 = driver.session("w", database=self.adb)
 
-        with self.assertRaises(types.DriverError) as exc:
-            tx = session2.begin_transaction()
-            list(tx.run("RETURN 1 as n"))
+        if self.driver_supports_features(types.Feature.OPT_EAGER_TX_BEGIN):
+            with self.assertRaises(types.DriverError) as exc:
+                session2.begin_transaction()
+        else:
+            with self.assertRaises(types.DriverError) as exc:
+                tx = session2.begin_transaction()
+                list(tx.run("RETURN 1 as n"))
 
         if get_driver_name() in ["java"]:
             self.assertEqual(


### PR DESCRIPTION
The `test_should_enforce_pool_size_per_cluster_member` should try to consume the result for getting the error since
javascript driver postpone the error raise.