### PR TITLE
Add tests for languages to throw on reading id with new storage engine enabled

### DIFF
--- a/boltstub/bolt_protocol.py
+++ b/boltstub/bolt_protocol.py
@@ -87,8 +87,8 @@ class BoltProtocol:
         assert isinstance(b, (bytes, bytearray))
         assert len(b) == 16
         for spec in (b[i:(i + 4)] for i in range(0, 16, 4)):
-            _, range_, minor, major = spec
-            for minor in range(minor, minor - range_ - 1, -1):
+            _, range_, spec_minor, major = spec
+            for minor in range(spec_minor, spec_minor - range_ - 1, -1):
                 yield major, minor
 
     @classmethod

--- a/nutkit/frontend/result.py
+++ b/nutkit/frontend/result.py
@@ -36,6 +36,11 @@ class Result:
         assert isinstance(res, protocol.RecordList)
         return res.records
 
+    def read_cypher_type_field(self, record_key, type_name, field_id):
+        req = protocol.CypherTypeField(self._result.id, record_key, type_name,
+                                       field_id)
+        return self._driver.send_and_receive(req, allow_resolution=True)
+
     def keys(self):
         return self._result.keys
 

--- a/nutkit/protocol/feature.py
+++ b/nutkit/protocol/feature.py
@@ -126,7 +126,7 @@ class Feature(Enum):
     # if the server doesn't provide them. If the driver does not report this
     # feature flag,TestKit will assert the value to be -1/null instead.
     DETAIL_THROW_ON_MISSING_ID = "Detail:ThrowOnMissingId"
-    
+
     # === CONFIGURATION HINTS (BOLT 4.3+) ===
     # The driver understands and follow the connection hint
     # connection.recv_timeout_seconds which tells it to close the connection

--- a/nutkit/protocol/feature.py
+++ b/nutkit/protocol/feature.py
@@ -122,7 +122,10 @@ class Feature(Enum):
     # doesn't provide them. If the driver does not report this feature flag,
     # TestKit will assert the value to be -1 instead.
     DETAIL_NULL_ON_MISSING_ID = "Detail:NullOnMissingId"
-
+    # The driver throws when trying to access the id of nodes and relationships
+    # if the server doesn't provide them. If the driver does not report this
+    # feature flag,TestKit will assert the value to be -1/null instead.
+    DETAIL_THROW_ON_MISSING_ID = "Detail:ThrowOnMissingId"
     # === CONFIGURATION HINTS (BOLT 4.3+) ===
     # The driver understands and follow the connection hint
     # connection.recv_timeout_seconds which tells it to close the connection

--- a/nutkit/protocol/feature.py
+++ b/nutkit/protocol/feature.py
@@ -126,6 +126,7 @@ class Feature(Enum):
     # if the server doesn't provide them. If the driver does not report this
     # feature flag,TestKit will assert the value to be -1/null instead.
     DETAIL_THROW_ON_MISSING_ID = "Detail:ThrowOnMissingId"
+    
     # === CONFIGURATION HINTS (BOLT 4.3+) ===
     # The driver understands and follow the connection hint
     # connection.recv_timeout_seconds which tells it to close the connection

--- a/nutkit/protocol/requests.py
+++ b/nutkit/protocol/requests.py
@@ -504,3 +504,18 @@ class GetConnectionPoolMetrics:
     def __init__(self, driverId, address):
         self.driverId = driverId
         self.address = address
+
+
+class CypherTypeField:
+    """
+    Request to retrieve the next record on a result then extract field.
+
+    Backend should respond with a Field if there is field on a record,
+    an Error if error occurred while retrieving next record or reading field.
+    """
+
+    def __init__(self, result_id, record_key, type_name, field_id):
+        self.resultId = result_id
+        self.recordKey = record_key
+        self.type = type_name
+        self.field = field_id

--- a/nutkit/protocol/responses.py
+++ b/nutkit/protocol/responses.py
@@ -169,6 +169,24 @@ class Record:
         return self.__str__()
 
 
+class Field:
+    """A field received from reading a Result's Record."""
+
+    def __init__(self, value=None):
+        self.value = value
+
+    def __eq__(self, other):
+        if not isinstance(other, Field):
+            return False
+        return other.value == self.value
+
+    def __str__(self):
+        return "Field, value {}".format(self.value)
+
+    def __repr__(self):
+        return self.__str__()
+
+
 class NullRecord:
     """Represents end of records when iterating through records with Next."""
 

