### PR TITLE
Introduce Testkit error types

### DIFF
--- a/nutkit/protocol/error_type.py
+++ b/nutkit/protocol/error_type.py
@@ -7,7 +7,7 @@ class ErrorType(Enum):
     # - interrupting nodes
     # - no writers available
     # - connectivity issues
-    SESSION_EXPIRED_ERROR = "session_expired_error"
+    SESSION_EXPIRED_ERROR = "SessionExpiredError"
 
     # discovery
     # - procedure not found on discovery
@@ -16,36 +16,37 @@ class ErrorType(Enum):
     # - unreachable db discovery
     # direct
     # - connectivity issues
-    SERVICE_UNAVAILABLE_ERROR = "service_unavailable_error"
+    SERVICE_UNAVAILABLE_ERROR = "ServiceUnavailableError"
 
     # TO BE DISCUSSED
     # java wraps it into SESSION_EXPIRED_ERROR to signify that it is retryable
     # python seems to expose it directly
     # routing
     # - Neo.ClientError.Cluster.NotALeader
-    NOT_LEADER_ERROR = "not_leader_error"
+    NOT_LEADER_ERROR = "NotLeaderError"
 
     # TO BE DISCUSSED
     # java wraps it into SESSION_EXPIRED_ERROR to signify that it is retryable
     # python seems to expose it directly
     # routing
     # - Neo.ClientError.General.ForbiddenOnReadOnlyDatabase
-    FORBIDDEN_ON_RO_DB_ERROR = "forbidden_on_read_only_database_error"
+    FORBIDDEN_ON_RO_DB_ERROR = "ForbiddenOnReadOnlyDatabaseError"
 
     # routing
     # - Neo.ClientError.General.DatabaseUnavailable
     # - Neo.ClientError.Transaction.InvalidBookmark during discovery on run
-    # - Neo.ClientError.Transaction.InvalidBookmarkMixture during discovery on run
+    # - Neo.ClientError.Transaction.InvalidBookmarkMixture during discovery on
+    #       run
     # - no available connections in pool
     # - invalid bookmark
-    CLIENT_ERROR = "client_error"
+    CLIENT_ERROR = "ClientError"
 
     # TO BE DISCUSSED
     # java has a dedicated subtype of client error
     # python seems to expose it as client error
     # discovery
     # - Neo.ClientError.Database.DatabaseNotFound
-    FATAL_DISCOVERY_ERROR = "fatal_discovery_error"
+    FATAL_DISCOVERY_ERROR = "FatalDiscoveryError"
 
     # TO BE DISCUSSED
     # java exposes this a security exception subtype of client exception
@@ -53,42 +54,42 @@ class ErrorType(Enum):
     # discovery
     # - Neo.ClientError.Security.Forbidden
     # - Neo.ClientError.Security.MadeUpSecurityError (any security error)
-    SECURITY_ERROR = "security_error"
+    SECURITY_ERROR = "SecurityError"
 
     # TO BE DISCUSSED
     # see above
-    FORBIDDEN_ERROR = "security_error"
+    FORBIDDEN_ERROR = "SecurityError"
 
     # general usage
     # - driver closed
     # - id access when numeric id is not available
-    ILLEGAL_STATE_ERROR = "illegal_state_error"
+    ILLEGAL_STATE_ERROR = "IllegalStateError"
 
     # no routing
     # - Neo.TransientError.General.DatabaseUnavailable
     # - Neo.TransientError.Transaction.LockClientStopped
-    TRANSIENT_ERROR = "transient_error"
+    TRANSIENT_ERROR = "TransientError"
 
     # TO BE DISCUSSED
     # python seems to return TransientError
     # auth
     # - Neo.ClientError.Security.AuthorizationExpired
-    AUTH_EXPIRED_ERROR = "authorization_expired_error"
+    AUTH_EXPIRED_ERROR = "AuthorizationExpiredError"
 
     # TO BE DISCUSSED
     # dotnet seems to return ClientError
     # auth
     # - Neo.ClientError.Security.TokenExpired
-    TOKEN_EXPIRED_ERROR = "token_expired_error"
+    TOKEN_EXPIRED_ERROR = "TokenExpiredError"
 
     # when result is not a single entry
-    NOT_SINGLE_ERROR = "not_single_error"
+    NOT_SINGLE_ERROR = "NotSingleError"
 
     # TO BE DISCUSSED
     # python throws ConfigurationError when db name is used over Bolt 3.0
     # also throws when impersonation is used on Bolt < 4.4
     # java throws client exception
-    INVALID_CONF_ERROR = "invalid_configuration_error"
+    INVALID_CONF_ERROR = "InvalidConfigurationError"
 
     # TO BE DISCUSSED
     # direct
@@ -97,7 +98,7 @@ class ErrorType(Enum):
     # in direct mode python throws service unavailable
     # dotnet and java throw read timeout, in java it extends service
     # unavailable
-    CONNECTION_READ_TIMEOUT_ERROR = "connection_read_timeout_error"
+    CONNECTION_READ_TIMEOUT_ERROR = "ConnectionReadTimeoutError"
 
     # TO BE DISCUSSED
     # direct
@@ -105,32 +106,29 @@ class ErrorType(Enum):
     # java throws service unavailable error
     # there is a test that expects retry to be interrupted, java and dotnet
     # keep trying
-    INCOMPLETE_COMMIT_ERROR = "incomplete_commit_error"
+    INCOMPLETE_COMMIT_ERROR = "IncompleteCommitError"
 
     # TO BE DISCUSSED
     # direct
     # go throws this
     # others seems to throw service unavailable
-    CONNECTIVITY_ERROR = "connectivity_error"
+    CONNECTIVITY_ERROR = "ConnectivityError"
 
     # direct
     # - when result has been consumed
-    RESULT_CONSUMED_ERROR = "result_consumed_error"
+    RESULT_CONSUMED_ERROR = "ResultConsumedError"
 
     # configuration
     # - illegal argument value
-    ILLEGAL_ARGUMENT_ERROR = "illegal_argument_error"
+    ILLEGAL_ARGUMENT_ERROR = "IllegalArgumentError"
 
     # protocol violations
-    PROTOCOL_ERROR = "protocol_error"
+    PROTOCOL_ERROR = "ProtocolError"
 
     # TO BE DISCUSSED
     # python throws when transaction has been closed
     # java throws client exception
-    TRANSACTION_ERROR = "transaction_error"
-
-    # TO BE DISCUSSED
-    MANAGED_TRANSACTION_ERROR = "managed_transaction_error"
+    TRANSACTION_ERROR = "TransactionError"
 
     # unexpected agent string returned by server
-    UNTRUSTED_SERVER_ERROR = "untrusted_server_error"
+    UNTRUSTED_SERVER_ERROR = "UntrustedServerError"

--- a/nutkit/protocol/error_type.py
+++ b/nutkit/protocol/error_type.py
@@ -1,0 +1,136 @@
+"""Enumerate all the error types in the drivers."""
+from enum import Enum
+
+
+class ErrorType(Enum):
+    # routing
+    # - interrupting nodes
+    # - no writers available
+    # - connectivity issues
+    SESSION_EXPIRED_ERROR = "session_expired_error"
+
+    # discovery
+    # - procedure not found on discovery
+    # - unknown code
+    # - no readers in routing table (to be checked in "go", "java", "dotnet")
+    # - unreachable db discovery
+    # direct
+    # - connectivity issues
+    SERVICE_UNAVAILABLE_ERROR = "service_unavailable_error"
+
+    # TO BE DISCUSSED
+    # java wraps it into SESSION_EXPIRED_ERROR to signify that it is retryable
+    # python seems to expose it directly
+    # routing
+    # - Neo.ClientError.Cluster.NotALeader
+    NOT_LEADER_ERROR = "not_leader_error"
+
+    # TO BE DISCUSSED
+    # java wraps it into SESSION_EXPIRED_ERROR to signify that it is retryable
+    # python seems to expose it directly
+    # routing
+    # - Neo.ClientError.General.ForbiddenOnReadOnlyDatabase
+    FORBIDDEN_ON_RO_DB_ERROR = "forbidden_on_read_only_database_error"
+
+    # routing
+    # - Neo.ClientError.General.DatabaseUnavailable
+    # - Neo.ClientError.Transaction.InvalidBookmark during discovery on run
+    # - Neo.ClientError.Transaction.InvalidBookmarkMixture during discovery on run
+    # - no available connections in pool
+    # - invalid bookmark
+    CLIENT_ERROR = "client_error"
+
+    # TO BE DISCUSSED
+    # java has a dedicated subtype of client error
+    # python seems to expose it as client error
+    # discovery
+    # - Neo.ClientError.Database.DatabaseNotFound
+    FATAL_DISCOVERY_ERROR = "fatal_discovery_error"
+
+    # TO BE DISCUSSED
+    # java exposes this a security exception subtype of client exception
+    # python seems to expose it as client error
+    # discovery
+    # - Neo.ClientError.Security.Forbidden
+    # - Neo.ClientError.Security.MadeUpSecurityError (any security error)
+    SECURITY_ERROR = "security_error"
+
+    # TO BE DISCUSSED
+    # see above
+    FORBIDDEN_ERROR = "security_error"
+
+    # general usage
+    # - driver closed
+    # - id access when numeric id is not available
+    ILLEGAL_STATE_ERROR = "illegal_state_error"
+
+    # no routing
+    # - Neo.TransientError.General.DatabaseUnavailable
+    # - Neo.TransientError.Transaction.LockClientStopped
+    TRANSIENT_ERROR = "transient_error"
+
+    # TO BE DISCUSSED
+    # python seems to return TransientError
+    # auth
+    # - Neo.ClientError.Security.AuthorizationExpired
+    AUTH_EXPIRED_ERROR = "authorization_expired_error"
+
+    # TO BE DISCUSSED
+    # dotnet seems to return ClientError
+    # auth
+    # - Neo.ClientError.Security.TokenExpired
+    TOKEN_EXPIRED_ERROR = "token_expired_error"
+
+    # when result is not a single entry
+    NOT_SINGLE_ERROR = "not_single_error"
+
+    # TO BE DISCUSSED
+    # python throws ConfigurationError when db name is used over Bolt 3.0
+    # also throws when impersonation is used on Bolt < 4.4
+    # java throws client exception
+    INVALID_CONF_ERROR = "invalid_configuration_error"
+
+    # TO BE DISCUSSED
+    # direct
+    # dotnet throws this on read timeout
+    # others seems to throw session expired WHEN in routing mode
+    # in direct mode python throws service unavailable
+    # dotnet and java throw read timeout, in java it extends service
+    # unavailable
+    CONNECTION_READ_TIMEOUT_ERROR = "connection_read_timeout_error"
+
+    # TO BE DISCUSSED
+    # direct
+    # python throws when connection drops after commit
+    # java throws service unavailable error
+    # there is a test that expects retry to be interrupted, java and dotnet
+    # keep trying
+    INCOMPLETE_COMMIT_ERROR = "incomplete_commit_error"
+
+    # TO BE DISCUSSED
+    # direct
+    # go throws this
+    # others seems to throw service unavailable
+    CONNECTIVITY_ERROR = "connectivity_error"
+
+    # direct
+    # - when result has been consumed
+    RESULT_CONSUMED_ERROR = "result_consumed_error"
+
+    # configuration
+    # - illegal argument value
+    ILLEGAL_ARGUMENT_ERROR = "illegal_argument_error"
+
+    # protocol violations
+    PROTOCOL_ERROR = "protocol_error"
+
+    # TO BE DISCUSSED
+    # python throws when transaction has been closed
+    # java throws client exception
+    TRANSACTION_ERROR = "transaction_error"
+
+    # TO BE DISCUSSED
+    MANAGED_TRANSACTION_ERROR = "managed_transaction_error"
+
+    # unexpected agent string returned by server
+    UNTRUSTED_SERVER_ERROR = "untrusted_server_error"

