### PR TITLE
Add tests for `driver.verifyConnectivity` and `.getServerInfo`

### DIFF
--- a/nutkit/frontend/driver.py
+++ b/nutkit/frontend/driver.py
@@ -29,41 +29,67 @@ class Driver:
             raise Exception("Should be Driver but was %s" % res)
         self._driver = res
 
+    def receive(self, timeout=None, hooks=None, *, allow_resolution):
+        while True:
+            res = self._backend.receive(timeout=timeout, hooks=hooks)
+            if allow_resolution:
+                if isinstance(res, protocol.ResolverResolutionRequired):
+                    addresses = self.resolve(res.address)
+                    self._backend.send(
+                        protocol.ResolverResolutionCompleted(res.id,
+                                                             addresses),
+                        hooks=hooks
+                    )
+                    continue
+                elif isinstance(res, protocol.DomainNameResolutionRequired):
+                    addresses = self.resolve_domain_name(res.name)
+                    self._backend.send(
+                        protocol.DomainNameResolutionCompleted(res.id,
+                                                               addresses),
+                        hooks=hooks
+                    )
+                    continue
+            return res
+
+    def send(self, req, hooks=None):
+        self._backend.send(req, hooks=hooks)
+
+    def send_and_receive(self, req, timeout=None, hooks=None, *,
+                         allow_resolution):
+        self.send(req, hooks=hooks)
+        return self.receive(timeout=timeout, hooks=hooks,
+                            allow_resolution=allow_resolution)
+
     def verify_connectivity(self):
         req = protocol.VerifyConnectivity(self._driver.id)
-        self._backend.send(req)
-        while True:
-            res = self._backend.receive()
-            if isinstance(res, protocol.DomainNameResolutionRequired):
-                addresses = self.resolve_domain_name(res.name)
-                self._backend.send(
-                    protocol.DomainNameResolutionCompleted(res.id, addresses)
-                )
-            elif isinstance(res, protocol.Driver):
-                return
-            else:
-                raise Exception(
-                    "Should be Driver or DomainNameResolutionRequired "
-                    "but was: %s" % res
-                )
+        res = self.send_and_receive(req, allow_resolution=True)
+        if not isinstance(res, protocol.Driver):
+            raise Exception("Should be Driver but was: %s" % res)
+
+    def get_server_info(self):
+        req = protocol.GetServerInfo(self._driver.id)
+        res = self.send_and_receive(req, allow_resolution=True)
+        if not isinstance(res, protocol.ServerInfo):
+            raise Exception("Should be ServerInfo but was: %s" % res)
+        return res
 
     def supports_multi_db(self):
         req = protocol.CheckMultiDBSupport(self._driver.id)
-        res = self._backend.send_and_receive(req)
+        res = self.send_and_receive(req, allow_resolution=False)
         if not isinstance(res, protocol.MultiDBSupport):
             raise Exception("Should be MultiDBSupport")
         return res.available
 
     def is_encrypted(self):
         req = protocol.CheckDriverIsEncrypted(self._driver.id)
-        res = self._backend.send_and_receive(req)
+        res = self.send_and_receive(req, allow_resolution=False)
         if not isinstance(res, protocol.DriverIsEncrypted):
             raise Exception("Should be DriverIsEncrypted")
         return res.encrypted
 
     def close(self):
         req = protocol.DriverClose(self._driver.id)
-        res = self._backend.send_and_receive(req)
+        res = self.send_and_receive(req, allow_resolution=False)
         if not isinstance(res, protocol.Driver):
             raise Exception("Should be driver")
 
@@ -74,10 +100,10 @@ class Driver:
             database=database, fetchSize=fetch_size,
             impersonatedUser=impersonated_user
         )
-        res = self._backend.send_and_receive(req)
+        res = self.send_and_receive(req, allow_resolution=False)
         if not isinstance(res, protocol.Session):
             raise Exception("Should be session")