--- a/tests/stub/basic_query/test_basic_query.py
+++ b/tests/stub/basic_query/test_basic_query.py
@@ -226,8 +226,8 @@ class TestBasicQuery(TestkitTestCase):
                 '{"->": [null, null, "f", null, {"a": {"Z": "42"}}, "r1-123", '
                 '"n1-1", "n1-2"]}'
         }
-        for field in ["id", "startnodeid", "endnodeid"]:
-            with self.subTest(f"field:{field}"):
+        for field in ["id", "startNodeId", "endNodeId"]:
+            with self.subTest(field=field):
                 with self._get_session("single_result.script",
                                        script_params) as session:
                     result_handle = session.run("MATCH (n) RETURN n LIMIT 1")
@@ -366,7 +366,7 @@ class TestBasicQuery(TestkitTestCase):
 
     @driver_feature(types.Feature.BOLT_5_0,
                     types.Feature.DETAIL_THROW_ON_MISSING_ID)
-    def test_5x0_throws_on_reading_ids(self):
+    def test_5x0_path_throws_on_access_id_fields(self):
         script_params = {
             "#BOLT_PROTOCOL#": "5.0",
             "#RESULT#":
@@ -381,13 +381,13 @@ class TestBasicQuery(TestkitTestCase):
                 ']}'  # noqa: Q000
         }
         cases = [
-            "n.0.id",
-            "r.0.id",
-            "r.0.startnodeid",
-            "r.0.endnodeid"
+            "nodes.0.id",
+            "relationships.0.id",
+            "relationships.0.startNodeId",
+            "relationships.0.endNodeId"
         ]
         for field in cases:
-            with self.subTest(f"field:{field}"):
+            with self.subTest(field=field):
                 with self._get_session("single_result.script",
                                        script_params) as session:
 

--- a/tests/stub/basic_query/test_basic_query.py
+++ b/tests/stub/basic_query/test_basic_query.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 from nutkit import protocol as types
 from nutkit.frontend import Driver
 from nutkit.protocol import (
@@ -19,15 +21,9 @@ class TestBasicQuery(TestkitTestCase):
     def setUp(self):
         super().setUp()
         self._server = StubServer(9001)
-        uri = "bolt://%s" % self._server.address
-        self._driver = Driver(self._backend, uri,
-                              types.AuthorizationToken("basic", principal="",
-                                                       credentials=""))
         self._session = None
 
     def tearDown(self):
-        if self._session is not None:
-            self._session.close()
         self._server.reset()
         super().tearDown()
 
@@ -51,28 +47,44 @@ class TestBasicQuery(TestkitTestCase):
         ):
             self.assertEqual(expected, actual)
 
+    def _validate_invalid_operation(self, exc):
+        if get_driver_name() in ["dotnet"]:
+            self.assertEqual("InvalidOperationException",
+                             exc.exception.errorType)
+
+    @contextmanager
+    def _get_session(self, script_path, vars_=None):
+        uri = "bolt://%s" % self._server.address
+        driver = Driver(self._backend, uri,
+                        types.AuthorizationToken("basic", principal="",
+                                                 credentials=""))
+        self._server.start(path=self.script_path(script_path), vars_=vars_)
+        session = driver.session("r", fetch_size=1)
+        try:
+            yield session
+        finally:
+            session.close()
+            driver.close()
+            self._server.reset()
+
     @driver_feature(types.Feature.BOLT_4_4)
     def test_4x4_populates_node_element_id_with_id(self):
         script_params = {
             "#BOLT_PROTOCOL#": "4.4",
             "#RESULT#": '{"()": [123, ["l1", "l2"], {"a": {"Z": "42"}}]}'
         }
-        self._server.start(
-            path=self.script_path("single_result.script"),
-            vars_=script_params
-        )
 
-        self._session = self._driver.session("r", fetch_size=1)
-        result_handle = self._session.run("MATCH (n) RETURN n LIMIT 1")
+        with self._get_session("single_result.script",
+                               script_params) as session:
+            result_handle = session.run("MATCH (n) RETURN n LIMIT 1")
 
