### PR TITLE
Adjusting the `no writers` tests

### DIFF
--- a/tests/stub/routing/scripts/v3/router_yielding_no_writers_any_db.script
+++ b/tests/stub/routing/scripts/v3/router_yielding_no_writers_any_db.script
@@ -6,5 +6,5 @@ S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": #ROUTINGCTX#} {"[mode]": "r"}
 S: SUCCESS {"fields": ["ttl", "servers"]}
 C: PULL_ALL
-S: RECORD [1000, [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": [], "role":"WRITE"}]]
+S: RECORD [1000, [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010"], "role":"READ"}, {"addresses": [], "role":"WRITE"}]]
    SUCCESS {"type": "r"}

--- a/tests/stub/routing/scripts/v4x1/router_yielding_no_writers_any_db.script
+++ b/tests/stub/routing/scripts/v4x1/router_yielding_no_writers_any_db.script
@@ -10,7 +10,7 @@ S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 }}
 C: PULL {"n": -1}
 S: SUCCESS {"fields": ["ttl", "servers"]}
-   RECORD [1000, [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": [], "role":"WRITE"}]]
+   RECORD [1000, [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010"], "role":"READ"}, {"addresses": [], "role":"WRITE"}]]
    SUCCESS {"type": "r"}
 *: RESET
 ?: GOODBYE

--- a/tests/stub/routing/scripts/v4x3/router_yielding_no_writers_any_db.script
+++ b/tests/stub/routing/scripts/v4x3/router_yielding_no_writers_any_db.script
@@ -4,5 +4,5 @@
 C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 C: ROUTE #ROUTINGCTX# "*" "*"
-S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": [], "role":"WRITE"}]}}
+S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010"], "role":"READ"}, {"addresses": [], "role":"WRITE"}]}}
 ?: GOODBYE

--- a/tests/stub/routing/scripts/v4x4/router_yielding_no_writers_any_db.script
+++ b/tests/stub/routing/scripts/v4x4/router_yielding_no_writers_any_db.script
@@ -4,5 +4,5 @@
 C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 C: ROUTE #ROUTINGCTX# "*" {"[db]": {"U": "*"}}
-S: SUCCESS { "rt": { "ttl": 1000, "db": "any-db", "servers": [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": [], "role":"WRITE"}]}}
+S: SUCCESS { "rt": { "ttl": 1000, "db": "any-db", "servers": [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010"], "role":"READ"}, {"addresses": [], "role":"WRITE"}]}}
 ?: GOODBYE


### PR DESCRIPTION
The tests was setting two different readers in the routing table, but it was not starting all the readers.
This was causing random failures in the tests.

Removing the second reader make the test more predictable and avoid possible flackyness.