### PR TITLE
Fix `test_no_reset_on_clean_connection`

### DIFF
--- a/tests/stub/optimizations/test_optimizations.py
+++ b/tests/stub/optimizations/test_optimizations.py
@@ -89,7 +89,7 @@ class TestOptimizations(TestkitTestCase):
                     res.consume()
                 else:
                     results.append(
-                        list(map(lambda r: r.value, res.next().values))
+                        list(map(lambda r: r.values[0].value, res))
                     )
                 if use_tx == "commit":
                     tx.commit()
@@ -101,7 +101,7 @@ class TestOptimizations(TestkitTestCase):
                     res.consume()
                 else:
                     results.append(
-                        list(map(lambda r: r.value, res.next().values))
+                        list(map(lambda r: r.values[0].value, res))
                     )
 
         session.close()

--- a/tests/stub/optimizations/test_optimizations.py
+++ b/tests/stub/optimizations/test_optimizations.py
@@ -89,7 +89,7 @@ class TestOptimizations(TestkitTestCase):
                     res.consume()
                 else:
                     results.append(
-                        list(map(lambda r: r.values[0].value, res))
+                        [value.value for rec in res for value in rec.values]
                     )
                 if use_tx == "commit":
                     tx.commit()
@@ -101,7 +101,7 @@ class TestOptimizations(TestkitTestCase):
                     res.consume()
                 else:
                     results.append(
-                        list(map(lambda r: r.values[0].value, res))
+                        [value.value for rec in res for value in rec.values]
                     )
 
         session.close()


### PR DESCRIPTION
The test was not exausting the record consumption, so it was not always true the driver processed the SUCCESS when the Session.close is called. Closing a session with a result open will trigger a reset in the javascript driver, which makes the test fail.