-        node = result_handle.next()
+            node = result_handle.next()
 
-        self.assertEqual(CypherInt(123), node.values[0].id)
-        self._assert_element_id(CypherString("123"), node.values[0].elementId)
+            self.assertEqual(CypherInt(123), node.values[0].id)
+            self._assert_element_id(CypherString("123"), node.values[0]
+                                    .elementId)
 
-        self._session.close()
-        self._session = None
-        self._server.done()
+            self._server.done()
 
     @driver_feature(types.Feature.BOLT_5_0)
     def test_5x0_populates_node_element_id_with_string(self):
@@ -81,22 +93,16 @@ class TestBasicQuery(TestkitTestCase):
             "#RESULT#":
                 '{"()": [123, ["l1", "l2"], {"a": {"Z": "42"}}, "123"]}'
         }
-        self._server.start(
-            path=self.script_path("single_result.script"),
-            vars_=script_params
-        )
+        with self._get_session("single_result.script",
+                               script_params) as session:
+            result_handle = session.run("MATCH (n) RETURN n LIMIT 1")
 
-        self._session = self._driver.session("r", fetch_size=1)
-        result_handle = self._session.run("MATCH (n) RETURN n LIMIT 1")
+            node = result_handle.next()
 
-        node = result_handle.next()
+            self.assertEqual(CypherInt(123), node.values[0].id)
+            self.assertEqual(CypherString("123"), node.values[0].elementId)
 
-        self.assertEqual(CypherInt(123), node.values[0].id)
-        self.assertEqual(CypherString("123"), node.values[0].elementId)
-
-        self._session.close()
-        self._session = None
-        self._server.done()
+            self._server.done()
 
     @driver_feature(types.Feature.BOLT_5_0)
     def test_5x0_populates_node_only_element_id(self):
@@ -105,23 +111,16 @@ class TestBasicQuery(TestkitTestCase):
             "#RESULT#":
                 '{"()": [null, ["l1", "l2"], {"a": {"Z": "42"}}, "n1-123"]}'
         }
+        with self._get_session("single_result.script",
+                               script_params) as session:
+            result_handle = session.run("MATCH (n) RETURN n LIMIT 1")
 
-        self._server.start(
-            path=self.script_path("single_result.script"),
-            vars_=script_params
-        )
+            node = result_handle.next()
 
-        self._session = self._driver.session("r", fetch_size=1)
-        result_handle = self._session.run("MATCH (n) RETURN n LIMIT 1")
+            self._assert_is_unset_id(node.values[0].id)
+            self.assertEqual(CypherString("n1-123"), node.values[0].elementId)
 
-        node = result_handle.next()
-
-        self._assert_is_unset_id(node.values[0].id)
-        self.assertEqual(CypherString("n1-123"), node.values[0].elementId)
-
-        self._session.close()
-        self._session = None
-        self._server.done()
+            self._server.done()
 
     @driver_feature(types.Feature.BOLT_5_0,
                     types.Feature.DETAIL_THROW_ON_MISSING_ID)
@@ -131,25 +130,15 @@ class TestBasicQuery(TestkitTestCase):
             "#RESULT#":
                 '{"()": [null, ["l1", "l2"], {"a": {"Z": "42"}}, "n1-123"]}'
         }
+        with self._get_session("single_result.script",
+                               script_params) as session:
+            result_handle = session.run("MATCH (n) RETURN n LIMIT 1")
 
-        self._server.start(
-            path=self.script_path("single_result.script"),
-            vars_=script_params
-        )
+            with self.assertRaises(types.DriverError) as exc:
+                result_handle.read_cypher_type_field("n", "node", "id")
+            self._validate_invalid_operation(exc)
 
-        self._session = self._driver.session("r", fetch_size=1)
-        result_handle = self._session.run("MATCH (n) RETURN n LIMIT 1")
-
-        with self.assertRaises(types.DriverError) as exc:
-            result_handle.read_cypher_type_field("n", "node", "id")
-
-        if get_driver_name() in ["dotnet"]:
-            self.assertEqual("InvalidOperationException",
-                             exc.exception.errorType)
-
-        self._session.close()
-        self._session = None
-        self._server.done()
+            self._server.done()
 
     @driver_feature(types.Feature.BOLT_4_4)
     def test_4x4_populates_rel_element_id_with_id(self):
