### PR TITLE
Update connection acquisition timeout feature flags

### DIFF
--- a/nutkit/protocol/feature.py
+++ b/nutkit/protocol/feature.py
@@ -4,6 +4,13 @@ from enum import Enum
 
 class Feature(Enum):
     # === FUNCTIONAL FEATURES ===
+    # The driver offers a configuration option to limit time it spend at most,
+    # trying to acquire a connection from the pool.
+    # The connection acquisition timeout must account for the whole acquisition
+    # execution time, whether a new connection is created, an idle connection
+    # is picked up instead or we need to wait until the full pool depletes.
+    API_CONNECTION_ACQUISITION_TIMEOUT = \
+        "Feature:API:ConnectionAcquisitionTimeout"
     # The driver offers a method for checking if a connection to the remote
     # server of cluster can be established and retrieve the server info of the
     # reached remote.
@@ -22,7 +29,7 @@ class Feature(Enum):
     # records)
     API_RESULT_PEEK = "Feature:API:Result.Peek"
     # The driver offers a method for the result to retrieve exactly one record.
-    # This methods asserts that exactly one record in left in the result
+    # This method asserts that exactly one record in left in the result
     # stream, else it will raise an exception.
     API_RESULT_SINGLE = "Feature:API:Result.Single"
     # The driver supports connection liveness check.
@@ -71,13 +78,6 @@ class Feature(Enum):
     # If this flag is missing, TestKit assumes that attempting to establish
     # such a connection fails.
     TLS_1_3 = "Feature:TLS:1.3"
-    # The driver configuration connection_acquisition_timeout_ms
-    # should be suported.
-    # The connection acquisition timeout must account for the whole acquisition
-    # execution time, whether a new connection is created, an idle connection
-    # is picked up instead or we need to wait until the full pool depletes.
-    CONNECTION_ACQUISITION_TIMEOUT = \
-        "Feature:Configuration:ConnectionAcquisitionTimeout"
 
     # === OPTIMIZATIONS ===
     # On receiving Neo.ClientError.Security.AuthorizationExpired, the driver
@@ -138,10 +138,6 @@ class Feature(Enum):
     # should not be exposed to the user).
     BACKEND_RT_FORCE_UPDATE = "Backend:RTForceUpdate"
 
-    # Temporary driver feature that will be removed when all official driver
-    # backends have implemented the connection acquisition timeout config.
-    TMP_CONNECTION_ACQUISITION_TIMEOUT = \
-        "Temporary:ConnectionAcquisitionTimeout"
     # Temporary driver feature that will be removed when all official driver
     # backends have implemented path and relationship types
     TMP_CYPHER_PATH_AND_RELATIONSHIP = "Temporary:CypherPathAndRelationship"

--- a/nutkit/protocol/requests.py
+++ b/nutkit/protocol/requests.py
@@ -80,12 +80,7 @@ class NewDriver:
         assert hasattr(Feature, "TMP_DRIVER_MAX_CONNECTION_POOL_SIZE")
         if max_connection_pool_size is not None:
             self.maxConnectionPoolSize = max_connection_pool_size
-        # TODO: remove assertion and condition as soon as all drivers support
-        #       driver-scoped connection acquisition timeout config
-        assert hasattr(Feature, "TMP_CONNECTION_ACQUISITION_TIMEOUT")
-        if connection_acquisition_timeout_ms is not None:
-            self.connectionAcquisitionTimeoutMs = \
-                connection_acquisition_timeout_ms
+        self.connectionAcquisitionTimeoutMs = connection_acquisition_timeout_ms
         # (bool) whether to enable or disable encryption
         # field missing in message: use driver default (should be False)
         if encrypted is not None:

--- a/tests/stub/driver_parameters/test_connection_acquisition_timeout_ms.py
+++ b/tests/stub/driver_parameters/test_connection_acquisition_timeout_ms.py
@@ -33,7 +33,7 @@ class TestConnectionAcquisitionTimeoutMs(TestkitTestCase):
 
     required_features = (
         types.Feature.BOLT_4_4,
-        types.Feature.CONNECTION_ACQUISITION_TIMEOUT
+        types.Feature.API_CONNECTION_ACQUISITION_TIMEOUT
     )
 
     def setUp(self):

--- a/tests/stub/driver_parameters/test_max_connection_pool_size.py
+++ b/tests/stub/driver_parameters/test_max_connection_pool_size.py
@@ -44,7 +44,7 @@ class TestMaxConnectionPoolSize(TestkitTestCase):
         assert self._driver is None
         kwargs = {}
         if self.driver_supports_features(
-            types.Feature.TMP_CONNECTION_ACQUISITION_TIMEOUT
+            types.Feature.API_CONNECTION_ACQUISITION_TIMEOUT
         ):
             kwargs["connection_acquisition_timeout_ms"] = 500
         if max_pool_size is not None:
@@ -57,7 +57,7 @@ class TestMaxConnectionPoolSize(TestkitTestCase):
     @contextmanager
     def _backend_timeout_adjustment(self):
         if self.driver_supports_features(
-            types.Feature.TMP_CONNECTION_ACQUISITION_TIMEOUT
+            types.Feature.API_CONNECTION_ACQUISITION_TIMEOUT
         ):
             yield
         else:

--- a/tests/stub/routing/test_routing_v5x0.py
+++ b/tests/stub/routing/test_routing_v5x0.py
@@ -2794,7 +2794,7 @@ class RoutingV5x0(RoutingBase):
         self._writeServer1.done()
 
     @driver_feature(types.Feature.TMP_DRIVER_MAX_CONNECTION_POOL_SIZE,
-                    types.Feature.TMP_CONNECTION_ACQUISITION_TIMEOUT)
+                    types.Feature.API_CONNECTION_ACQUISITION_TIMEOUT)
     def test_should_enforce_pool_size_per_cluster_member(self):
         acq_timeout_ms = 100
         driver = Driver(self._backend, self._uri_with_context, self._auth,


### PR DESCRIPTION
 * Drop "Temporary:ConnectionAcquisitionTimeout" which is now supported by all
   official drivers' backend
 * Rename "Feature:Configuration:ConnectionAcquisitionTimeout" to
   "Feature:API:ConnectionAcquisitionTimeout"

Depends on:
 * https://github.com/neo4j/neo4j-python-driver/pull/676
 * https://github.com/neo4j/neo4j-dotnet-driver/pull/596
 * https://github.com/neo4j/neo4j-java-driver/pull/1179
 * https://github.com/neo4j/neo4j-go-driver/pull/329
 * https://github.com/neo4j/neo4j-javascript-driver/pull/894