--- a/tests/neo4j/test_bookmarks.py
+++ b/tests/neo4j/test_bookmarks.py
@@ -85,14 +85,9 @@ class TestBookmarks(TestkitTestCase):
             tx = self._session.begin_transaction()
             result = tx.run("RETURN 1")
             result.next()
-        if get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(
                 ErrorType.CLIENT_ERROR.value,
-                exc.exception.errorType
-            )
-        elif get_driver_name() in ["python"]:
-            self.assertEqual(
-                "<class 'neo4j.exceptions.ClientError'>",
                 exc.exception.errorType
             )
         elif get_driver_name() in ["ruby"]:
@@ -119,14 +114,9 @@ class TestBookmarks(TestkitTestCase):
 
         with self.assertRaises(types.DriverError) as exc:
             self._session.read_transaction(work)
-        if get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(
                 ErrorType.CLIENT_ERROR.value,
-                exc.exception.errorType
-            )
-        elif get_driver_name() in ["python"]:
-            self.assertEqual(
-                "<class 'neo4j.exceptions.ClientError'>",
                 exc.exception.errorType
             )
         elif get_driver_name() in ["ruby"]:

--- a/tests/neo4j/test_bookmarks.py
+++ b/tests/neo4j/test_bookmarks.py
@@ -85,7 +85,7 @@ class TestBookmarks(TestkitTestCase):
             tx = self._session.begin_transaction()
             result = tx.run("RETURN 1")
             result.next()
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(
                 ErrorType.CLIENT_ERROR.value,
                 exc.exception.errorType
@@ -114,7 +114,7 @@ class TestBookmarks(TestkitTestCase):
 
         with self.assertRaises(types.DriverError) as exc:
             self._session.read_transaction(work)
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(
                 ErrorType.CLIENT_ERROR.value,
                 exc.exception.errorType

--- a/tests/neo4j/test_bookmarks.py
+++ b/tests/neo4j/test_bookmarks.py
@@ -1,6 +1,7 @@
 from uuid import uuid4
 
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 from tests.neo4j.shared import (
     cluster_unsafe_test,
     get_driver,
@@ -86,7 +87,7 @@ class TestBookmarks(TestkitTestCase):
             result.next()
         if get_driver_name() in ["java"]:
             self.assertEqual(
-                "org.neo4j.driver.exceptions.ClientException",
+                ErrorType.CLIENT_ERROR.value,
                 exc.exception.errorType
             )
         elif get_driver_name() in ["python"]:
@@ -120,7 +121,7 @@ class TestBookmarks(TestkitTestCase):
             self._session.read_transaction(work)
         if get_driver_name() in ["java"]:
             self.assertEqual(
-                "org.neo4j.driver.exceptions.ClientException",
+                ErrorType.CLIENT_ERROR.value,
                 exc.exception.errorType
             )
         elif get_driver_name() in ["python"]:

--- a/tests/neo4j/test_direct_driver.py
+++ b/tests/neo4j/test_direct_driver.py
@@ -73,7 +73,7 @@ class TestDirectDriver(TestkitTestCase):
                                   connection_timeout_ms=500)
         with self.assertRaises(types.DriverError) as e:
             self._driver.verify_connectivity()
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                              e.exception.errorType)
 
@@ -107,7 +107,7 @@ class TestDirectDriver(TestkitTestCase):
                          "Neo.ClientError.Database.DatabaseNotFound")
         self.assertIn("test-database", exc.msg)
         self.assertIn("exist", exc.msg)
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(ErrorType.FATAL_DISCOVERY_ERROR.value,
                              exc.errorType)
 

--- a/tests/neo4j/test_direct_driver.py
+++ b/tests/neo4j/test_direct_driver.py
@@ -1,4 +1,5 @@
 from nutkit import protocol as types
+from nutkit.protocol.error_type import ErrorType
 
 from ..shared import (
     dns_resolve_single,
@@ -75,6 +76,9 @@ class TestDirectDriver(TestkitTestCase):
         if get_driver_name() in ["python"]:
             self.assertEqual(e.exception.errorType,
                              "<class 'neo4j.exceptions.ServiceUnavailable'>")
+        elif get_driver_name() in ["java"]:
+            self.assertEqual(ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
+                             e.exception.errorType)
 
     @driver_feature(types.Feature.TMP_FULL_SUMMARY)
     def test_supports_multi_db(self):
@@ -109,6 +113,9 @@ class TestDirectDriver(TestkitTestCase):
         if get_driver_name() in ["python"]:
             self.assertEqual(exc.errorType,
                              "<class 'neo4j.exceptions.ClientError'>")
+        elif get_driver_name() in ["java"]:
+            self.assertEqual(ErrorType.FATAL_DISCOVERY_ERROR.value,
+                             exc.errorType)
 
     @driver_feature(types.Feature.TMP_FULL_SUMMARY)
     @requires_multi_db_support
@@ -146,6 +153,9 @@ class TestDirectDriver(TestkitTestCase):
                     "database is not supported in Bolt Protocol Version(3, 0)",
                     e.exception.msg
                 )
+            elif get_driver_name() in ["java"]:
+                self.assertEqual(ErrorType.CLIENT_ERROR.value,
+                                 e.exception.errorType)
 
     @requires_multi_db_support
     @cluster_unsafe_test

--- a/tests/neo4j/test_direct_driver.py
+++ b/tests/neo4j/test_direct_driver.py
@@ -73,10 +73,7 @@ class TestDirectDriver(TestkitTestCase):
                                   connection_timeout_ms=500)
         with self.assertRaises(types.DriverError) as e:
             self._driver.verify_connectivity()
-        if get_driver_name() in ["python"]:
-            self.assertEqual(e.exception.errorType,
-                             "<class 'neo4j.exceptions.ServiceUnavailable'>")
-        elif get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                              e.exception.errorType)
 
@@ -110,10 +107,7 @@ class TestDirectDriver(TestkitTestCase):
                          "Neo.ClientError.Database.DatabaseNotFound")
         self.assertIn("test-database", exc.msg)
         self.assertIn("exist", exc.msg)
-        if get_driver_name() in ["python"]:
-            self.assertEqual(exc.errorType,
-                             "<class 'neo4j.exceptions.ClientError'>")
-        elif get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(ErrorType.FATAL_DISCOVERY_ERROR.value,
                              exc.errorType)
 