@@ -157,29 +146,23 @@ class TestBasicQuery(TestkitTestCase):
             "#BOLT_PROTOCOL#": "4.4",
             "#RESULT#": '{"->": [123, 1, "f", 2, {"a": {"Z": "42"}}]}'
         }
+        with self._get_session("single_result.script",
+                               script_params) as session:
+            result_handle = session.run("MATCH ()-[r:]-() RETURN r LIMIT 1")
 
-        self._server.start(
-            path=self.script_path("single_result.script"),
-            vars_=script_params
-        )
-        self._session = self._driver.session("r", fetch_size=1)
-        result_handle = self._session.run("MATCH ()-[r:]-() RETURN r LIMIT 1")
+            relationship = result_handle.next()
 
-        relationship = result_handle.next()
+            self.assertEqual(CypherInt(123), relationship.values[0].id)
+            self._assert_element_id(CypherString("123"),
+                                    relationship.values[0].elementId)
+            self.assertEqual(CypherInt(1), relationship.values[0].startNodeId)
+            self.assertEqual(CypherInt(2), relationship.values[0].endNodeId)
+            self._assert_element_id(CypherString("1"),
+                                    relationship.values[0].startNodeElementId)
+            self._assert_element_id(CypherString("2"),
+                                    relationship.values[0].endNodeElementId)
 
-        self.assertEqual(CypherInt(123), relationship.values[0].id)
-        self._assert_element_id(CypherString("123"),
-                                relationship.values[0].elementId)
-        self.assertEqual(CypherInt(1), relationship.values[0].startNodeId)
-        self.assertEqual(CypherInt(2), relationship.values[0].endNodeId)
-        self._assert_element_id(CypherString("1"),
-                                relationship.values[0].startNodeElementId)
-        self._assert_element_id(CypherString("2"),
-                                relationship.values[0].endNodeElementId)
-
-        self._session.close()
-        self._session = None
-        self._server.done()
+            self._server.done()
 
     @driver_feature(types.Feature.BOLT_5_0)
     def test_5x0_populates_rel_element_id_with_string(self):
@@ -189,28 +172,23 @@ class TestBasicQuery(TestkitTestCase):
                 '{"->": [123, 1, "f", 2, {"a": {"Z": "42"}}, "123", '
                 '"1", "2"]}'
         }
-        self._server.start(
-            path=self.script_path("single_result.script"),
-            vars_=script_params
-        )
-        self._session = self._driver.session("r", fetch_size=1)
-        result_handle = self._session.run("MATCH ()-[r:]-() RETURN r LIMIT 1")
+        with self._get_session("single_result.script",
+                               script_params) as session:
+            result_handle = session.run("MATCH ()-[r:]-() RETURN r LIMIT 1")
 
-        relationship = result_handle.next()
+            relationship = result_handle.next()
 
-        self.assertEqual(CypherInt(123), relationship.values[0].id)
-        self.assertEqual(CypherString("123"),
-                         relationship.values[0].elementId)
-        self.assertEqual(CypherInt(1), relationship.values[0].startNodeId)
-        self.assertEqual(CypherInt(2), relationship.values[0].endNodeId)
-        self.assertEqual(CypherString("1"),
-                         relationship.values[0].startNodeElementId)
-        self.assertEqual(CypherString("2"),
-                         relationship.values[0].endNodeElementId)
+            self.assertEqual(CypherInt(123), relationship.values[0].id)
+            self.assertEqual(CypherString("123"),
+                             relationship.values[0].elementId)
+            self.assertEqual(CypherInt(1), relationship.values[0].startNodeId)
+            self.assertEqual(CypherInt(2), relationship.values[0].endNodeId)
+            self.assertEqual(CypherString("1"),
+                             relationship.values[0].startNodeElementId)
+            self.assertEqual(CypherString("2"),
+                             relationship.values[0].endNodeElementId)
 
-        self._session.close()
-        self._session = None
-        self._server.done()
+            self._server.done()
 
     @driver_feature(types.Feature.BOLT_5_0)
     def test_5x0_populates_rel_only_element_id(self):
@@ -220,30 +198,47 @@ class TestBasicQuery(TestkitTestCase):
                 '{"->": [null, null, "f", null, {"a": {"Z": "42"}}, "r1-123", '
                 '"n1-1", "n1-2"]}'
         }