-        return Session(self, self._backend, res)
+        return Session(self, res)
 
     def resolve(self, address):
         return self._resolver_fn(address)
@@ -89,20 +115,20 @@ class Driver:
         req = protocol.ForcedRoutingTableUpdate(
             self._driver.id, database=database, bookmarks=bookmarks
         )
-        res = self._backend.send_and_receive(req)
+        res = self.send_and_receive(req, allow_resolution=True)
         if not isinstance(res, protocol.Driver):
             return Exception("Should be Driver")
 
     def get_routing_table(self, database=None):
         req = protocol.GetRoutingTable(self._driver.id, database=database)
-        res = self._backend.send_and_receive(req)
+        res = self.send_and_receive(req, allow_resolution=False)
         if not isinstance(res, protocol.RoutingTable):
             raise Exception("Should be RoutingTable")
         return res
 
     def get_connection_pool_metrics(self, address):
         req = protocol.GetConnectionPoolMetrics(self._driver.id, address)
-        res = self._backend.send_and_receive(req)
+        res = self.send_and_receive(req, allow_resolution=False)
         if not isinstance(res, protocol.ConnectionPoolMetrics):
             raise Exception("Should be ConnectionPoolMetrics")
         return res

--- a/nutkit/frontend/result.py
+++ b/nutkit/frontend/result.py
@@ -2,14 +2,14 @@ from .. import protocol
 
 
 class Result:
-    def __init__(self, backend, result):
-        self._backend = backend
+    def __init__(self, driver, result):
+        self._driver = driver
         self._result = result
 
     def next(self):
         """Move to next record in result."""
         req = protocol.ResultNext(self._result.id)
-        return self._backend.send_and_receive(req)
+        return self._driver.send_and_receive(req, allow_resolution=True)
 
     def single(self):
         """Return one record if there is exactly one.
@@ -17,22 +17,22 @@ class Result:
         Raises error otherwise.
         """
         req = protocol.ResultSingle(self._result.id)
-        return self._backend.send_and_receive(req)
+        return self._driver.send_and_receive(req, allow_resolution=True)
 
     def peek(self):
         """Return the next Record or NullRecord without consuming it."""
         req = protocol.ResultPeek(self._result.id)
-        return self._backend.send_and_receive(req)
+        return self._driver.send_and_receive(req, allow_resolution=True)
 
     def consume(self):
         """Discard all records in result and returns summary."""
         req = protocol.ResultConsume(self._result.id)
-        return self._backend.send_and_receive(req)
+        return self._driver.send_and_receive(req, allow_resolution=True)
 
     def list(self):
         """Retrieve the entire result stream."""
         req = protocol.ResultList(self._result.id)
-        res = self._backend.send_and_receive(req)
+        res = self._driver.send_and_receive(req, allow_resolution=True)
         assert isinstance(res, protocol.RecordList)
         return res.records
 

--- a/nutkit/frontend/transaction.py
+++ b/nutkit/frontend/transaction.py
@@ -3,31 +3,31 @@ from .result import Result
 
 
 class Transaction:
-    def __init__(self, backend, id_):
-        self._backend = backend
+    def __init__(self, driver, id_):
+        self._driver = driver
         self._id = id_
 
     def run(self, cypher, params=None):
         req = protocol.TransactionRun(self._id, cypher, params)
-        res = self._backend.send_and_receive(req)
+        res = self._driver.send_and_receive(req, allow_resolution=True)
         if not isinstance(res, protocol.Result):
             raise Exception("Should be result but was: %s" % res)
-        return Result(self._backend, res)
+        return Result(self._driver, res)
 
     def commit(self):
         req = protocol.TransactionCommit(self._id)
-        res = self._backend.send_and_receive(req)
+        res = self._driver.send_and_receive(req, allow_resolution=True)
         if not isinstance(res, protocol.Transaction):
             raise Exception("Should be transaction but was: %s" % res)
 
     def rollback(self):
         req = protocol.TransactionRollback(self._id)