@@ -146,7 +140,7 @@ class TestDirectDriver(TestkitTestCase):
                 self._session.run("RETURN 1").consume()
             if get_driver_name() in ["python"]:
                 self.assertEqual(
-                    "<class 'neo4j.exceptions.ConfigurationError'>",
+                    ErrorType.INVALID_CONF_ERROR.value,
                     e.exception.errorType
                 )
                 self.assertIn(

--- a/tests/neo4j/test_tx_run.py
+++ b/tests/neo4j/test_tx_run.py
@@ -328,6 +328,12 @@ class TestTxRun(TestkitTestCase):
         if get_driver_name() in ["java", "python"]:
             self.assertEqual(ErrorType.TRANSIENT_ERROR.value,
                              e.exception.errorType)
+        # "Neo.TransientError.Transaction.LockClientStopped"
+        # will be moved to client-error since it is not retriable.
+        # Shall we categorized it as a client error?
+        if get_driver_name() in ["javascript"]:
+            self.assertEqual(ErrorType.CLIENT_ERROR.value,
+                             e.exception.errorType)
 
     @cluster_unsafe_test
     def test_consume_after_commit(self):

--- a/tests/neo4j/test_tx_run.py
+++ b/tests/neo4j/test_tx_run.py
@@ -325,10 +325,7 @@ class TestTxRun(TestkitTestCase):
             result.consume()
         self.assertEqual(e.exception.code,
                          "Neo.TransientError.Transaction.LockClientStopped")
-        if get_driver_name() in ["python"]:
-            self.assertEqual(e.exception.errorType,
-                             "<class 'neo4j.exceptions.TransientError'>")
-        elif get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(ErrorType.TRANSIENT_ERROR.value,
                              e.exception.errorType)
 

--- a/tests/neo4j/test_tx_run.py
+++ b/tests/neo4j/test_tx_run.py
@@ -1,6 +1,7 @@
 import uuid
 
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 from tests.neo4j.shared import (
     cluster_unsafe_test,
     get_driver,
@@ -327,6 +328,9 @@ class TestTxRun(TestkitTestCase):
         if get_driver_name() in ["python"]:
             self.assertEqual(e.exception.errorType,
                              "<class 'neo4j.exceptions.TransientError'>")
+        elif get_driver_name() in ["java"]:
+            self.assertEqual(ErrorType.TRANSIENT_ERROR.value,
+                             e.exception.errorType)
 
     @cluster_unsafe_test
     def test_consume_after_commit(self):

--- a/tests/stub/authorization/test_authorization.py
+++ b/tests/stub/authorization/test_authorization.py
@@ -3,6 +3,7 @@ import os
 
 from nutkit.frontend import Driver
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     driver_feature,
     get_driver_name,
@@ -20,9 +21,8 @@ class AuthorizationBase(TestkitTestCase):
         self.assertEqual("Neo.ClientError.Security.AuthorizationExpired",
                          error.code)
         if driver in ["java"]:
-            self.assertEqual(
-                "org.neo4j.driver.exceptions.AuthorizationExpiredException",
-                error.errorType)
+            self.assertEqual(ErrorType.AUTH_EXPIRED_ERROR.value,
+                             error.errorType)
         elif driver in ["python"]:
             self.assertEqual(
                 "<class 'neo4j.exceptions.TransientError'>", error.errorType
@@ -52,9 +52,8 @@ class AuthorizationBase(TestkitTestCase):
                 "Token expired", error.msg
             )
         elif driver == "java":
-            self.assertEqual(
-                "org.neo4j.driver.exceptions.TokenExpiredException",
-                error.errorType)
+            self.assertEqual(ErrorType.TOKEN_EXPIRED_ERROR.value,
+                             error.errorType)
             self.assertIn("Token expired", error.msg)
         elif driver == "ruby":
             self.assertEqual(

--- a/tests/stub/authorization/test_authorization.py
+++ b/tests/stub/authorization/test_authorization.py
@@ -20,13 +20,9 @@ class AuthorizationBase(TestkitTestCase):
         driver = get_driver_name()
         self.assertEqual("Neo.ClientError.Security.AuthorizationExpired",
                          error.code)
-        if driver in ["java"]:
+        if driver in ["java", "python"]:
             self.assertEqual(ErrorType.AUTH_EXPIRED_ERROR.value,
                              error.errorType)
-        elif driver in ["python"]:
-            self.assertEqual(
-                "<class 'neo4j.exceptions.TransientError'>", error.errorType
-            )
         elif driver in ["javascript"]:
             # only test for code
             pass
@@ -43,15 +39,11 @@ class AuthorizationBase(TestkitTestCase):
         driver = get_driver_name()
         self.assertEqual("Neo.ClientError.Security.TokenExpired",
                          error.code)
-        if driver in ["python"]:
-            self.assertEqual(
-                "<class 'neo4j.exceptions.TokenExpired'>", error.errorType
-            )
-        elif driver in ["go", "javascript"]:
+        if driver in ["go", "javascript"]:
             self.assertIn(
                 "Token expired", error.msg
             )
-        elif driver == "java":
+        elif driver in ["java", "python"]:
             self.assertEqual(ErrorType.TOKEN_EXPIRED_ERROR.value,
                              error.errorType)
             self.assertIn("Token expired", error.msg)

--- a/tests/stub/authorization/test_authorization.py
+++ b/tests/stub/authorization/test_authorization.py
@@ -39,7 +39,7 @@ class AuthorizationBase(TestkitTestCase):
         driver = get_driver_name()
         self.assertEqual("Neo.ClientError.Security.TokenExpired",
                          error.code)
-        if driver in ["go", "javascript"]:
+        if driver in ["go"]:
             self.assertIn(
                 "Token expired", error.msg
             )

--- a/tests/stub/authorization/test_authorization.py
+++ b/tests/stub/authorization/test_authorization.py
@@ -20,7 +20,7 @@ class AuthorizationBase(TestkitTestCase):
         driver = get_driver_name()
         self.assertEqual("Neo.ClientError.Security.AuthorizationExpired",
                          error.code)
-        if driver in ["java", "python"]:
+        if driver in ["java", "python", "javascript"]:
             self.assertEqual(ErrorType.AUTH_EXPIRED_ERROR.value,
                              error.errorType)
         elif driver in ["javascript"]:
@@ -43,7 +43,7 @@ class AuthorizationBase(TestkitTestCase):
             self.assertIn(
                 "Token expired", error.msg
             )
-        elif driver in ["java", "python"]:
+        elif driver in ["java", "python", "javascript"]:
             self.assertEqual(ErrorType.TOKEN_EXPIRED_ERROR.value,
                              error.errorType)
             self.assertIn("Token expired", error.msg)

--- a/tests/stub/basic_query/test_basic_query.py
+++ b/tests/stub/basic_query/test_basic_query.py
@@ -52,7 +52,7 @@ class TestBasicQuery(TestkitTestCase):
         if get_driver_name() in ["dotnet"]:
             self.assertEqual("InvalidOperationException",
                              exc.exception.errorType)
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(ErrorType.ILLEGAL_STATE_ERROR.value,
                              exc.exception.errorType)
 

--- a/tests/stub/basic_query/test_basic_query.py
+++ b/tests/stub/basic_query/test_basic_query.py
@@ -52,7 +52,7 @@ class TestBasicQuery(TestkitTestCase):
         if get_driver_name() in ["dotnet"]:
             self.assertEqual("InvalidOperationException",
                              exc.exception.errorType)
-        if get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(ErrorType.ILLEGAL_STATE_ERROR.value,
                              exc.exception.errorType)
 

--- a/tests/stub/basic_query/test_basic_query.py
+++ b/tests/stub/basic_query/test_basic_query.py
@@ -9,6 +9,7 @@ from nutkit.protocol import (
     CypherPath,
     CypherString,
 )
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     driver_feature,
     get_driver_name,
@@ -52,7 +53,7 @@ class TestBasicQuery(TestkitTestCase):
             self.assertEqual("InvalidOperationException",
                              exc.exception.errorType)
         if get_driver_name() in ["java"]:
-            self.assertEqual("java.lang.IllegalStateException",
+            self.assertEqual(ErrorType.ILLEGAL_STATE_ERROR.value,
                              exc.exception.errorType)
 
     @contextmanager

--- a/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
+++ b/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
@@ -43,7 +43,7 @@ class TestDirectConnectionRecvTimeout(TestkitTestCase):
 
     def _assert_is_timeout_exception(self, e):
         if get_driver_name() in ["python"]:
-            self.assertEqual("<class 'neo4j.exceptions.ServiceUnavailable'>",
+            self.assertEqual(ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                              e.errorType)
         elif get_driver_name() in ["java"]:
             self.assertEqual(ErrorType.CONNECTION_READ_TIMEOUT_ERROR.value,
@@ -63,6 +63,8 @@ class TestDirectConnectionRecvTimeout(TestkitTestCase):
     def _assert_is_client_exception(self, e):
         if get_driver_name() in ["java"]:
             self.assertEqual(ErrorType.CLIENT_ERROR.value, e.errorType)
+        elif get_driver_name() in ["python"]:
+            self.assertEqual(ErrorType.TRANSACTION_ERROR.value, e.errorType)
         elif get_driver_name() in ["ruby"]:
             self.assertEqual(
                 "Neo4j::Driver::Exceptions::ClientException",
@@ -270,10 +272,7 @@ class TestRoutingConnectionRecvTimeout(TestDirectConnectionRecvTimeout):
         TestkitTestCase.tearDown(self)
 
     def _assert_is_timeout_exception(self, e):
-        if get_driver_name() in ["python"]:
-            self.assertEqual("<class 'neo4j.exceptions.SessionExpired'>",
-                             e.errorType)
-        elif get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(ErrorType.SESSION_EXPIRED_ERROR.value,
                              e.errorType)
         elif get_driver_name() in ["ruby"]:

--- a/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
+++ b/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
@@ -1,5 +1,6 @@
 from nutkit.frontend import Driver
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     dns_resolve_single,
     driver_feature,
@@ -45,9 +46,8 @@ class TestDirectConnectionRecvTimeout(TestkitTestCase):
             self.assertEqual("<class 'neo4j.exceptions.ServiceUnavailable'>",
                              e.errorType)
         elif get_driver_name() in ["java"]:
-            self.assertEqual(
-                "org.neo4j.driver.exceptions.ConnectionReadTimeoutException",
-                e.errorType)
+            self.assertEqual(ErrorType.CONNECTION_READ_TIMEOUT_ERROR.value,
+                             e.errorType)
         elif get_driver_name() in ["go"]:
             # remove second assertion once the context API PR is merged
             self.assertTrue("context deadline exceeded" in e.msg
@@ -62,9 +62,7 @@ class TestDirectConnectionRecvTimeout(TestkitTestCase):
 
     def _assert_is_client_exception(self, e):
         if get_driver_name() in ["java"]:
-            self.assertEqual(
-                "org.neo4j.driver.exceptions.ClientException",
-                e.errorType)
+            self.assertEqual(ErrorType.CLIENT_ERROR.value, e.errorType)
         elif get_driver_name() in ["ruby"]:
             self.assertEqual(
                 "Neo4j::Driver::Exceptions::ClientException",
@@ -276,10 +274,8 @@ class TestRoutingConnectionRecvTimeout(TestDirectConnectionRecvTimeout):
             self.assertEqual("<class 'neo4j.exceptions.SessionExpired'>",
                              e.errorType)
         elif get_driver_name() in ["java"]:
-            self.assertEqual(
-                "org.neo4j.driver.exceptions.SessionExpiredException",
-                e.errorType
-            )
+            self.assertEqual(ErrorType.SESSION_EXPIRED_ERROR.value,
+                             e.errorType)
         elif get_driver_name() in ["ruby"]:
             self.assertEqual(
                 "Neo4j::Driver::Exceptions::SessionExpiredException",

--- a/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
+++ b/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
@@ -42,7 +42,7 @@ class TestDirectConnectionRecvTimeout(TestkitTestCase):
         self._server.start(path=self.script_path(script))
 
     def _assert_is_timeout_exception(self, e):
-        if get_driver_name() in ["python"]:
+        if get_driver_name() in ["python", "javascript"]:
             self.assertEqual(ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                              e.errorType)
         elif get_driver_name() in ["java"]:
@@ -272,7 +272,7 @@ class TestRoutingConnectionRecvTimeout(TestDirectConnectionRecvTimeout):
         TestkitTestCase.tearDown(self)
 
     def _assert_is_timeout_exception(self, e):
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(ErrorType.SESSION_EXPIRED_ERROR.value,
                              e.errorType)
         elif get_driver_name() in ["ruby"]:

--- a/tests/stub/disconnects/test_disconnects.py
+++ b/tests/stub/disconnects/test_disconnects.py
@@ -1,5 +1,6 @@
 from nutkit.frontend import Driver
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     get_driver_name,
     TestkitTestCase,
@@ -251,6 +252,9 @@ class TestDisconnects(TestkitTestCase):
                 "<class 'neo4j.exceptions.IncompleteCommit'>",
                 self._last_exc.errorType
             )
+        elif get_driver_name() in ["java"]:
+            self.assertEqual(ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
+                             self._last_exc.errorType)
 
     # FIXME: This test doesn't really fit here. It tests FAILURE handling, not
     #        handling sudden loss of connectivity.

--- a/tests/stub/disconnects/test_disconnects.py
+++ b/tests/stub/disconnects/test_disconnects.py
@@ -248,10 +248,8 @@ class TestDisconnects(TestkitTestCase):
         expected_step = "after commit"
         self.assertEqual(step, expected_step)
         if get_driver_name() in ["python"]:
-            self.assertEqual(
-                "<class 'neo4j.exceptions.IncompleteCommit'>",
-                self._last_exc.errorType
-            )
+            self.assertEqual(ErrorType.INCOMPLETE_COMMIT_ERROR.value,
+                             self._last_exc.errorType)
         elif get_driver_name() in ["java"]:
             self.assertEqual(ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                              self._last_exc.errorType)

--- a/tests/stub/iteration/test_result_list.py
+++ b/tests/stub/iteration/test_result_list.py
@@ -13,10 +13,7 @@ class TestResultList(IterationTestBase):
     def _assert_connection_error(self, error):
         self.assertIsInstance(error, types.DriverError)
         driver = get_driver_name()
-        if driver in ["python"]:
-            self.assertEqual("<class 'neo4j.exceptions.ServiceUnavailable'>",
-                             error.errorType)
-        elif driver in ["java"]:
+        if driver in ["java", "python"]:
             self.assertEqual(
                 ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                 error.errorType

--- a/tests/stub/iteration/test_result_list.py
+++ b/tests/stub/iteration/test_result_list.py
@@ -13,7 +13,7 @@ class TestResultList(IterationTestBase):
     def _assert_connection_error(self, error):
         self.assertIsInstance(error, types.DriverError)
         driver = get_driver_name()
-        if driver in ["java", "python"]:
+        if driver in ["java", "python", "javascript"]:
             self.assertEqual(
                 ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                 error.errorType

--- a/tests/stub/iteration/test_result_list.py
+++ b/tests/stub/iteration/test_result_list.py
@@ -1,4 +1,5 @@
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import get_driver_name
 
 from ._common import IterationTestBase
@@ -17,7 +18,7 @@ class TestResultList(IterationTestBase):
                              error.errorType)
         elif driver in ["java"]:
             self.assertEqual(
-                "org.neo4j.driver.exceptions.ServiceUnavailableException",
+                ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                 error.errorType
             )
         elif driver in ["javascript"]:

--- a/tests/stub/iteration/test_result_peek.py
+++ b/tests/stub/iteration/test_result_peek.py
@@ -1,4 +1,5 @@
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     driver_feature,
     get_driver_name,
@@ -18,10 +19,8 @@ class TestResultPeek(IterationTestBase):
             self.assertEqual("<class 'neo4j.exceptions.ServiceUnavailable'>",
                              error.errorType)
         elif driver in ["java"]:
-            self.assertEqual(
-                "org.neo4j.driver.exceptions.ServiceUnavailableException",
-                error.errorType
-            )
+            self.assertEqual(ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
+                             error.errorType)
         elif driver in ["ruby"]:
             self.assertEqual(
                 "Neo4j::Driver::Exceptions::ServiceUnavailableException",

--- a/tests/stub/iteration/test_result_peek.py
+++ b/tests/stub/iteration/test_result_peek.py
@@ -15,7 +15,7 @@ class TestResultPeek(IterationTestBase):
     def _assert_connection_error(self, error):
         self.assertIsInstance(error, types.DriverError)
         driver = get_driver_name()
-        if driver in ["java", "python"]:
+        if driver in ["java", "python", "javascript"]:
             self.assertEqual(
                 ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                 error.errorType

--- a/tests/stub/iteration/test_result_peek.py
+++ b/tests/stub/iteration/test_result_peek.py
@@ -15,12 +15,11 @@ class TestResultPeek(IterationTestBase):
     def _assert_connection_error(self, error):
         self.assertIsInstance(error, types.DriverError)
         driver = get_driver_name()
-        if driver in ["python"]:
-            self.assertEqual("<class 'neo4j.exceptions.ServiceUnavailable'>",
-                             error.errorType)
-        elif driver in ["java"]:
-            self.assertEqual(ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
-                             error.errorType)
+        if driver in ["java", "python"]:
+            self.assertEqual(
+                ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
+                error.errorType
+            )
         elif driver in ["ruby"]:
             self.assertEqual(
                 "Neo4j::Driver::Exceptions::ServiceUnavailableException",

--- a/tests/stub/iteration/test_result_scope.py
+++ b/tests/stub/iteration/test_result_scope.py
@@ -35,14 +35,14 @@ class TestResultScope(TestkitTestCase):
 
     def _assert_result_out_of_scope_exception(self, exc):
         driver = get_driver_name()
-        if driver in ["python"]:
-            self.assertEqual(exc.errorType,
-                             "<class 'neo4j.exceptions.ResultConsumedError'>")
-            self.assertIn("closed", exc.msg.lower())
-            self.assertIn("transaction", exc.msg.lower())
-        elif driver in ["java"]:
-            self.assertEqual(ErrorType.RESULT_CONSUMED_ERROR.value,
-                             exc.errorType)
+        if driver in ["java", "python"]:
+            self.assertEqual(
+                ErrorType.RESULT_CONSUMED_ERROR.value,
+                exc.errorType
+            )
+            if driver in ["python"]:
+                self.assertIn("closed", exc.msg.lower())
+                self.assertIn("transaction", exc.msg.lower())
         elif driver in ["dotnet"]:
             self.assertEqual(exc.errorType, "ResultConsumedError")
         elif driver in ["javascript"]:
@@ -52,13 +52,11 @@ class TestResultScope(TestkitTestCase):
 
     def _assert_result_consumed_exception(self, exc):
         driver = get_driver_name()
-        if driver in ["python"]:
-            self.assertEqual(exc.errorType,
-                             "<class 'neo4j.exceptions.ResultConsumedError'>")
-            self.assertIn("consume", exc.msg.lower())
-        elif driver in ["java"]:
-            self.assertEqual(ErrorType.RESULT_CONSUMED_ERROR.value,
-                             exc.errorType)
+        if driver in ["java", "python"]:
+            self.assertEqual(
+                ErrorType.RESULT_CONSUMED_ERROR.value,
+                exc.errorType
+            )
         elif driver in ["dotnet"]:
             self.assertEqual(exc.errorType, "ResultConsumedError")
         elif driver in ["javascript"]:

--- a/tests/stub/iteration/test_result_scope.py
+++ b/tests/stub/iteration/test_result_scope.py
@@ -35,7 +35,7 @@ class TestResultScope(TestkitTestCase):
 
     def _assert_result_out_of_scope_exception(self, exc):
         driver = get_driver_name()
-        if driver in ["java", "python"]:
+        if driver in ["java", "python", "javascript"]:
             self.assertEqual(
                 ErrorType.RESULT_CONSUMED_ERROR.value,
                 exc.errorType
@@ -52,7 +52,7 @@ class TestResultScope(TestkitTestCase):
 
     def _assert_result_consumed_exception(self, exc):
         driver = get_driver_name()
-        if driver in ["java", "python"]:
+        if driver in ["java", "python", "javascript"]:
             self.assertEqual(
                 ErrorType.RESULT_CONSUMED_ERROR.value,
                 exc.errorType

--- a/tests/stub/iteration/test_result_scope.py
+++ b/tests/stub/iteration/test_result_scope.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 
 from nutkit.frontend import Driver
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     get_driver_name,
     TestkitTestCase,
@@ -40,10 +41,8 @@ class TestResultScope(TestkitTestCase):
             self.assertIn("closed", exc.msg.lower())
             self.assertIn("transaction", exc.msg.lower())
         elif driver in ["java"]:
-            self.assertEqual(
-                exc.errorType,
-                "org.neo4j.driver.exceptions.ResultConsumedException"
-            )
+            self.assertEqual(ErrorType.RESULT_CONSUMED_ERROR.value,
+                             exc.errorType)
         elif driver in ["dotnet"]:
             self.assertEqual(exc.errorType, "ResultConsumedError")
         elif driver in ["javascript"]:
@@ -58,10 +57,8 @@ class TestResultScope(TestkitTestCase):
                              "<class 'neo4j.exceptions.ResultConsumedError'>")
             self.assertIn("consume", exc.msg.lower())
         elif driver in ["java"]:
-            self.assertEqual(
-                exc.errorType,
-                "org.neo4j.driver.exceptions.ResultConsumedException"
-            )
+            self.assertEqual(ErrorType.RESULT_CONSUMED_ERROR.value,
+                             exc.errorType)
         elif driver in ["dotnet"]:
             self.assertEqual(exc.errorType, "ResultConsumedError")
         elif driver in ["javascript"]:

--- a/tests/stub/iteration/test_result_single.py
+++ b/tests/stub/iteration/test_result_single.py
@@ -15,37 +15,31 @@ class TestResultSingle(IterationTestBase):
     def _assert_not_exactly_one_record_error(self, error):
         self.assertIsInstance(error, types.DriverError)
         driver = get_driver_name()
-        if driver in ["python"]:
-            self.assertEqual(
-                "<class 'neo4j.exceptions.ResultNotSingleError'>",
-                error.errorType
-            )
+        if driver in ["java", "python"]:
+            self.assertEqual(ErrorType.NOT_SINGLE_ERROR.value, error.errorType)
         elif driver in ["ruby"]:
             self.assertEqual(
                 "Neo4j::Driver::Exceptions::NoSuchRecordException",
                 error.errorType)
         elif driver in ["dotnet"]:
             self.assertEqual("InvalidOperationException", error.errorType)
-        elif driver in ["java"]:
-            self.assertEqual(ErrorType.NOT_SINGLE_ERROR.value, error.errorType)
         else:
             self.fail("no error mapping is defined for %s driver" % driver)
 
     def _assert_connection_error(self, error):
         self.assertIsInstance(error, types.DriverError)
         driver = get_driver_name()
-        if driver in ["python"]:
-            self.assertEqual("<class 'neo4j.exceptions.ServiceUnavailable'>",
-                             error.errorType)
+        if driver in ["java", "python"]:
+            self.assertEqual(
+                ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
+                error.errorType
+            )
         elif driver in ["ruby"]:
             self.assertEqual(
                 "Neo4j::Driver::Exceptions::ServiceUnavailableException",
                 error.errorType)
         elif driver in ["dotnet"]:
             self.assertEqual("ServiceUnavailableError", error.errorType)
-        elif driver in ["java"]:
-            self.assertEqual(ErrorType.SERVICE_UNAVAILABLE_ERROR,
-                             error.errorType)
         else:
             self.fail("no error mapping is defined for %s driver" % driver)
 

--- a/tests/stub/iteration/test_result_single.py
+++ b/tests/stub/iteration/test_result_single.py
@@ -1,4 +1,5 @@
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     driver_feature,
     get_driver_name,
@@ -25,6 +26,8 @@ class TestResultSingle(IterationTestBase):
                 error.errorType)
         elif driver in ["dotnet"]:
             self.assertEqual("InvalidOperationException", error.errorType)
+        elif driver in ["java"]:
+            self.assertEqual(ErrorType.NOT_SINGLE_ERROR.value, error.errorType)
         else:
             self.fail("no error mapping is defined for %s driver" % driver)
 
@@ -40,6 +43,9 @@ class TestResultSingle(IterationTestBase):
                 error.errorType)
         elif driver in ["dotnet"]:
             self.assertEqual("ServiceUnavailableError", error.errorType)
+        elif driver in ["java"]:
+            self.assertEqual(ErrorType.SERVICE_UNAVAILABLE_ERROR,
+                             error.errorType)
         else:
             self.fail("no error mapping is defined for %s driver" % driver)
 

--- a/tests/stub/iteration/test_result_single.py
+++ b/tests/stub/iteration/test_result_single.py
@@ -29,7 +29,7 @@ class TestResultSingle(IterationTestBase):
     def _assert_connection_error(self, error):
         self.assertIsInstance(error, types.DriverError)
         driver = get_driver_name()
-        if driver in ["java", "python"]:
+        if driver in ["java", "python", "javascript"]:
             self.assertEqual(
                 ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                 error.errorType

--- a/tests/stub/retry/test_retry.py
+++ b/tests/stub/retry/test_retry.py
@@ -1,5 +1,6 @@
 from nutkit.frontend import Driver
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     get_driver_name,
     TestkitTestCase,
@@ -124,7 +125,7 @@ class TestRetry(TestkitTestCase):
             session.write_transaction(once)
         if get_driver_name() in ["python"]:
             self.assertEqual(
-                "<class 'neo4j.exceptions.IncompleteCommit'>",
+                ErrorType.INCOMPLETE_COMMIT_ERROR.value,
                 e.exception.errorType
             )
 

--- a/tests/stub/retry/test_retry_clustering.py
+++ b/tests/stub/retry/test_retry_clustering.py
@@ -1,5 +1,6 @@
 from nutkit.frontend import Driver
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     get_driver_name,
     TestkitTestCase,
@@ -102,7 +103,7 @@ class TestRetryClustering(TestkitTestCase):
             session.write_transaction(once)
         if get_driver_name() in ["python"]:
             self.assertEqual(
-                "<class 'neo4j.exceptions.IncompleteCommit'>",
+                ErrorType.INCOMPLETE_COMMIT_ERROR.value,
                 e.exception.errorType
             )
 

--- a/tests/stub/routing/test_no_routing_v4x1.py
+++ b/tests/stub/routing/test_no_routing_v4x1.py
@@ -1,5 +1,6 @@
 from nutkit.frontend import Driver
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     driver_feature,
     get_dns_resolved_server_address,
@@ -570,8 +571,7 @@ class NoRoutingV4x1(TestkitTestCase):
     def _assert_is_transient_rollback_exception(
             self, e, expected_msg="Unable to rollback"):
         if get_driver_name() in ["java"]:
-            self.assertEqual("org.neo4j.driver.exceptions.TransientException",
-                             e.errorType)
+            self.assertEqual(ErrorType.TRANSIENT_ERROR.value, e.errorType)
             self.assertEqual(expected_msg, e.msg)
         elif get_driver_name() in ["ruby"]:
             self.assertEqual("Neo4j::Driver::Exceptions::TransientException",
@@ -584,8 +584,7 @@ class NoRoutingV4x1(TestkitTestCase):
     def _assert_is_transient_commit_exception(
             self, e, expected_msg="Unable to commit"):
         if get_driver_name() in ["java"]:
-            self.assertEqual("org.neo4j.driver.exceptions.TransientException",
-                             e.errorType)
+            self.assertEqual(ErrorType.TRANSIENT_ERROR.value, e.errorType)
             self.assertEqual(expected_msg, e.msg)
         elif get_driver_name() in ["ruby"]:
             self.assertEqual("Neo4j::Driver::Exceptions::TransientException",

--- a/tests/stub/routing/test_no_routing_v4x1.py
+++ b/tests/stub/routing/test_no_routing_v4x1.py
@@ -570,7 +570,7 @@ class NoRoutingV4x1(TestkitTestCase):
 
     def _assert_is_transient_rollback_exception(
             self, e, expected_msg="Unable to rollback"):
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(ErrorType.TRANSIENT_ERROR.value, e.errorType)
             self.assertEqual(expected_msg, e.msg)
         elif get_driver_name() in ["ruby"]:
@@ -583,7 +583,7 @@ class NoRoutingV4x1(TestkitTestCase):
 
     def _assert_is_transient_commit_exception(
             self, e, expected_msg="Unable to commit"):
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(ErrorType.TRANSIENT_ERROR.value, e.errorType)
             self.assertEqual(expected_msg, e.msg)
         elif get_driver_name() in ["ruby"]:

--- a/tests/stub/routing/test_no_routing_v4x1.py
+++ b/tests/stub/routing/test_no_routing_v4x1.py
@@ -570,7 +570,7 @@ class NoRoutingV4x1(TestkitTestCase):
 
     def _assert_is_transient_rollback_exception(
             self, e, expected_msg="Unable to rollback"):
-        if get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(ErrorType.TRANSIENT_ERROR.value, e.errorType)
             self.assertEqual(expected_msg, e.msg)
         elif get_driver_name() in ["ruby"]:
@@ -583,7 +583,7 @@ class NoRoutingV4x1(TestkitTestCase):
 
     def _assert_is_transient_commit_exception(
             self, e, expected_msg="Unable to commit"):
-        if get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(ErrorType.TRANSIENT_ERROR.value, e.errorType)
             self.assertEqual(expected_msg, e.msg)
         elif get_driver_name() in ["ruby"]:

--- a/tests/stub/routing/test_routing_v3.py
+++ b/tests/stub/routing/test_routing_v3.py
@@ -72,16 +72,12 @@ class RoutingV3(RoutingV4x4):
             session.run("RETURN 1 AS x").consume()
         except types.DriverError as e:
             failed = True
-            if get_driver_name() in ["java"]:
+            if get_driver_name() in ["java", "python"]:
                 self.assertEqual(
                     ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                     e.errorType
                 )
-            elif get_driver_name() in ["python"]:
-                self.assertEqual(
-                    e.errorType,
-                    "<class 'neo4j.exceptions.ServiceUnavailable'>"
-                )
-                self.assertIn("routing", e.msg)
+                if get_driver_name() in ["python"]:
+                    self.assertIn("routing", e.msg)
 
         self.assertTrue(failed)

--- a/tests/stub/routing/test_routing_v3.py
+++ b/tests/stub/routing/test_routing_v3.py
@@ -1,5 +1,6 @@
 from nutkit.frontend import Driver
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 
 from ...shared import get_driver_name
 from .test_routing_v4x4 import RoutingV4x4
@@ -71,7 +72,12 @@ class RoutingV3(RoutingV4x4):
             session.run("RETURN 1 AS x").consume()
         except types.DriverError as e:
             failed = True
-            if get_driver_name() in ["python"]:
+            if get_driver_name() in ["java"]:
+                self.assertEqual(
+                    ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
+                    e.errorType
+                )
+            elif get_driver_name() in ["python"]:
                 self.assertEqual(
                     e.errorType,
                     "<class 'neo4j.exceptions.ServiceUnavailable'>"

--- a/tests/stub/routing/test_routing_v3.py
+++ b/tests/stub/routing/test_routing_v3.py
@@ -72,7 +72,7 @@ class RoutingV3(RoutingV4x4):
             session.run("RETURN 1 AS x").consume()
         except types.DriverError as e:
             failed = True
-            if get_driver_name() in ["java", "python"]:
+            if get_driver_name() in ["java", "python", "javascript"]:
                 self.assertEqual(
                     ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                     e.errorType

--- a/tests/stub/routing/test_routing_v5x0.py
+++ b/tests/stub/routing/test_routing_v5x0.py
@@ -235,7 +235,7 @@ class RoutingV5x0(RoutingBase):
                 # else they should fail here
                 session.close()
             except types.DriverError as e:
-                if get_driver_name() in ["java", "python"]:
+                if get_driver_name() in ["java", "python", "javascript"]:
                     self.assertEqual(
                         ErrorType.SESSION_EXPIRED_ERROR.value,
                         e.errorType
@@ -286,7 +286,7 @@ class RoutingV5x0(RoutingBase):
             # else they should fail here
             tx.commit()
         except types.DriverError as e:
-            if get_driver_name() in ["java", "python"]:
+            if get_driver_name() in ["java", "python", "javascript"]:
                 self.assertEqual(
                     ErrorType.SESSION_EXPIRED_ERROR.value,
                     e.errorType
@@ -340,7 +340,7 @@ class RoutingV5x0(RoutingBase):
         session.close()
         driver.close()
 
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(
                 ErrorType.SESSION_EXPIRED_ERROR.value,
                 exc.exception.errorType
@@ -395,7 +395,7 @@ class RoutingV5x0(RoutingBase):
         session.close()
         driver.close()
 
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(
                 ErrorType.SESSION_EXPIRED_ERROR.value,
                 exc.exception.errorType
@@ -654,7 +654,7 @@ class RoutingV5x0(RoutingBase):
                 # else they should fail here
                 session.close()
             except types.DriverError as e:
-                if get_driver_name() in ["java", "python"]:
+                if get_driver_name() in ["java", "python", "javascript"]:
                     self.assertEqual(
                         ErrorType.SESSION_EXPIRED_ERROR.value,
                         e.errorType
@@ -719,7 +719,7 @@ class RoutingV5x0(RoutingBase):
             with self.assertRaises(types.DriverError) as exc:
                 tx.run("RETURN 1 as n")
 
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(
                 ErrorType.SESSION_EXPIRED_ERROR.value,
                 exc.exception.errorType
@@ -771,7 +771,7 @@ class RoutingV5x0(RoutingBase):
         try:
             driver.verify_connectivity()
         except types.DriverError as e:
-            if get_driver_name() in ["java", "python"]:
+            if get_driver_name() in ["java", "python", "javascript"]:
                 self.assertEqual(
                     ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                     e.errorType
@@ -802,7 +802,7 @@ class RoutingV5x0(RoutingBase):
         try:
             driver.verify_connectivity()
         except types.DriverError as e:
-            if get_driver_name() in ["java", "python"]:
+            if get_driver_name() in ["java", "python", "javascript"]:
                 self.assertEqual(
                     ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                     e.errorType
@@ -948,7 +948,7 @@ class RoutingV5x0(RoutingBase):
         try:
             session.run("RETURN 1 as n").consume()
         except types.DriverError as e:
-            if get_driver_name() in ["java", "python"]:
+            if get_driver_name() in ["java", "python", "javascript"]:
                 self.assertEqual(ErrorType.CLIENT_ERROR.value, e.errorType)
                 if get_driver_name() in ["python"]:
                     self.assertEqual(
@@ -2096,7 +2096,7 @@ class RoutingV5x0(RoutingBase):
         exc = self._test_fast_fail_discover(
             "router_yielding_invalid_bookmark_failure.script",
         )
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(
                 ErrorType.CLIENT_ERROR.value,
                 exc.exception.errorType
@@ -2115,7 +2115,7 @@ class RoutingV5x0(RoutingBase):
         exc = self._test_fast_fail_discover(
             "router_yielding_invalid_bookmark_mixture_failure.script",
         )
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(
                 ErrorType.CLIENT_ERROR.value,
                 exc.exception.errorType
@@ -2135,7 +2135,7 @@ class RoutingV5x0(RoutingBase):
         exc = self._test_fast_fail_discover(
             "router_yielding_forbidden_failure.script",
         )
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(
                 ErrorType.SECURITY_ERROR.value,
                 exc.exception.errorType
@@ -2155,7 +2155,7 @@ class RoutingV5x0(RoutingBase):
         exc = self._test_fast_fail_discover(
             "router_yielding_any_security_failure.script",
         )
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(
                 ErrorType.SECURITY_ERROR.value,
                 exc.exception.errorType
@@ -2188,7 +2188,7 @@ class RoutingV5x0(RoutingBase):
             result = session.run("RETURN 1 as n")
             self.collect_records(result)
         except types.DriverError as e:
-            if get_driver_name() in ["java", "python"]:
+            if get_driver_name() in ["java", "python", "javascript"]:
                 self.assertEqual(
                     ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                     e.errorType
@@ -2417,7 +2417,7 @@ class RoutingV5x0(RoutingBase):
         with self.assertRaises(types.DriverError) as exc:
             session.run("RETURN 1 as n")
 
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(
                 ErrorType.ILLEGAL_STATE_ERROR.value,
                 exc.exception.errorType
@@ -2450,7 +2450,7 @@ class RoutingV5x0(RoutingBase):
             # drivers doing lazy loading should fail here
             result.next()
         except types.DriverError as e:
-            if get_driver_name() in ["java", "python"]:
+            if get_driver_name() in ["java", "python", "javascript"]:
                 self.assertEqual(
                     ErrorType.SESSION_EXPIRED_ERROR.value,
                     e.errorType
@@ -2569,7 +2569,7 @@ class RoutingV5x0(RoutingBase):
                 # drivers doing lazy loading should fail here
                 result.next()
 
-            if get_driver_name() in ["java", "python"]:
+            if get_driver_name() in ["java", "python", "javascript"]:
                 self.assertEqual(
                     ErrorType.SESSION_EXPIRED_ERROR.value,
                     exc.exception.errorType
@@ -2638,7 +2638,7 @@ class RoutingV5x0(RoutingBase):
             # drivers doing lazy loading should fail here
             result.next()
 
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(
                 ErrorType.SESSION_EXPIRED_ERROR.value,
                 exc.exception.errorType
@@ -2775,7 +2775,7 @@ class RoutingV5x0(RoutingBase):
                 tx = session2.begin_transaction()
                 list(tx.run("RETURN 1 as n"))
 
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(
                 ErrorType.CLIENT_ERROR.value,
                 exc.exception.errorType

--- a/tests/stub/routing/test_routing_v5x0.py
+++ b/tests/stub/routing/test_routing_v5x0.py
@@ -10,8 +10,7 @@ from tests.shared import (
     get_driver_name,
     get_ip_addresses,
 )
-
-from ._routing import RoutingBase
+from tests.stub.routing._routing import RoutingBase
 
 
 class RoutingV5x0(RoutingBase):
@@ -236,10 +235,11 @@ class RoutingV5x0(RoutingBase):
                 # else they should fail here
                 session.close()
             except types.DriverError as e:
-                if get_driver_name() in ["java"]:
+                if get_driver_name() in ["java", "python"]:
                     self.assertEqual(
                         ErrorType.SESSION_EXPIRED_ERROR.value,
-                        e.errorType)
+                        e.errorType
+                    )
                 elif get_driver_name() in ["ruby"]:
                     self.assertEqual(
                         "Neo4j::Driver::Exceptions::SessionExpiredException",
@@ -286,7 +286,7 @@ class RoutingV5x0(RoutingBase):
             # else they should fail here
             tx.commit()
         except types.DriverError as e:
-            if get_driver_name() in ["java"]:
+            if get_driver_name() in ["java", "python"]:
                 self.assertEqual(
                     ErrorType.SESSION_EXPIRED_ERROR.value,
                     e.errorType
@@ -340,7 +340,7 @@ class RoutingV5x0(RoutingBase):
         session.close()
         driver.close()
 
-        if get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(
                 ErrorType.SESSION_EXPIRED_ERROR.value,
                 exc.exception.errorType
@@ -395,7 +395,7 @@ class RoutingV5x0(RoutingBase):
         session.close()
         driver.close()
 
-        if get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(
                 ErrorType.SESSION_EXPIRED_ERROR.value,
                 exc.exception.errorType
@@ -654,14 +654,9 @@ class RoutingV5x0(RoutingBase):
                 # else they should fail here
                 session.close()
             except types.DriverError as e:
-                if get_driver_name() in ["java"]:
+                if get_driver_name() in ["java", "python"]:
                     self.assertEqual(
                         ErrorType.SESSION_EXPIRED_ERROR.value,
-                        e.errorType
-                    )
-                elif get_driver_name() in ["python"]:
-                    self.assertEqual(
-                        "<class 'neo4j.exceptions.SessionExpired'>",
                         e.errorType
                     )
                 elif get_driver_name() in ["ruby"]:
@@ -724,7 +719,7 @@ class RoutingV5x0(RoutingBase):
             with self.assertRaises(types.DriverError) as exc:
                 tx.run("RETURN 1 as n")
 
-        if get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(
                 ErrorType.SESSION_EXPIRED_ERROR.value,
                 exc.exception.errorType
@@ -776,14 +771,9 @@ class RoutingV5x0(RoutingBase):
         try:
             driver.verify_connectivity()
         except types.DriverError as e:
-            if get_driver_name() in ["java"]:
+            if get_driver_name() in ["java", "python"]:
                 self.assertEqual(
                     ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
-                    e.errorType
-                )
-            elif get_driver_name() in ["python"]:
-                self.assertEqual(
-                    "<class 'neo4j.exceptions.ServiceUnavailable'>",
                     e.errorType
                 )
             elif get_driver_name() in ["ruby"]:
@@ -812,7 +802,7 @@ class RoutingV5x0(RoutingBase):
         try:
             driver.verify_connectivity()
         except types.DriverError as e:
-            if get_driver_name() in ["java"]:
+            if get_driver_name() in ["java", "python"]:
                 self.assertEqual(
                     ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                     e.errorType
@@ -858,7 +848,7 @@ class RoutingV5x0(RoutingBase):
                 )
             elif get_driver_name() in ["python"]:
                 self.assertEqual(
-                    "<class 'neo4j.exceptions.NotALeader'>",
+                    ErrorType.NOT_LEADER_ERROR.value,
                     e.errorType
                 )
                 self.assertEqual(
@@ -908,11 +898,13 @@ class RoutingV5x0(RoutingBase):
             session.run("RETURN 1 as n").consume()
         except types.DriverError as e:
             if get_driver_name() in ["java"]:
-                self.assertEqual(ErrorType.SESSION_EXPIRED_ERROR.value,
-                                 e.errorType)
+                self.assertEqual(
+                    ErrorType.SESSION_EXPIRED_ERROR.value,
+                    e.errorType
+                )
             elif get_driver_name() in ["python"]:
                 self.assertEqual(
-                    "<class 'neo4j.exceptions.ForbiddenOnReadOnlyDatabase'>",
+                    ErrorType.FORBIDDEN_ON_RO_DB_ERROR.value,
                     e.errorType
                 )
                 self.assertEqual(
@@ -956,17 +948,13 @@ class RoutingV5x0(RoutingBase):
         try:
             session.run("RETURN 1 as n").consume()
         except types.DriverError as e:
-            if get_driver_name() in ["java"]:
+            if get_driver_name() in ["java", "python"]:
                 self.assertEqual(ErrorType.CLIENT_ERROR.value, e.errorType)
-            elif get_driver_name() in ["python"]:
-                self.assertEqual(
-                    "<class 'neo4j.exceptions.ClientError'>",
-                    e.errorType
-                )
-                self.assertEqual(
-                    "Neo.ClientError.General.DatabaseUnavailable",
-                    e.code
-                )
+                if get_driver_name() in ["python"]:
+                    self.assertEqual(
+                        "Neo.ClientError.General.DatabaseUnavailable",
+                        e.code
+                    )
             failed = True
         session.close()
 
@@ -1021,10 +1009,8 @@ class RoutingV5x0(RoutingBase):
                         e.errorType
                     )
                 elif get_driver_name() in ["python"]:
-                    self.assertEqual(
-                        "<class 'neo4j.exceptions.NotALeader'>",
-                        e.errorType
-                    )
+                    self.assertEqual(ErrorType.NOT_LEADER_ERROR.value,
+                                     e.errorType)
                 elif get_driver_name() in ["ruby"]:
                     self.assertEqual(
                         "Neo4j::Driver::Exceptions::SessionExpiredException",
@@ -1073,10 +1059,8 @@ class RoutingV5x0(RoutingBase):
                     e.errorType
                 )
             elif get_driver_name() in ["python"]:
-                self.assertEqual(
-                    "<class 'neo4j.exceptions.NotALeader'>",
-                    e.errorType
-                )
+                self.assertEqual(ErrorType.NOT_LEADER_ERROR.value,
+                                 e.errorType)
             elif get_driver_name() in ["ruby"]:
                 self.assertEqual(
                     "Neo4j::Driver::Exceptions::SessionExpiredException",
@@ -1130,10 +1114,8 @@ class RoutingV5x0(RoutingBase):
                     e.errorType
                 )
             elif get_driver_name() in ["python"]:
-                self.assertEqual(
-                    "<class 'neo4j.exceptions.NotALeader'>",
-                    e.errorType
-                )
+                self.assertEqual(ErrorType.NOT_LEADER_ERROR.value,
+                                 e.errorType)
             elif get_driver_name() in ["ruby"]:
                 self.assertEqual(
                     "Neo4j::Driver::Exceptions::SessionExpiredException",
@@ -1776,8 +1758,8 @@ class RoutingV5x0(RoutingBase):
 
         if get_driver_name() in ["python"]:
             self.assertEqual(
-                exc.exception.errorType,
-                "<class 'neo4j.exceptions.ServiceUnavailable'>"
+                ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
+                exc.exception.errorType
             )
         elif get_driver_name() in ["javascript"]:
             self.assertEqual(
@@ -2074,10 +2056,8 @@ class RoutingV5x0(RoutingBase):
                     e.errorType
                 )
             elif get_driver_name() in ["python"]:
-                self.assertEqual(
-                    "<class 'neo4j.exceptions.ClientError'>",
-                    e.errorType
-                )
+                self.assertEqual(ErrorType.CLIENT_ERROR.value,
+                                 e.errorType)
             elif get_driver_name() in ["ruby"]:
                 self.assertEqual(
                     "Neo4j::Driver::Exceptions::FatalDiscoveryException",
@@ -2116,14 +2096,9 @@ class RoutingV5x0(RoutingBase):
         exc = self._test_fast_fail_discover(
             "router_yielding_invalid_bookmark_failure.script",
         )
-        if get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(
                 ErrorType.CLIENT_ERROR.value,
-                exc.exception.errorType
-            )
-        elif get_driver_name() in ["python"]:
-            self.assertEqual(
-                "<class 'neo4j.exceptions.ClientError'>",
                 exc.exception.errorType
             )
         elif get_driver_name() in ["ruby"]:
@@ -2140,14 +2115,9 @@ class RoutingV5x0(RoutingBase):
         exc = self._test_fast_fail_discover(
             "router_yielding_invalid_bookmark_mixture_failure.script",
         )
-        if get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(
                 ErrorType.CLIENT_ERROR.value,
-                exc.exception.errorType
-            )
-        elif get_driver_name() in ["python"]:
-            self.assertEqual(
-                "<class 'neo4j.exceptions.ClientError'>",
                 exc.exception.errorType
             )
         elif get_driver_name() in ["ruby"]:
@@ -2165,14 +2135,9 @@ class RoutingV5x0(RoutingBase):
         exc = self._test_fast_fail_discover(
             "router_yielding_forbidden_failure.script",
         )
-        if get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(
                 ErrorType.SECURITY_ERROR.value,
-                exc.exception.errorType
-            )
-        elif get_driver_name() in ["python"]:
-            self.assertEqual(
-                "<class 'neo4j.exceptions.Forbidden'>",
                 exc.exception.errorType
             )
         if get_driver_name() in ["ruby"]:
@@ -2190,14 +2155,9 @@ class RoutingV5x0(RoutingBase):
         exc = self._test_fast_fail_discover(
             "router_yielding_any_security_failure.script",
         )
-        if get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(
                 ErrorType.SECURITY_ERROR.value,
-                exc.exception.errorType
-            )
-        elif get_driver_name() in ["python"]:
-            self.assertEqual(
-                "<class 'neo4j.exceptions.ClientError'>",
                 exc.exception.errorType
             )
         elif get_driver_name() in ["ruby"]:
@@ -2228,7 +2188,7 @@ class RoutingV5x0(RoutingBase):
             result = session.run("RETURN 1 as n")
             self.collect_records(result)
         except types.DriverError as e:
-            if get_driver_name() in ["java"]:
+            if get_driver_name() in ["java", "python"]:
                 self.assertEqual(
                     ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                     e.errorType
@@ -2449,24 +2409,25 @@ class RoutingV5x0(RoutingBase):
         session.close()
         session = driver.session("r", database=self.adb)
         driver.close()
+        self._readServer1.done()
+        # Start up the server again to allow the driver to attempt another
+        # read, which it will hopefully refuse, since the driver is closed now.
+        self.start_server(self._readServer1, "reader.script")
 
-        failed_on_run = False
-        try:
+        with self.assertRaises(types.DriverError) as exc:
             session.run("RETURN 1 as n")
-        except types.DriverError as e:
-            if get_driver_name() in ["java"]:
-                self.assertEqual(
-                    ErrorType.ILLEGAL_STATE_ERROR.value,
-                    e.errorType
-                )
-            elif get_driver_name() in ["ruby"]:
-                self.assertEqual(
-                    "Neo4j::Driver::Exceptions::IllegalStateException",
-                    e.errorType
-                )
-            failed_on_run = True
 
-        self.assertTrue(failed_on_run)
+        if get_driver_name() in ["java", "python"]:
+            self.assertEqual(
+                ErrorType.ILLEGAL_STATE_ERROR.value,
+                exc.exception.errorType
+            )
+        elif get_driver_name() in ["ruby"]:
+            self.assertEqual(
+                "Neo4j::Driver::Exceptions::IllegalStateException",
+                exc.exception.errorType
+            )
+
         self._routingServer1.done()
         self._readServer1.done()
         self.assertTrue(summary.server_info.address in
@@ -2489,14 +2450,9 @@ class RoutingV5x0(RoutingBase):
             # drivers doing lazy loading should fail here
             result.next()
         except types.DriverError as e:
-            if get_driver_name() in ["java"]:
+            if get_driver_name() in ["java", "python"]:
                 self.assertEqual(
                     ErrorType.SESSION_EXPIRED_ERROR.value,
-                    e.errorType
-                )
-            elif get_driver_name() in ["python"]:
-                self.assertEqual(
-                    "<class 'neo4j.exceptions.SessionExpired'>",
                     e.errorType
                 )
             failed = True
@@ -2549,12 +2505,12 @@ class RoutingV5x0(RoutingBase):
             elif get_driver_name() in ["python"]:
                 if attempt == 0:
                     self.assertEqual(
-                        "<class 'neo4j.exceptions.NotALeader'>",
+                        ErrorType.NOT_LEADER_ERROR.value,
                         e.exception.errorType
                     )
                 else:
                     self.assertEqual(
-                        "<class 'neo4j.exceptions.SessionExpired'>",
+                        ErrorType.SESSION_EXPIRED_ERROR.value,
                         e.exception.errorType
                     )
             if attempt == 0:
@@ -2613,14 +2569,9 @@ class RoutingV5x0(RoutingBase):
                 # drivers doing lazy loading should fail here
                 result.next()
 
-            if get_driver_name() in ["java"]:
+            if get_driver_name() in ["java", "python"]:
                 self.assertEqual(
                     ErrorType.SESSION_EXPIRED_ERROR.value,
-                    exc.exception.errorType
-                )
-            elif get_driver_name() in ["python"]:
-                self.assertEqual(
-                    "<class 'neo4j.exceptions.SessionExpired'>",
                     exc.exception.errorType
                 )
             elif get_driver_name() in ["ruby"]:
@@ -2687,14 +2638,9 @@ class RoutingV5x0(RoutingBase):
             # drivers doing lazy loading should fail here
             result.next()
 
-        if get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(
                 ErrorType.SESSION_EXPIRED_ERROR.value,
-                exc.exception.errorType
-            )
-        elif get_driver_name() in ["python"]:
-            self.assertEqual(
-                "<class 'neo4j.exceptions.SessionExpired'>",
                 exc.exception.errorType
             )
         elif get_driver_name() in ["ruby"]:
@@ -2829,15 +2775,20 @@ class RoutingV5x0(RoutingBase):
                 tx = session2.begin_transaction()
                 list(tx.run("RETURN 1 as n"))
 
-        if get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(
                 ErrorType.CLIENT_ERROR.value,
                 exc.exception.errorType
             )
-            self.assertTrue("Unable to acquire connection from the "
-                            "pool within configured maximum time of "
-                            f"{acq_timeout_ms}ms"
-                            in exc.exception.msg)
+            if get_driver_name() in ["java"]:
+                self.assertIn("Unable to acquire connection from the "
+                              "pool within configured maximum time of "
+                              f"{acq_timeout_ms}ms",
+                              exc.exception.msg)
+            elif get_driver_name() in ["python"]:
+                self.assertIn("Failed to obtain a connection from pool within "
+                              f"{acq_timeout_ms / 1000}s",
+                              exc.exception.msg)
 
         session2.close()
 

--- a/tests/stub/routing/test_routing_v5x0.py
+++ b/tests/stub/routing/test_routing_v5x0.py
@@ -3,6 +3,7 @@ import time
 
 from nutkit.frontend import Driver
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     driver_feature,
     get_dns_resolved_server_address,
@@ -237,7 +238,7 @@ class RoutingV5x0(RoutingBase):
             except types.DriverError as e:
                 if get_driver_name() in ["java"]:
                     self.assertEqual(
-                        "org.neo4j.driver.exceptions.SessionExpiredException",
+                        ErrorType.SESSION_EXPIRED_ERROR.value,
                         e.errorType)
                 elif get_driver_name() in ["ruby"]:
                     self.assertEqual(
@@ -287,7 +288,7 @@ class RoutingV5x0(RoutingBase):
         except types.DriverError as e:
             if get_driver_name() in ["java"]:
                 self.assertEqual(
-                    "org.neo4j.driver.exceptions.SessionExpiredException",
+                    ErrorType.SESSION_EXPIRED_ERROR.value,
                     e.errorType
                 )
             elif get_driver_name() in ["ruby"]:
@@ -341,7 +342,7 @@ class RoutingV5x0(RoutingBase):
 
         if get_driver_name() in ["java"]:
             self.assertEqual(
-                "org.neo4j.driver.exceptions.SessionExpiredException",
+                ErrorType.SESSION_EXPIRED_ERROR.value,
                 exc.exception.errorType
             )
         elif get_driver_name() in ["ruby"]:
@@ -396,7 +397,7 @@ class RoutingV5x0(RoutingBase):
 
         if get_driver_name() in ["java"]:
             self.assertEqual(
-                "org.neo4j.driver.exceptions.SessionExpiredException",
+                ErrorType.SESSION_EXPIRED_ERROR.value,
                 exc.exception.errorType
             )
         elif get_driver_name() in ["ruby"]:
@@ -655,7 +656,7 @@ class RoutingV5x0(RoutingBase):
             except types.DriverError as e:
                 if get_driver_name() in ["java"]:
                     self.assertEqual(
-                        "org.neo4j.driver.exceptions.SessionExpiredException",
+                        ErrorType.SESSION_EXPIRED_ERROR.value,
                         e.errorType
                     )
                 elif get_driver_name() in ["python"]:
@@ -725,7 +726,7 @@ class RoutingV5x0(RoutingBase):
 
         if get_driver_name() in ["java"]:
             self.assertEqual(
-                "org.neo4j.driver.exceptions.SessionExpiredException",
+                ErrorType.SESSION_EXPIRED_ERROR.value,
                 exc.exception.errorType
             )
         session.close()
@@ -777,7 +778,7 @@ class RoutingV5x0(RoutingBase):
         except types.DriverError as e:
             if get_driver_name() in ["java"]:
                 self.assertEqual(
-                    "org.neo4j.driver.exceptions.ServiceUnavailableException",
+                    ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                     e.errorType
                 )
             elif get_driver_name() in ["python"]:
@@ -813,7 +814,7 @@ class RoutingV5x0(RoutingBase):
         except types.DriverError as e:
             if get_driver_name() in ["java"]:
                 self.assertEqual(
-                    "org.neo4j.driver.exceptions.ServiceUnavailableException",
+                    ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                     e.errorType
                 )
             elif get_driver_name() in ["ruby"]:
@@ -852,7 +853,7 @@ class RoutingV5x0(RoutingBase):
         except types.DriverError as e:
             if get_driver_name() in ["java"]:
                 self.assertEqual(
-                    "org.neo4j.driver.exceptions.SessionExpiredException",
+                    ErrorType.SESSION_EXPIRED_ERROR.value,
                     e.errorType
                 )
             elif get_driver_name() in ["python"]:
@@ -906,7 +907,10 @@ class RoutingV5x0(RoutingBase):
         try:
             session.run("RETURN 1 as n").consume()
         except types.DriverError as e:
-            if get_driver_name() in ["python"]:
+            if get_driver_name() in ["java"]:
+                self.assertEqual(ErrorType.SESSION_EXPIRED_ERROR.value,
+                                 e.errorType)
+            elif get_driver_name() in ["python"]:
                 self.assertEqual(
                     "<class 'neo4j.exceptions.ForbiddenOnReadOnlyDatabase'>",
                     e.errorType
@@ -952,7 +956,9 @@ class RoutingV5x0(RoutingBase):
         try:
             session.run("RETURN 1 as n").consume()
         except types.DriverError as e:
-            if get_driver_name() in ["python"]:
+            if get_driver_name() in ["java"]:
+                self.assertEqual(ErrorType.CLIENT_ERROR.value, e.errorType)
+            elif get_driver_name() in ["python"]:
                 self.assertEqual(
                     "<class 'neo4j.exceptions.ClientError'>",
                     e.errorType
@@ -1011,7 +1017,7 @@ class RoutingV5x0(RoutingBase):
             except types.DriverError as e:
                 if get_driver_name() in ["java"]:
                     self.assertEqual(
-                        "org.neo4j.driver.exceptions.SessionExpiredException",
+                        ErrorType.SESSION_EXPIRED_ERROR.value,
                         e.errorType
                     )
                 elif get_driver_name() in ["python"]:
@@ -1063,7 +1069,7 @@ class RoutingV5x0(RoutingBase):
         except types.DriverError as e:
             if get_driver_name() in ["java"]:
                 self.assertEqual(
-                    "org.neo4j.driver.exceptions.SessionExpiredException",
+                    ErrorType.SESSION_EXPIRED_ERROR.value,
                     e.errorType
                 )
             elif get_driver_name() in ["python"]:
@@ -1120,7 +1126,7 @@ class RoutingV5x0(RoutingBase):
         except types.DriverError as e:
             if get_driver_name() in ["java"]:
                 self.assertEqual(
-                    "org.neo4j.driver.exceptions.SessionExpiredException",
+                    ErrorType.SESSION_EXPIRED_ERROR.value,
                     e.errorType
                 )
             elif get_driver_name() in ["python"]:
@@ -1693,7 +1699,7 @@ class RoutingV5x0(RoutingBase):
         except types.DriverError as e:
             if get_driver_name() in ["java"]:
                 self.assertEqual(
-                    "org.neo4j.driver.exceptions.SessionExpiredException",
+                    ErrorType.SESSION_EXPIRED_ERROR.value,
                     e.errorType
                 )
             elif get_driver_name() in ["ruby"]:
@@ -2064,7 +2070,7 @@ class RoutingV5x0(RoutingBase):
         except types.DriverError as e:
             if get_driver_name() in ["java"]:
                 self.assertEqual(
-                    "org.neo4j.driver.exceptions.FatalDiscoveryException",
+                    ErrorType.FATAL_DISCOVERY_ERROR.value,
                     e.errorType
                 )
             elif get_driver_name() in ["python"]:
@@ -2112,7 +2118,7 @@ class RoutingV5x0(RoutingBase):
         )
         if get_driver_name() in ["java"]:
             self.assertEqual(
-                "org.neo4j.driver.exceptions.ClientException",
+                ErrorType.CLIENT_ERROR.value,
                 exc.exception.errorType
             )
         elif get_driver_name() in ["python"]:
@@ -2136,7 +2142,7 @@ class RoutingV5x0(RoutingBase):
         )
         if get_driver_name() in ["java"]:
             self.assertEqual(
-                "org.neo4j.driver.exceptions.ClientException",
+                ErrorType.CLIENT_ERROR.value,
                 exc.exception.errorType
             )
         elif get_driver_name() in ["python"]:
@@ -2161,7 +2167,7 @@ class RoutingV5x0(RoutingBase):
         )
         if get_driver_name() in ["java"]:
             self.assertEqual(
-                "org.neo4j.driver.exceptions.SecurityException",
+                ErrorType.SECURITY_ERROR.value,
                 exc.exception.errorType
             )
         elif get_driver_name() in ["python"]:
@@ -2186,7 +2192,7 @@ class RoutingV5x0(RoutingBase):
         )
         if get_driver_name() in ["java"]:
             self.assertEqual(
-                "org.neo4j.driver.exceptions.SecurityException",
+                ErrorType.SECURITY_ERROR.value,
                 exc.exception.errorType
             )
         elif get_driver_name() in ["python"]:
@@ -2224,7 +2230,7 @@ class RoutingV5x0(RoutingBase):
         except types.DriverError as e:
             if get_driver_name() in ["java"]:
                 self.assertEqual(
-                    "org.neo4j.driver.exceptions.ServiceUnavailableException",
+                    ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                     e.errorType
                 )
             elif get_driver_name() in ["ruby"]:
@@ -2450,7 +2456,7 @@ class RoutingV5x0(RoutingBase):
         except types.DriverError as e:
             if get_driver_name() in ["java"]:
                 self.assertEqual(
-                    "java.lang.IllegalStateException",
+                    ErrorType.ILLEGAL_STATE_ERROR.value,
                     e.errorType
                 )
             elif get_driver_name() in ["ruby"]:
@@ -2485,7 +2491,7 @@ class RoutingV5x0(RoutingBase):
         except types.DriverError as e:
             if get_driver_name() in ["java"]:
                 self.assertEqual(
-                    "org.neo4j.driver.exceptions.SessionExpiredException",
+                    ErrorType.SESSION_EXPIRED_ERROR.value,
                     e.errorType
                 )
             elif get_driver_name() in ["python"]:
@@ -2537,7 +2543,7 @@ class RoutingV5x0(RoutingBase):
                 result.next()
             if get_driver_name() in ["java"]:
                 self.assertEqual(
-                    "org.neo4j.driver.exceptions.SessionExpiredException",
+                    ErrorType.SESSION_EXPIRED_ERROR.value,
                     e.exception.errorType
                 )
             elif get_driver_name() in ["python"]:
@@ -2609,7 +2615,7 @@ class RoutingV5x0(RoutingBase):
 
             if get_driver_name() in ["java"]:
                 self.assertEqual(
-                    "org.neo4j.driver.exceptions.SessionExpiredException",
+                    ErrorType.SESSION_EXPIRED_ERROR.value,
                     exc.exception.errorType
                 )
             elif get_driver_name() in ["python"]:
@@ -2683,7 +2689,7 @@ class RoutingV5x0(RoutingBase):
 
         if get_driver_name() in ["java"]:
             self.assertEqual(
-                "org.neo4j.driver.exceptions.SessionExpiredException",
+                ErrorType.SESSION_EXPIRED_ERROR.value,
                 exc.exception.errorType
             )
         elif get_driver_name() in ["python"]:
@@ -2825,7 +2831,7 @@ class RoutingV5x0(RoutingBase):
 
         if get_driver_name() in ["java"]:
             self.assertEqual(
-                "org.neo4j.driver.exceptions.ClientException",
+                ErrorType.CLIENT_ERROR.value,
                 exc.exception.errorType
             )
             self.assertTrue("Unable to acquire connection from the "

--- a/tests/stub/server_side_routing/test_server_side_routing.py
+++ b/tests/stub/server_side_routing/test_server_side_routing.py
@@ -54,7 +54,7 @@ class TestServerSideRouting(TestkitTestCase):
         self._start_server()
         with self.assertRaises(types.DriverError) as exc:
             driver = Driver(self._backend, uri, self._auth, self._userAgent)
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(ErrorType.ILLEGAL_ARGUMENT_ERROR.value,
                              exc.exception.errorType)
             self.assertIn(uri, exc.exception.msg)

--- a/tests/stub/server_side_routing/test_server_side_routing.py
+++ b/tests/stub/server_side_routing/test_server_side_routing.py
@@ -1,5 +1,6 @@
 from nutkit.frontend import Driver
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     get_driver_name,
     TestkitTestCase,
@@ -54,7 +55,7 @@ class TestServerSideRouting(TestkitTestCase):
         with self.assertRaises(types.DriverError) as exc:
             driver = Driver(self._backend, uri, self._auth, self._userAgent)
         if get_driver_name() in ["java"]:
-            self.assertEqual("java.lang.IllegalArgumentException",
+            self.assertEqual(ErrorType.ILLEGAL_ARGUMENT_ERROR.value,
                              exc.exception.errorType)
             self.assertIn(uri, exc.exception.msg)
         elif get_driver_name() in ["ruby"]:

--- a/tests/stub/server_side_routing/test_server_side_routing.py
+++ b/tests/stub/server_side_routing/test_server_side_routing.py
@@ -54,15 +54,12 @@ class TestServerSideRouting(TestkitTestCase):
         self._start_server()
         with self.assertRaises(types.DriverError) as exc:
             driver = Driver(self._backend, uri, self._auth, self._userAgent)
-        if get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(ErrorType.ILLEGAL_ARGUMENT_ERROR.value,
                              exc.exception.errorType)
             self.assertIn(uri, exc.exception.msg)
         elif get_driver_name() in ["ruby"]:
             self.assertEqual("ArgumentError", exc.exception.errorType)
-        elif get_driver_name() in ["python"]:
-            self.assertEqual("<class 'ValueError'>", exc.exception.errorType)
-            self.assertIn(uri, exc.exception.msg)
         elif get_driver_name() in ["javascript"]:
             self.assertIn(uri, exc.exception.msg)
         elif get_driver_name() in ["go"]:

--- a/tests/stub/session_run_parameters/test_session_run_parameters.py
+++ b/tests/stub/session_run_parameters/test_session_run_parameters.py
@@ -178,10 +178,8 @@ class TestSessionRunParameters(TestkitTestCase):
                                   "impersonated_user": "that-other-dude"
                               })
                 if self._driver_name in ["python"]:
-                    self.assertEqual(
-                        exc.exception.errorType,
-                        "<class 'neo4j.exceptions.ConfigurationError'>"
-                    )
+                    self.assertEqual(ErrorType.INVALID_CONF_ERROR.value,
+                                     exc.exception.errorType)
                     self.assertIn("that-other-dude", exc.exception.msg)
                 elif self._driver_name in ["java"]:
                     self.assertEqual(ErrorType.CLIENT_ERROR.value,

--- a/tests/stub/session_run_parameters/test_session_run_parameters.py
+++ b/tests/stub/session_run_parameters/test_session_run_parameters.py
@@ -1,5 +1,6 @@
 from nutkit.frontend import Driver
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     driver_feature,
     get_driver_name,
@@ -183,10 +184,8 @@ class TestSessionRunParameters(TestkitTestCase):
                     )
                     self.assertIn("that-other-dude", exc.exception.msg)
                 elif self._driver_name in ["java"]:
-                    self.assertEqual(
-                        exc.exception.errorType,
-                        "org.neo4j.driver.exceptions.ClientException"
-                    )
+                    self.assertEqual(ErrorType.CLIENT_ERROR.value,
+                                     exc.exception.errorType)
                 elif self._driver_name in ["go"]:
                     self.assertIn("impersonation", exc.exception.msg)
                 elif self._driver_name in ["ruby"]:

--- a/tests/stub/summary/test_summary.py
+++ b/tests/stub/summary/test_summary.py
@@ -3,6 +3,7 @@ import json
 
 from nutkit import protocol as types
 from nutkit.frontend import Driver
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     driver_feature,
     get_dns_resolved_server_address,
@@ -116,15 +117,10 @@ class TestSummary(TestkitTestCase):
                     result = session.run("RETURN 1 AS n",
                                          params={"foo": types.CypherInt(123)})
                     result.consume()
-            if get_driver_name() == "python":
+            if get_driver_name() in ["java", "python"]:
                 self.assertEqual(
-                    e.exception.errorType,
-                    "<class 'neo4j._exceptions.BoltProtocolError'>"
-                )
-            elif get_driver_name() == "java":
-                self.assertEqual(
-                    e.exception.errorType,
-                    "org.neo4j.driver.exceptions.ProtocolException"
+                    ErrorType.PROTOCOL_ERROR.value,
+                    e.exception.errorType
                 )
 
         for query_type in ("wr",):

--- a/tests/stub/summary/test_summary.py
+++ b/tests/stub/summary/test_summary.py
@@ -117,7 +117,7 @@ class TestSummary(TestkitTestCase):
                     result = session.run("RETURN 1 AS n",
                                          params={"foo": types.CypherInt(123)})
                     result.consume()
-            if get_driver_name() in ["java", "python"]:
+            if get_driver_name() in ["java", "python", "javascript"]:
                 self.assertEqual(
                     ErrorType.PROTOCOL_ERROR.value,
                     e.exception.errorType

--- a/tests/stub/tx_begin_parameters/test_tx_begin_parameters.py
+++ b/tests/stub/tx_begin_parameters/test_tx_begin_parameters.py
@@ -216,10 +216,8 @@ class TestTxBeginParameters(TestkitTestCase):
                                   "impersonated_user": "that-other-dude"
                               })
                 if self._driver_name in ["python"]:
-                    self.assertEqual(
-                        exc.exception.errorType,
-                        "<class 'neo4j.exceptions.ConfigurationError'>"
-                    )
+                    self.assertEqual(ErrorType.INVALID_CONF_ERROR.value,
+                                     exc.exception.errorType)
                     self.assertIn("that-other-dude", exc.exception.msg)
                 elif self._driver_name in ["java"]:
                     self.assertEqual(ErrorType.CLIENT_ERROR.value,

--- a/tests/stub/tx_begin_parameters/test_tx_begin_parameters.py
+++ b/tests/stub/tx_begin_parameters/test_tx_begin_parameters.py
@@ -1,5 +1,6 @@
 from nutkit.frontend import Driver
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     driver_feature,
     get_driver_name,
@@ -221,10 +222,8 @@ class TestTxBeginParameters(TestkitTestCase):
                     )
                     self.assertIn("that-other-dude", exc.exception.msg)
                 elif self._driver_name in ["java"]:
-                    self.assertEqual(
-                        exc.exception.errorType,
-                        "org.neo4j.driver.exceptions.ClientException"
-                    )
+                    self.assertEqual(ErrorType.CLIENT_ERROR.value,
+                                     exc.exception.errorType)
                 elif self._driver_name in ["go"]:
                     self.assertIn("impersonation", exc.exception.msg)
                 elif self._driver_name in ["ruby"]:

--- a/tests/stub/tx_lifetime/test_tx_lifetime.py
+++ b/tests/stub/tx_lifetime/test_tx_lifetime.py
@@ -39,13 +39,12 @@ class TestTxLifetime(TestkitTestCase):
         driver = get_driver_name()
         assert isinstance(exc, types.DriverError)
         if driver in ["python"]:
-            self.assertEqual(exc.errorType,
-                             "<class 'neo4j.exceptions.TransactionError'>")
+            self.assertEqual(ErrorType.TRANSACTION_ERROR.value, exc.errorType)
             self.assertIn("closed", exc.msg.lower())
-        elif driver in ["javascript", "go", "dotnet"]:
-            self.assertIn("transaction", exc.msg.lower())
         elif driver in ["java"]:
             self.assertEqual(ErrorType.CLIENT_ERROR.value, exc.errorType)
+        elif driver in ["javascript", "go", "dotnet"]:
+            self.assertIn("transaction", exc.msg.lower())
         else:
             self.fail("no error mapping is defined for %s driver" % driver)
 

--- a/tests/stub/tx_lifetime/test_tx_lifetime.py
+++ b/tests/stub/tx_lifetime/test_tx_lifetime.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 
 from nutkit.frontend import Driver
 import nutkit.protocol as types
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     get_driver_name,
     TestkitTestCase,
@@ -44,8 +45,7 @@ class TestTxLifetime(TestkitTestCase):
         elif driver in ["javascript", "go", "dotnet"]:
             self.assertIn("transaction", exc.msg.lower())
         elif driver in ["java"]:
-            self.assertEqual(exc.errorType,
-                             "org.neo4j.driver.exceptions.ClientException")
+            self.assertEqual(ErrorType.CLIENT_ERROR.value, exc.errorType)
         else:
             self.fail("no error mapping is defined for %s driver" % driver)
 

--- a/tests/stub/tx_run/test_tx_run.py
+++ b/tests/stub/tx_run/test_tx_run.py
@@ -185,10 +185,7 @@ class TestTxRun(TestkitTestCase):
     @driver_feature(types.Feature.OPT_EAGER_TX_BEGIN)
     def test_eager_begin_on_tx_run_with_disconnect_on_begin(self):
         exc = self._eager_tx_run("tx_disconnect_on_begin.script")
-        if get_driver_name() in ["python"]:
-            self.assertEqual("<class 'neo4j.exceptions.ServiceUnavailable'>",
-                             exc.errorType)
-        elif get_driver_name() in ["java"]:
+        if get_driver_name() in ["java", "python"]:
             self.assertEqual(ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                              exc.errorType)
 

--- a/tests/stub/tx_run/test_tx_run.py
+++ b/tests/stub/tx_run/test_tx_run.py
@@ -1,5 +1,6 @@
 from nutkit import protocol as types
 from nutkit.frontend import Driver
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     driver_feature,
     get_driver_name,
@@ -186,6 +187,9 @@ class TestTxRun(TestkitTestCase):
         exc = self._eager_tx_run("tx_disconnect_on_begin.script")
         if get_driver_name() in ["python"]:
             self.assertEqual("<class 'neo4j.exceptions.ServiceUnavailable'>",
+                             exc.errorType)
+        elif get_driver_name() in ["java"]:
+            self.assertEqual(ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                              exc.errorType)
 
     @driver_feature(types.Feature.OPT_EAGER_TX_BEGIN)

--- a/tests/stub/tx_run/test_tx_run.py
+++ b/tests/stub/tx_run/test_tx_run.py
@@ -185,7 +185,7 @@ class TestTxRun(TestkitTestCase):
     @driver_feature(types.Feature.OPT_EAGER_TX_BEGIN)
     def test_eager_begin_on_tx_run_with_disconnect_on_begin(self):
         exc = self._eager_tx_run("tx_disconnect_on_begin.script")
-        if get_driver_name() in ["java", "python"]:
+        if get_driver_name() in ["java", "python", "javascript"]:
             self.assertEqual(ErrorType.SERVICE_UNAVAILABLE_ERROR.value,
                              exc.errorType)
 

--- a/tests/stub/versions/test_versions.py
+++ b/tests/stub/versions/test_versions.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 
 from nutkit import protocol as types
 from nutkit.frontend import Driver
+from nutkit.protocol.error_type import ErrorType
 from tests.shared import (
     driver_feature,
     get_dns_resolved_server_address,
@@ -276,9 +277,8 @@ class TestProtocolVersions(TestkitTestCase):
 
     def _assert_is_untrusted_server_exception(self, e):
         if get_driver_name() in ["java"]:
-            self.assertEqual(
-                "org.neo4j.driver.exceptions.UntrustedServerException",
-                e.errorType)
+            self.assertEqual(ErrorType.UNTRUSTED_SERVER_ERROR.value,
+                             e.errorType)
         if get_driver_name() in ["ruby"]:
             self.assertEqual(
                 "Neo4j::Driver::Exceptions::UntrustedServerException",

--- a/tests/stub/versions/test_versions.py
+++ b/tests/stub/versions/test_versions.py
@@ -277,7 +277,7 @@ class TestProtocolVersions(TestkitTestCase):
 
     def _assert_is_untrusted_server_exception(self, e):
         driver = get_driver_name()
-        if driver in ["java", "python"]:
+        if driver in ["java", "python", "javascript"]:
             self.assertEqual(ErrorType.UNTRUSTED_SERVER_ERROR.value,
                              e.errorType)
         elif driver in ["ruby"]:

--- a/tests/stub/versions/test_versions.py
+++ b/tests/stub/versions/test_versions.py
@@ -276,10 +276,14 @@ class TestProtocolVersions(TestkitTestCase):
         driver.close()
 
     def _assert_is_untrusted_server_exception(self, e):
-        if get_driver_name() in ["java"]:
+        driver = get_driver_name()
+        if driver in ["java", "python"]:
             self.assertEqual(ErrorType.UNTRUSTED_SERVER_ERROR.value,
                              e.errorType)
-        if get_driver_name() in ["ruby"]:
+        elif driver in ["ruby"]:
             self.assertEqual(
                 "Neo4j::Driver::Exceptions::UntrustedServerException",
-                e.errorType)
+                e.errorType
+            )
+        else:
+            self.fail("no error mapping is defined for %s driver" % driver)


### PR DESCRIPTION
The goal of this update is to introduce Testkit error types that Testkit would expect driver backend to map its error to. This would allow Testkit to remain driver agnostic and still verify expected errors.