+        with self._get_session("single_result.script",
+                               script_params) as session:
+            result_handle = session.run("MATCH (n) RETURN n LIMIT 1")
 
-        self._server.start(
-            path=self.script_path("single_result.script"),
-            vars_=script_params
-        )
-        self._session = self._driver.session("r", fetch_size=1)
-        result_handle = self._session.run("MATCH (n) RETURN n LIMIT 1")
+            relationship = result_handle.next()
 
-        relationship = result_handle.next()
+            self._assert_is_unset_id(relationship.values[0].id)
+            self.assertEqual(CypherString("r1-123"),
+                             relationship.values[0].elementId)
 
-        self._assert_is_unset_id(relationship.values[0].id)
-        self.assertEqual(CypherString("r1-123"),
-                         relationship.values[0].elementId)
+            self._assert_is_unset_id(relationship.values[0].startNodeId)
+            self._assert_is_unset_id(relationship.values[0].endNodeId)
+            self.assertEqual(CypherString("n1-1"),
+                             relationship.values[0].startNodeElementId)
+            self.assertEqual(CypherString("n1-2"),
+                             relationship.values[0].endNodeElementId)
 
-        self._assert_is_unset_id(relationship.values[0].startNodeId)
-        self._assert_is_unset_id(relationship.values[0].endNodeId)
-        self.assertEqual(CypherString("n1-1"),
-                         relationship.values[0].startNodeElementId)
-        self.assertEqual(CypherString("n1-2"),
-                         relationship.values[0].endNodeElementId)
+            self._server.done()
 
-        self._session.close()
-        self._session = None
-        self._server.done()
+    @driver_feature(types.Feature.BOLT_5_0,
+                    types.Feature.DETAIL_THROW_ON_MISSING_ID)
+    def test_5x0_throws_on_relationship_access_id_fields(self):
+        script_params = {
+            "#BOLT_PROTOCOL#": "5.0",
+            "#RESULT#":
+                '{"->": [null, null, "f", null, {"a": {"Z": "42"}}, "r1-123", '
+                '"n1-1", "n1-2"]}'
+        }
+        for field in ["id", "startnodeid", "endnodeid"]:
+            with self.subTest(f"field:{field}"):
+                with self._get_session("single_result.script",
+                                       script_params) as session:
+                    result_handle = session.run("MATCH (n) RETURN n LIMIT 1")
+
+                    with self.assertRaises(types.DriverError) as exc:
+                        result_handle.read_cypher_type_field("n",
+                                                             "relationship",
+                                                             field)
+                    self._validate_invalid_operation(exc)
+
+                    self._server.done()
 
     @driver_feature(types.Feature.BOLT_4_4)
     def test_4x4_populates_path_element_ids_with_long(self):
@@ -258,35 +253,34 @@ class TestBasicQuery(TestkitTestCase):
                 '{"()": [1, ["l"], {}]}'
                 ']}'  # noqa: Q000
         }
+        with self._get_session("single_result.script",
+                               script_params) as session:
 