-        res = self._backend.send_and_receive(req)
+        res = self._driver.send_and_receive(req, allow_resolution=True)
         if not isinstance(res, protocol.Transaction):
             raise Exception("Should be transaction but was: %s" % res)
 
     def close(self):
         req = protocol.TransactionClose(self._id)
-        res = self._backend.send_and_receive(req)
+        res = self._driver.send_and_receive(req, allow_resolution=True)
         if not isinstance(res, protocol.Transaction):
             raise Exception("Should be transaction but was: %s" % res)

--- a/nutkit/protocol/feature.py
+++ b/nutkit/protocol/feature.py
@@ -4,9 +4,16 @@ from enum import Enum
 
 class Feature(Enum):
     # === FUNCTIONAL FEATURES ===
+    # The driver offers a method for checking if a connection to the remote
+    # server of cluster can be established and retrieve the server info of the
+    # reached remote.
+    API_DRIVER_GET_SERVER_INFO = "Feature:API:Driver:GetServerInfo"
     # The driver offers a method for driver objects to report if they were
     # configured with a or without encryption.
     API_DRIVER_IS_ENCRYPTED = "Feature:API:Driver.IsEncrypted"
+    # The driver offers a method for checking if a connection to the remote
+    # server of cluster can be established.
+    API_DRIVER_VERIFY_CONNECTIVITY = "Feature:API:Driver.VerifyConnectivity"
     # The driver offers a method for the result to return all records as a list
     # or array. This method should exhaust the result.
     API_RESULT_LIST = "Feature:API:Result.List"
@@ -108,6 +115,16 @@ class Feature(Enum):
     # routing table and assume all other connections to the server are dead
     # as well.
     CONF_HINT_CON_RECV_TIMEOUT = "ConfHint:connection.recv_timeout_seconds"
+
+    # === BACKEND FEATURES FOR TESTING ===
+    # The backend understands the GetRoutingTable protocol message and provides
+    # a way for TestKit to request the routing table (for testing only, should
+    # not be exposed to the user).
+    BACKEND_RT_FETCH = "Backend:RTFetch"
+    # The backend understands the ForcedRoutingTableUpdate protocol message
+    # and provides a way to force a routing table update (for testing only,
+    # should not be exposed to the user).
+    BACKEND_RT_FORCE_UPDATE = "Backend:RTForceUpdate"
 
     # Temporary driver feature that will be removed when all official driver
     # backends have implemented the connection acquisition timeout config.

