### PR TITLE
Update tests for not pipelining drivers

### DIFF
--- a/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
+++ b/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
@@ -83,11 +83,7 @@ class TestDirectConnectionRecvTimeout(TestkitTestCase):
             if get_driver_name() in ["javascript", "dotnet"]:
                 result.next()
 
-        result = self._session.run("in time")
-        # TODO It will be removed as soon as JS Driver
-        # has async iterator api
-        if get_driver_name() in ["javascript"]:
-            result.next()
+        list(self._session.run("in time"))
 
         self._server.done()
         self._assert_is_timeout_exception(exc.exception)

--- a/tests/stub/routing/test_routing_v5x0.py
+++ b/tests/stub/routing/test_routing_v5x0.py
@@ -703,12 +703,9 @@ class RoutingV5x0(RoutingBase):
 
         session = driver.session("w", database=self.adb)
         tx = session.begin_transaction()
-        pipelining_driver = self.driver_supports_features(
-            types.Feature.OPT_PULL_PIPELINING
-        )
         # TODO: It will be removed as soon as JS Driver
         #       has async iterator api
-        if get_driver_name() in ["javascript"] or not pipelining_driver:
+        if get_driver_name() in ["javascript"]:
             fails_on_next = True
         if fails_on_next:
             result = tx.run("RETURN 1 as n")


### PR DESCRIPTION
Updates:
- `test_timeout` - added explicit consumption to satisfy stub script expectation
- `test_should_fail_when_writing_on_unexpectedly_interrupting_writer_on_run_using_tx_run` - remove expectation that not pipelining drivers only fail on `next()`