-        self._server.start(
-            path=self.script_path("single_result.script"),
-            vars_=script_params
-        )
-        self._session = self._driver.session("r", fetch_size=1)
-        result_handle = self._session.run("MATCH p = ()--()--() "
-                                          "RETURN p LIMIT 1")
-        result = result_handle.next()
-        self.assertIsInstance(result.values[0], CypherPath)
-        path = result.values[0]
-        self.assertIsInstance(path.nodes, CypherList)
-        self.assertIsInstance(path.relationships, CypherList)
-        nodes = path.nodes.value
-        rels = path.relationships.value
-        # node ids
-        self.assertEqual(CypherInt(1), nodes[0].id)
-        self._assert_element_id(CypherString("1"), nodes[0].elementId)
-        # rel ids
-        self.assertEqual(CypherInt(2), rels[0].id)
-        self._assert_element_id(CypherString("2"), rels[0].elementId)
-        # rel start/end ids
-        self.assertEqual(CypherInt(1), rels[0].startNodeId)
-        self.assertEqual(CypherInt(3), rels[0].endNodeId)
-        self._assert_element_id(CypherString("1"), rels[0].startNodeElementId)
-        self._assert_element_id(CypherString("3"), rels[0].endNodeElementId)
-        self._session.close()
-        self._session = None
-        self._server.done()
+            result_handle = session.run("MATCH p = ()--()--() "
+                                        "RETURN p LIMIT 1")
+
+            result = result_handle.next()
+            self.assertIsInstance(result.values[0], CypherPath)
+            path = result.values[0]
+            self.assertIsInstance(path.nodes, CypherList)
+            self.assertIsInstance(path.relationships, CypherList)
+            nodes = path.nodes.value
+            rels = path.relationships.value
+            # node ids
+            self.assertEqual(CypherInt(1), nodes[0].id)
+            self._assert_element_id(CypherString("1"), nodes[0].elementId)
+            # rel ids
+            self.assertEqual(CypherInt(2), rels[0].id)
+            self._assert_element_id(CypherString("2"), rels[0].elementId)
+            # rel start/end ids
+            self.assertEqual(CypherInt(1), rels[0].startNodeId)
+            self.assertEqual(CypherInt(3), rels[0].endNodeId)
+            self._assert_element_id(CypherString("1"),
+                                    rels[0].startNodeElementId)
+            self._assert_element_id(CypherString("3"),
+                                    rels[0].endNodeElementId)
+
+            self._server.done()
 
     @driver_feature(types.Feature.BOLT_5_0)
     def test_5x0_populates_path_element_ids_with_string(self):
@@ -301,38 +295,32 @@ class TestBasicQuery(TestkitTestCase):
                 '{"()": [1, ["l"], {}, "1"]}'
                 ']}'  # noqa: Q000
         }
+        with self._get_session("single_result.script",
+                               script_params) as session:
+            result_handle = session.run("MATCH p = ()--()--() "
+                                        "RETURN p LIMIT 1")
 
-        self._server.start(
-            path=self.script_path("single_result.script"),
-            vars_=script_params
-        )
-        self._session = self._driver.session("r", fetch_size=1)
-        result_handle = self._session.run("MATCH p = ()--()--() "
-                                          "RETURN p LIMIT 1")
+            result = result_handle.next()
 
-        result = result_handle.next()
+            self.assertIsInstance(result.values[0], CypherPath)
+            path = result.values[0]
+            self.assertIsInstance(path.nodes, CypherList)
+            self.assertIsInstance(path.relationships, CypherList)
+            nodes = path.nodes.value
+            rels = path.relationships.value
+            # node ids
+            self.assertEqual(CypherInt(1), nodes[0].id)
+            self.assertEqual(CypherString("1"), nodes[0].elementId)
+            # rel ids
+            self.assertEqual(CypherInt(2), rels[0].id)
+            self.assertEqual(CypherString("2"), rels[0].elementId)
+            # rel start/end ids
+            self.assertEqual(CypherInt(1), rels[0].startNodeId)
+            self.assertEqual(CypherInt(3), rels[0].endNodeId)
+            self.assertEqual(CypherString("1"), rels[0].startNodeElementId)
+            self.assertEqual(CypherString("3"), rels[0].endNodeElementId)
 
-        self.assertIsInstance(result.values[0], CypherPath)
-        path = result.values[0]
-        self.assertIsInstance(path.nodes, CypherList)
-        self.assertIsInstance(path.relationships, CypherList)
-        nodes = path.nodes.value
-        rels = path.relationships.value
-        # node ids
-        self.assertEqual(CypherInt(1), nodes[0].id)
-        self.assertEqual(CypherString("1"), nodes[0].elementId)
-        # rel ids
-        self.assertEqual(CypherInt(2), rels[0].id)
-        self.assertEqual(CypherString("2"), rels[0].elementId)
-        # rel start/end ids
-        self.assertEqual(CypherInt(1), rels[0].startNodeId)
-        self.assertEqual(CypherInt(3), rels[0].endNodeId)
-        self.assertEqual(CypherString("1"), rels[0].startNodeElementId)
-        self.assertEqual(CypherString("3"), rels[0].endNodeElementId)
-
-        self._session.close()
-        self._session = None
-        self._server.done()
+            self._server.done()
 
     @driver_feature(types.Feature.BOLT_5_0)
     def test_5x0_populates_path_element_ids_with_only_string(self):
