### PR TITLE
Add support for build args for Driver Docker Image (#374)

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,23 @@ Environment variables:
     Username used to connect, defaults to neo4j
   * `TEST_NEO4J_PASS`  
     Password used to connect
+
+## Sending build args for the Driver Docker Image
+
+TestKit is able to send different `--build-arg`s for building the driver docker image.
+This configuration is done by setting environment variables prefixed with
+`TESTKIT_DRIVER_BUILD_ARG_`. The driver build will called with all build args
+minus the prefix.
+
+For example:
+
+```console
+export TESTKIT_DRIVER_BUILD_ARG_NODE_VERSION=12
+export TESTKIT_DRIVER_BUILD_ARG_NPM_VERSION=7
+python main.py
+```
+will result in the following build command:
+
+```console
+docker build --build-arg NODE_VERSION=12 --build-arg NPM_VERSION=7 --tag <some_tag> /driver/path/testkit
+```

--- a/docker.py
+++ b/docker.py
@@ -181,23 +181,26 @@ def load(readable):
         raise Exception("Failed to load docker image")
 
 
-def build_and_tag(tag_name, dockerfile_path, cwd=None, log_path=None):
-    print("Building runner Docker image %s from %s" % (tag_name,
-                                                       dockerfile_path))
+def build_and_tag(tag_name, dockerfile_path, cwd=None,
+                  log_path=None, args=None):
+    if args is None:
+        args = {}
+    build_args = [e for k, v in args.items()
+                  for e in ("--build-arg", f"{k}={v}")]
+
+    cmd = ["docker", "build", *build_args, "--tag", tag_name, dockerfile_path]
+    print(cmd)
+
     if not log_path:
-        subprocess.check_call([
-            "docker", "build", "--tag", tag_name, dockerfile_path
-        ], cwd=cwd)
+        subprocess.check_call(cmd, cwd=cwd)
     else:
         clean_tag = re.sub(r"\W", "_", tag_name)
         out_path = os.path.join(log_path, "build_{}_out.log".format(clean_tag))
         err_path = os.path.join(log_path, "build_{}_err.log".format(clean_tag))
         with open(out_path, "w") as out_fd:
             with open(err_path, "w") as err_fd:
-                print(["docker", "build", "--tag", tag_name, dockerfile_path])
-                subprocess.check_call([
-                    "docker", "build", "--tag", tag_name, dockerfile_path
-                ], cwd=cwd, stdout=out_fd, stderr=err_fd)
+                subprocess.check_call(cmd,
+                                      cwd=cwd, stdout=out_fd, stderr=err_fd)
     _created_tags.add(tag_name)
     remove_dangling()
 


### PR DESCRIPTION
This feature solves problems like select the version of languages runtimes or libraries present in the driver docker image during the test.
Sending --build-args to the image makes easier to handle this kind of configuration on the image level instead of changing the version using other scripts in a post process.

The first use-case of this feature will be the selection of Nodejs version in the Javascript Driver.

More info about how to use it in the updated docs.

Backport of https://github.com/neo4j-drivers/testkit/pull/374