--- a/nutkit/protocol/requests.py
+++ b/nutkit/protocol/requests.py
@@ -136,8 +136,20 @@ class VerifyConnectivity:
     Backend should respond with a Driver response or an Error response.
     """
 
-    def __init__(self, driverId):
-        self.driverId = driverId
+    def __init__(self, driver_id):
+        self.driverId = driver_id
+
+
+class GetServerInfo:
+    """
+    Request to verify connectivity on the driver and get ServerInfo.
+
+    instance corresponding to the specified driver id.
+    Backend should respond with a ServerInfo response or an Error response.
+    """
+
+    def __init__(self, driver_id):
+        self.driverId = driver_id
 
 
 class CheckMultiDBSupport:

--- a/nutkit/protocol/responses.py
+++ b/nutkit/protocol/responses.py
@@ -294,7 +294,10 @@ class Summary:
 
 
 class ServerInfo:
-    """Represents server info that is included in the Summary response."""
+    """Represents server info.
+
+    It can be part of a Summary response or a stand-alone response
+    """
 
     def __init__(self, address, agent, protocolVersion):
         self.address = address

--- a/tests/neo4j/test_direct_driver.py
+++ b/tests/neo4j/test_direct_driver.py
@@ -60,6 +60,7 @@ class TestDirectDriver(TestkitTestCase):
         self.assertEqual(summary.server_info.address, "%s:%d" % (host, port))
         self.assertEqual(resolved_addresses, ["*:7687"])
 
+    @driver_feature(types.Feature.API_DRIVER_VERIFY_CONNECTIVITY)
     def test_fail_nicely_when_using_http_port(self):
         # TODO add support and remove this block
         if get_driver_name() in ["go"]:

--- a/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
+++ b/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
@@ -12,7 +12,10 @@ from tests.stub.shared import StubServer
 
 class TestDirectConnectionRecvTimeout(TestkitTestCase):
 
-    required_features = types.Feature.BOLT_4_3,
+    required_features = (
+        types.Feature.BOLT_4_3,
+        types.Feature.CONF_HINT_CON_RECV_TIMEOUT
+    )
 
     def setUp(self):
         super().setUp()
@@ -234,6 +237,12 @@ class TestDirectConnectionRecvTimeout(TestkitTestCase):
 
 
 class TestRoutingConnectionRecvTimeout(TestDirectConnectionRecvTimeout):
+
+    required_features = (
+        types.Feature.BACKEND_RT_FETCH,
+        *TestDirectConnectionRecvTimeout.required_features,
+    )
+
     def setUp(self):
         TestkitTestCase.setUp(self)
         self._server = StubServer(9010)

--- a/tests/stub/connectivity_check/scripts/handshake_only.script
+++ b/tests/stub/connectivity_check/scripts/handshake_only.script
@@ -1,0 +1,4 @@
+!: BOLT 4.4
+!: AUTO RESET
+
+S: <EXIT>

--- a/tests/stub/connectivity_check/scripts/hello_auth_error.script
+++ b/tests/stub/connectivity_check/scripts/hello_auth_error.script
@@ -1,0 +1,6 @@
+!: BOLT 4.4
+!: AUTO RESET
+
+C: HELLO {"{}": "*"}
+S: FAILURE {"code": "Neo.ClientError.Security.Unauthorized", "message": "The client is unauthorized due to authentication failure."}
+   <EXIT>

--- a/tests/stub/connectivity_check/scripts/hello_only.script
+++ b/tests/stub/connectivity_check/scripts/hello_only.script
@@ -1,0 +1,5 @@
+!: BOLT 4.4
+!: AUTO RESET
+
+A: HELLO {"{}": "*"}
+?: GOODBYE

--- a/tests/stub/connectivity_check/scripts/query_then_resets.script
+++ b/tests/stub/connectivity_check/scripts/query_then_resets.script
@@ -1,0 +1,11 @@
+!: BOLT 4.4
+!: AUTO RESET
+
+A: HELLO {"{}": "*"}
+C: RUN {"U": "*"} {} {"[mode]": {"U": "*"}, "[db]": "*"}
+S: SUCCESS {"fields": ["n"]}
+C: PULL {"n": {"Z": "*"}}
+S: RECORD [1]
+   SUCCESS {"type": "r"}
+*: RESET
+?: GOODBYE

--- a/tests/stub/connectivity_check/scripts/router.script
+++ b/tests/stub/connectivity_check/scripts/router.script
@@ -1,0 +1,12 @@
+!: BOLT 4.4
+
+A: HELLO {"{}": "*"}
+*: RESET
+{{
+    C: ROUTE {"{}": "*"} null {"[db]": null, "[imp_user]": null}
+----
+    C: ROUTE {"{}": "*"} [] {"[db]": null, "[imp_user]": null}
+}}
+S: SUCCESS {"rt": {"ttl": 1000, "db": "homedb", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010"], "role":"READ"}, {"addresses": ["#HOST#:9020"], "role":"WRITE"}]}}
+*: RESET
+?: GOODBYE

--- a/tests/stub/connectivity_check/scripts/router_5_readers.script
+++ b/tests/stub/connectivity_check/scripts/router_5_readers.script
@@ -1,0 +1,12 @@
+!: BOLT 4.4
+
+A: HELLO {"{}": "*"}
+*: RESET
+{{
+    C: ROUTE {"{}": "*"} null {"[db]": null, "[imp_user]": null}
+----
+    C: ROUTE {"{}": "*"} [] {"[db]": null, "[imp_user]": null}
+}}
+S: SUCCESS {"rt": {"ttl": 1000, "db": "homedb", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9020", "#HOST#:9030", "#HOST#:9040", "#HOST#:9050"], "role":"READ"}, {"addresses": ["#HOST#:9060"], "role":"WRITE"}]}}
+*: RESET
+?: GOODBYE

--- a/tests/stub/connectivity_check/scripts/router_changing_home_db.script
+++ b/tests/stub/connectivity_check/scripts/router_changing_home_db.script
@@ -1,0 +1,19 @@
+!: BOLT 4.4
+
+A: HELLO {"{}": "*"}
+*: RESET
+{{
+    C: ROUTE {"{}": "*"} null {"[db]": null, "[imp_user]": null}
+----
+    C: ROUTE {"{}": "*"} [] {"[db]": null, "[imp_user]": null}
+}}
+S: SUCCESS {"rt": {"ttl": 1000, "db": "homedb", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010"], "role":"READ"}, {"addresses": ["#HOST#:9020"], "role":"WRITE"}]}}
+*: RESET
+{{
+    C: ROUTE {"{}": "*"} null {"[db]": null, "[imp_user]": null}
+----
+    C: ROUTE {"{}": "*"} [] {"[db]": null, "[imp_user]": null}
+}}
+S: SUCCESS {"rt": {"ttl": 1000, "db": "homedb2", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9020"], "role":"READ"}, {"addresses": ["#HOST#:9010"], "role":"WRITE"}]}}
+*: RESET
+?: GOODBYE

--- a/tests/stub/connectivity_check/scripts/router_multi.script
+++ b/tests/stub/connectivity_check/scripts/router_multi.script
@@ -1,0 +1,14 @@
+!: BOLT 4.4
+
+A: HELLO {"{}": "*"}
+*: RESET
+{*
+    {{
+        C: ROUTE {"{}": "*"} null {"[db]": null, "[imp_user]": null}
+    ----
+        C: ROUTE {"{}": "*"} [] {"[db]": null, "[imp_user]": null}
+    }}
+    S: SUCCESS {"rt": {"ttl": 1000, "db": "homedb", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010"], "role":"READ"}, {"addresses": ["#HOST#:9020"], "role":"WRITE"}]}}
+    *: RESET
+*}
+?: GOODBYE

--- a/tests/stub/connectivity_check/test_get_server_info.py
+++ b/tests/stub/connectivity_check/test_get_server_info.py
@@ -1,0 +1,219 @@
+from contextlib import contextmanager
+
+from nutkit import protocol as types
+from nutkit.frontend import Driver
+from tests.shared import TestkitTestCase
+from tests.stub.shared import (
+    StubScriptNotFinishedError,
+    StubServer,
+)
+
+
+class TestGetServerInfo(TestkitTestCase):
+
+    required_features = types.Feature.API_DRIVER_GET_SERVER_INFO,
+
+    def setUp(self):
+        super().setUp()
+        self._router = StubServer(9000)
+        self._server1 = StubServer(9010)
+        self._server2 = StubServer(9020)
+        self._server3 = StubServer(9030)
+        self._server4 = StubServer(9040)
+        self._server5 = StubServer(9050)
+        self._server6 = StubServer(9060)
+
+    def tearDown(self):
+        self._router.reset()
+        self._server1.reset()
+        self._server2.reset()
+        self._server3.reset()
+        self._server4.reset()
+        self._server5.reset()
+        self._server6.reset()
+        super().tearDown()
+
+    def _build_result_check_cb(self, expected_port,
+                               expected_agent="Neo4j/4.4.0"):
+        def check(server_info):
+            port = server_info.address.rsplit(":", 1)[1]
+            self.assertEqual(port, str(expected_port))
+            self.assertEqual(server_info.agent, expected_agent)
+            self.assertEqual(server_info.protocol_version, "4.4")
+
+        return check
+
+    def _test_call(self, driver, result_check_cb=None):
+        server_info = driver.get_server_info()
+        if result_check_cb:
+            result_check_cb(server_info)
+
+    def _start_server(self, server, script, vars_=None):
+        vars__ = {"#HOST#": self._router.host}
+        if vars_:
+            vars__.update(vars_)
+        server.start(path=self.script_path(script), vars_=vars__)
+
+    def _create_direct_driver(self):
+        uri = "bolt://%s" % self._server1.address
+        return Driver(
+            self._backend, uri,
+            types.AuthorizationToken("basic", principal="", credentials="")
+        )
+
+    def _create_routing_driver(self):
+        uri = "neo4j://%s" % self._router.address
+        return Driver(
+            self._backend, uri,
+            types.AuthorizationToken("basic", principal="", credentials="")
+        )
+
+    @contextmanager
+    def _direct_driver(self, script=None):
+        if script:
+            self._start_server(self._server1, script)
+        driver = self._create_direct_driver()
+        try:
+            yield driver
+        finally:
+            driver.close()
+
+    @contextmanager
+    def _routing_driver(self, scripts=None):
+        if scripts is None:
+            scripts = {}
+        for server, script in scripts.items():
+            self._start_server(server, script)
+        driver = self._create_routing_driver()
+        try:
+            yield driver
+        finally:
+            driver.close()
+
+    def test_direct_no_server(self):
+        # driver should try to open a connection to the server
+        with self._direct_driver() as driver:
+            with self.assertRaises(types.DriverError):
+                self._test_call(driver)
+
+    def test_direct_raises_error(self):
+        # driver should try to open a connection to the server
+        with self._direct_driver("hello_auth_error.script") as driver:
+            with self.assertRaises(types.DriverError) as exc:
+                self._test_call(driver)
+            self.assertEqual(exc.exception.code,
+                             "Neo.ClientError.Security.Unauthorized")
+
+    def test_direct(self):
+        # driver should open a connection to the server
+        with self._direct_driver("hello_only.script") as driver:
+            self._test_call(driver,
+                            self._build_result_check_cb(self._server1.port))
+        self._server1.done()
+
+    def test_direct_from_pool(self):
+        # driver should pick connection from the pool and send RESET
+        with self._direct_driver("query_then_resets.script") as driver:
+            session = driver.session("r")
+            list(session.run("QUERY"))
+            session.close()
+            resets1 = self._server1.count_requests("RESET")
+            self._test_call(driver,
+                            self._build_result_check_cb(self._server1.port))
+            resets2 = self._server1.count_requests("RESET")
+            if self.driver_supports_features(types.Feature.OPT_MINIMAL_RESETS):
+                self.assertEqual(resets1 + 1, resets2)
+            else:
+                self.assertGreater(resets2, resets1)
+        self._server1.done()
+
+    def test_routing_no_server(self):
+        # driver should try to open a connection to the server
+        with self._routing_driver() as driver:
+            with self.assertRaises(types.DriverError):
+                self._test_call(driver)
+
+    def test_routing_raises_error(self):
+        # driver should try to open a connection to the server
+        with self._routing_driver({
+            self._router: "router.script",
+            self._server1: "hello_auth_error.script",
+        }) as driver:
+            with self.assertRaises(types.DriverError) as exc:
+                self._test_call(driver)
+            self.assertEqual(exc.exception.code,
+                             "Neo.ClientError.Security.Unauthorized")
+
+    def test_routing(self):
+        # driver should open a connection to the server
+        with self._routing_driver({
+            self._router: "router.script",
+            self._server1: "hello_only.script",
+        }) as driver:
+            self._test_call(driver,
+                            self._build_result_check_cb(self._server1.port))
+        self._router.done()
+        self._server1.done()
+
+    def test_routing_from_pool(self):
+        # driver should pick connection from the pool and send RESET
+        with self._routing_driver({
+            self._router: "router_multi.script",
+            self._server1: "query_then_resets.script",
+        }) as driver:
+            session = driver.session("r")
+            list(session.run("QUERY"))
+            session.close()
+            resets1 = self._server1.count_requests("RESET")
+            self.assertEqual(self._router.count_requests("ROUTE"), 1)
+            self._test_call(driver,
+                            self._build_result_check_cb(self._server1.port))
+            self.assertEqual(self._router.count_requests("ROUTE"), 2)
+            resets2 = self._server1.count_requests("RESET")
+            if self.driver_supports_features(types.Feature.OPT_MINIMAL_RESETS):
+                self.assertEqual(resets1 + 1, resets2)
+            else:
+                self.assertGreater(resets2, resets1)
+        self._router.done()
+        self._server1.done()
+
+    def test_routing_fetches_home_db(self):
+        # driver should pick connection from the pool and send RESET
+        with self._routing_driver({
+            self._router: "router_changing_home_db.script",
+            self._server1: "hello_only.script",
+            self._server2: "hello_only.script",
+        }) as driver:
+            # resolves home db and received server1 as reader
+            self._test_call(driver,
+                            self._build_result_check_cb(self._server1.port))
+            self._server1.done()
+            # resolves home db again and received server2 as reader
+            self._test_call(driver,
+                            self._build_result_check_cb(self._server2.port))
+            self._server2.done()
+        self._router.done()
+
+    def test_routing_tries_all_readers(self):
+        # driver should pick connection from the pool and send RESET
+        with self._routing_driver({
+            self._router: "router_5_readers.script",
+            self._server1: "handshake_only.script",
+            self._server2: "handshake_only.script",
+            self._server3: "handshake_only.script",
+            self._server4: "handshake_only.script",
+            self._server5: "handshake_only.script",
+            self._server6: "handshake_only.script",
+        }) as driver:
+            # resolves home db and received server1 as reader
+            with self.assertRaises(types.DriverError):
+                self._test_call(driver)
+        self._server1.done()
+        self._server2.done()
+        self._server3.done()
+        self._server4.done()
+        self._server5.done()
+        with self.assertRaises(StubScriptNotFinishedError):
+            # driver should not try to contact the writer
+            self._server6.done()
+        self._router.done()

--- a/tests/stub/connectivity_check/test_verify_connectivity.py
+++ b/tests/stub/connectivity_check/test_verify_connectivity.py
@@ -1,0 +1,16 @@
+from nutkit import protocol as types
+from tests.stub.connectivity_check.test_get_server_info import (
+    TestGetServerInfo,
+)
+
+
+# Driver.VerifyConnectivity should do exactly what Driver.GetServerInfo does,
+# except it should void the result.
+class TestVerifyConnectivity(TestGetServerInfo):
+    required_features = types.Feature.API_DRIVER_VERIFY_CONNECTIVITY,
+
+    def _build_result_check_cb(self, *args, **kwargs):
+        return None
+
+    def _test_call(self, driver, result_check_cb=None):
+        driver.verify_connectivity()


### PR DESCRIPTION
Tests are guarded by feature flags:
 * `API_DRIVER_GET_SERVER_INFO = "Feature:API:Driver:GetServerInfo"`
 * `API_DRIVER_VERIFY_CONNECTIVITY = "Feature:API:Driver.VerifyConnectivity"`

This PR also cleans up tests that ab-used `verifyConnectivity` to force the
driver to refresh the routing table. In this context, further new feature flags
were introduced:
 * `BACKEND_RT_FETCH = "Backend:RTFetch"`
 * `BACKEND_RT_FORCE_UPDATE = "Backend:RTForceUpdate"`