@@ -349,35 +337,65 @@ class TestBasicQuery(TestkitTestCase):
                 '{"()": [null, ["l"], {}, "n1-1"]}'
                 ']}'  # noqa: Q000
         }
+        with self._get_session("single_result.script",
+                               script_params) as session:
+            result_handle = session.run("MATCH p = ()--()--() "
+                                        "RETURN p LIMIT 1")
 
-        self._server.start(
-            path=self.script_path("single_result.script"),
-            vars_=script_params
-        )
-        self._session = self._driver.session("r", fetch_size=1)
-        result_handle = self._session.run("MATCH p = ()--()--() "
-                                          "RETURN p LIMIT 1")
+            result = result_handle.next()
 
-        result = result_handle.next()
+            self.assertIsInstance(result.values[0], CypherPath)
+            path = result.values[0]
+            self.assertIsInstance(path.nodes, CypherList)
+            self.assertIsInstance(path.relationships, CypherList)
+            nodes = path.nodes.value
+            rels = path.relationships.value
+            # node ids
+            self._assert_is_unset_id(nodes[0].id)
+            self.assertEqual(CypherString("n1-1"), nodes[0].elementId)
+            # rel ids
+            self._assert_is_unset_id(rels[0].id)
+            self.assertEqual(CypherString("r1-2"), rels[0].elementId)
+            # rel start/end ids
+            self._assert_is_unset_id(rels[0].startNodeId)
+            self._assert_is_unset_id(rels[0].endNodeId)
+            self.assertEqual(CypherString("n1-1"), rels[0].startNodeElementId)
+            self.assertEqual(CypherString("n1-3"), rels[0].endNodeElementId)
 
-        self.assertIsInstance(result.values[0], CypherPath)
-        path = result.values[0]
-        self.assertIsInstance(path.nodes, CypherList)
-        self.assertIsInstance(path.relationships, CypherList)
-        nodes = path.nodes.value
-        rels = path.relationships.value
-        # node ids
-        self._assert_is_unset_id(nodes[0].id)
-        self.assertEqual(CypherString("n1-1"), nodes[0].elementId)
-        # rel ids
-        self._assert_is_unset_id(rels[0].id)
-        self.assertEqual(CypherString("r1-2"), rels[0].elementId)
-        # rel start/end ids
-        self._assert_is_unset_id(rels[0].startNodeId)
-        self._assert_is_unset_id(rels[0].endNodeId)
-        self.assertEqual(CypherString("n1-1"), rels[0].startNodeElementId)
-        self.assertEqual(CypherString("n1-3"), rels[0].endNodeElementId)
+            self._server.done()
 
-        self._session.close()
-        self._session = None
-        self._server.done()
+    @driver_feature(types.Feature.BOLT_5_0,
+                    types.Feature.DETAIL_THROW_ON_MISSING_ID)
+    def test_5x0_throws_on_reading_ids(self):
+        script_params = {
+            "#BOLT_PROTOCOL#": "5.0",
+            "#RESULT#":
+                '{"..": ['
+                '{"()": [null, ["l"], {}, "n1-1"]}, '
+                '{"->": [null, null, "RELATES_TO", null, {}, '
+                '"r1-2", "n1-1", "n1-3"]}, '
+                '{"()": [null, ["l"], {}, "n1-3"]}, '
+                '{"->": [null, null, "RELATES_TO", null, '
+                '{}, "r1-4", "n1-3", "n1-1"]}, '
+                '{"()": [null, ["l"], {}, "n1-1"]}'
+                ']}'  # noqa: Q000
+        }
+        cases = [
+            "n.0.id",
+            "r.0.id",
+            "r.0.startnodeid",
+            "r.0.endnodeid"
+        ]
+        for field in cases:
+            with self.subTest(f"field:{field}"):
+                with self._get_session("single_result.script",
+                                       script_params) as session:
+
+                    result_handle = session.run("MATCH p = ()--()--() "
+                                                "RETURN p LIMIT 1")
+
+                    with self.assertRaises(types.DriverError) as exc:
+                        result_handle.read_cypher_type_field("n", "path",
+                                                             field)
+                    self._validate_invalid_operation(exc)
+                    self._server.done()


### PR DESCRIPTION
add tests to support languages that should throw when reading an integer id field but using new storage engine.