### PR TITLE
Add tests scenarios for VerifyConnectivity and GetServerInfo

### DIFF
--- a/tests/stub/connectivity_check/scripts/router_no_readers.script
+++ b/tests/stub/connectivity_check/scripts/router_no_readers.script
@@ -1,0 +1,12 @@
+!: BOLT 4.4
+
+A: HELLO {"{}": "*"}
+*: RESET
+{{
+    C: ROUTE {"{}": "*"} null {"[db]": null, "[imp_user]": null}
+----
+    C: ROUTE {"{}": "*"} [] {"[db]": null, "[imp_user]": null}
+}}
+S: SUCCESS {"rt": {"ttl": 1000, "db": "homedb", "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": [], "role":"READ"}, {"addresses": ["#HOST#:9020"], "role":"WRITE"}]}}
+*: RESET
+?: GOODBYE

--- a/tests/stub/connectivity_check/test_get_server_info.py
+++ b/tests/stub/connectivity_check/test_get_server_info.py
@@ -230,11 +230,17 @@ class TestGetServerInfo(TestkitTestCase):
             self._server4: "hello_only.script"
         }) as driver:
             self._test_call(driver)
-        self._server3.done()
 
-        with self.assertRaises(StubScriptNotFinishedError):
-            # driver should not try to contact the forth reader
+        # Should connect to one of the reader,
+        # but not both
+        try:
+            self._server3.done()
+        except StubScriptNotFinishedError:
             self._server4.done()
+        else:
+            with self.assertRaises(StubScriptNotFinishedError):
+                self._server4.done()
+
         self._router.done()
 
     def test_routing_fail_when_no_reader_are_available(self):

--- a/tests/stub/connectivity_check/test_get_server_info.py
+++ b/tests/stub/connectivity_check/test_get_server_info.py
@@ -222,3 +222,31 @@ class TestGetServerInfo(TestkitTestCase):
             # driver should not try to contact the writer
             self._server6.done()
         self._router.done()
+
+    def test_routing_should_resolve_if_at_least_one_reader_is_up(self):
+        with self._routing_driver({
+            self._router: "router_5_readers.script",
+            self._server3: "hello_only.script",
+            self._server4: "hello_only.script"
+        }) as driver:
+            self._test_call(driver)
+        self._server3.done()
+
+        with self.assertRaises(StubScriptNotFinishedError):
+            # driver should not try to contact the forth reader
+            self._server4.done()
+        self._router.done()
+
+    def test_routing_fail_when_no_reader_are_available(self):
+        with self._routing_driver({
+            self._router: "router_no_readers.script",
+            self._server2: "hello_only.script",  # the writer
+        }) as driver:
+            # no readers are up
+            with self.assertRaises(types.DriverError):
+                self._test_call(driver)
+
+        with self.assertRaises(StubScriptNotFinishedError):
+            # driver should not try to contact the writer
+            self._server2.done()
+        self._router.done()


### PR DESCRIPTION
There were two scenarios not covered by tests.
The first one is the case some readers are down and others are running.
The second case is when there are not readers available.