### PR TITLE
Improve dumping of stub server output on script mismatch

### DIFF
--- a/tests/stub/shared.py
+++ b/tests/stub/shared.py
@@ -184,13 +184,13 @@ class StubServer:
         self._clean_up()
 
     def _poll(self, timeout):
-        polls = int(timeout * 10)
+        polls = int(timeout * 50)
         while True:
             self._process.poll()
             if self._process.returncode is None:
                 if polls > 0:
                     polls -= 1
-                    time.sleep(0.1)
+                    time.sleep(0.02)
                 else:
                     break
             else:
@@ -268,6 +268,8 @@ class StubServer:
         output.
         """
         if self._process:
+            # give it some time to fully shut down if there was an error
+            self._poll(0.1)
             # briefly try to get a shutdown that will dump script mismatches
             self._interrupt(.3)
             self._interrupt(0)


### PR DESCRIPTION
This is still not a guarantee that a script mismatch will be dumped on
`StubServer.reset` as there is a race condition going on that cannot be solved
with how communication between the StubServer and TestKit is currently
implemented, but it should increase the odds of a dump significantly.

Signed-off-by: Antonio Barcelos <antonio.barcelos@neo4j.com>