### PR TITLE
Migrate ITs from Java driver

### DIFF
--- a/tests/stub/iteration/scripts/v4x4/pull_1_nested.script
+++ b/tests/stub/iteration/scripts/v4x4/pull_1_nested.script
@@ -1,0 +1,36 @@
+!: BOLT 4.4
+!: ALLOW CONCURRENT
+
+A: HELLO {"{}": "*"}
+*: RESET
+{?
+    C: RUN "CYPHER" {} {}
+    S: SUCCESS {"fields": ["x"]}
+    C: PULL {"n": 1}
+    S: RECORD ["1_1"]
+       SUCCESS {"has_more": true}
+    C: PULL {"n": 1}
+    S: RECORD ["1_2"]
+       SUCCESS {}
+?}
+*: RESET
+{?
+    C: RUN "CYPHER NESTED 0" {} {}
+    S: SUCCESS {"fields": ["x"]}
+    C: PULL {"n": 1}
+    S: RECORD ["2_1"]
+       SUCCESS {"has_more": true}
+    C: PULL {"n": 1}
+    S: RECORD ["2_2"]
+       SUCCESS {}
+?}
+*: RESET
+{?
+    C: RUN "CYPHER NESTED 1" {} {}
+    S: SUCCESS {"fields": ["x"]}
+    C: PULL {"n": 1}
+    S: RECORD ["3_1"]
+       SUCCESS {}
+?}
+*: RESET
+?: GOODBYE

--- a/tests/stub/iteration/scripts/v4x4/pull_1_nested.script
+++ b/tests/stub/iteration/scripts/v4x4/pull_1_nested.script
@@ -9,9 +9,19 @@ A: HELLO {"{}": "*"}
     C: PULL {"n": 1}
     S: RECORD ["1_1"]
        SUCCESS {"has_more": true}
-    C: PULL {"n": 1}
-    S: RECORD ["1_2"]
-       SUCCESS {}
+    {{
+        C: PULL {"n": 1}
+        S: RECORD ["1_2"]
+           SUCCESS {"has_more": true}
+        C: PULL {"n": -1}
+        S: RECORD ["1_3"]
+           SUCCESS {}
+    ----
+        C: PULL {"n": -1}
+        S: RECORD ["1_2"]
+           RECORD ["1_3"]
+           SUCCESS {}
+    }}
 ?}
 *: RESET
 {?
@@ -30,6 +40,14 @@ A: HELLO {"{}": "*"}
     S: SUCCESS {"fields": ["x"]}
     C: PULL {"n": 1}
     S: RECORD ["3_1"]
+       SUCCESS {}
+?}
+*: RESET
+{?
+    C: RUN "CYPHER NESTED 2" {} {}
+    S: SUCCESS {"fields": ["x"]}
+    C: PULL {"n": 1}
+    S: RECORD ["4_1"]
        SUCCESS {}
 ?}
 *: RESET

--- a/tests/stub/iteration/scripts/v4x4/pull_1_nested.script
+++ b/tests/stub/iteration/scripts/v4x4/pull_1_nested.script
@@ -13,7 +13,11 @@ A: HELLO {"{}": "*"}
         C: PULL {"n": 1}
         S: RECORD ["1_2"]
            SUCCESS {"has_more": true}
-        C: PULL {"n": -1}
+        {{
+            C: PULL {"n": -1}
+        ----
+            C: PULL {"n": 1}
+        }}
         S: RECORD ["1_3"]
            SUCCESS {}
     ----

--- a/tests/stub/iteration/scripts/v4x4/pull_1_nested_list.script
+++ b/tests/stub/iteration/scripts/v4x4/pull_1_nested_list.script
@@ -1,0 +1,51 @@
+!: BOLT 4.4
+!: ALLOW CONCURRENT
+
+A: HELLO {"{}": "*"}
+*: RESET
+{?
+    C: RUN "CYPHER" {} {}
+    S: SUCCESS {"fields": ["x"]}
+    C: PULL {"n": 1}
+    S: RECORD ["1_1"]
+       SUCCESS {"has_more": true}
+    C: PULL {"n": 1}
+    S: RECORD ["1_2"]
+       SUCCESS {}
+?}
+*: RESET
+{?
+    C: RUN "CYPHER NESTED 0" {} {}
+    S: SUCCESS {"fields": ["x"]}
+    {{
+        C: PULL {"n": 1}
+        S: RECORD ["2_1"]
+           SUCCESS {"has_more": true}
+        C: PULL {"n": -1}
+        S: RECORD ["2_2"]
+    ----
+        C: PULL {"n": -1}
+        S: RECORD ["2_1"]
+           RECORD ["2_2"]
+    }}
+    S: SUCCESS {}
+?}
+*: RESET
+{?
+    C: RUN "CYPHER NESTED 1" {} {}
+    S: SUCCESS {"fields": ["x"]}
+    {{
+        C: PULL {"n": 1}
+        S: RECORD ["3_1"]
+           SUCCESS {"has_more": true}
+        C: PULL {"n": -1}
+        S: RECORD ["3_2"]
+    ----
+        C: PULL {"n": -1}
+        S: RECORD ["3_1"]
+           RECORD ["3_2"]
+    }}
+    S: SUCCESS {}
+?}
+*: RESET
+?: GOODBYE

--- a/tests/stub/iteration/scripts/v4x4/pull_1_nested_list.script
+++ b/tests/stub/iteration/scripts/v4x4/pull_1_nested_list.script
@@ -9,9 +9,19 @@ A: HELLO {"{}": "*"}
     C: PULL {"n": 1}
     S: RECORD ["1_1"]
        SUCCESS {"has_more": true}
-    C: PULL {"n": 1}
-    S: RECORD ["1_2"]
-       SUCCESS {}
+    {{
+        C: PULL {"n": 1}
+        S: RECORD ["1_2"]
+           SUCCESS {"has_more": true}
+        C: PULL {"n": -1}
+        S: RECORD ["1_3"]
+           SUCCESS {}
+    ----
+        C: PULL {"n": -1}
+        S: RECORD ["1_2"]
+           RECORD ["1_3"]
+           SUCCESS {}
+    }}
 ?}
 *: RESET
 {?
@@ -44,6 +54,23 @@ A: HELLO {"{}": "*"}
         C: PULL {"n": -1}
         S: RECORD ["3_1"]
            RECORD ["3_2"]
+    }}
+    S: SUCCESS {}
+?}
+*: RESET
+{?
+    C: RUN "CYPHER NESTED 2" {} {}
+    S: SUCCESS {"fields": ["x"]}
+    {{
+        C: PULL {"n": 1}
+        S: RECORD ["4_1"]
+           SUCCESS {"has_more": true}
+        C: PULL {"n": -1}
+        S: RECORD ["4_2"]
+    ----
+        C: PULL {"n": -1}
+        S: RECORD ["4_1"]
+           RECORD ["4_2"]
     }}
     S: SUCCESS {}
 ?}

--- a/tests/stub/iteration/scripts/v4x4/pull_1_nested_list.script
+++ b/tests/stub/iteration/scripts/v4x4/pull_1_nested_list.script
@@ -13,7 +13,11 @@ A: HELLO {"{}": "*"}
         C: PULL {"n": 1}
         S: RECORD ["1_2"]
            SUCCESS {"has_more": true}
-        C: PULL {"n": -1}
+        {{
+            C: PULL {"n": -1}
+        ----
+            C: PULL {"n": 1}
+        }}
         S: RECORD ["1_3"]
            SUCCESS {}
     ----

--- a/tests/stub/iteration/scripts/v4x4/tx_pull_1_nested.script
+++ b/tests/stub/iteration/scripts/v4x4/tx_pull_1_nested.script
@@ -52,7 +52,12 @@ S: RECORD ["1_1"]
     S: RECORD ["3_1"]
        SUCCESS {}
     C: PULL {"n": 1, "qid": 1}
-    S: RECORD ["1_2"]
+    S: RECORD ["1_3"]
+       SUCCESS {}
+    C: RUN "CYPHER NESTED" {} {}
+    S: SUCCESS {"fields": ["x"], "qid": 4}
+    C: PULL {"n": 1, "[qid]": 4}
+    S: RECORD ["4_1"]
        SUCCESS {}
 }}
 C: COMMIT

--- a/tests/stub/iteration/scripts/v4x4/tx_pull_1_nested.script
+++ b/tests/stub/iteration/scripts/v4x4/tx_pull_1_nested.script
@@ -64,4 +64,3 @@ C: COMMIT
 S: SUCCESS {"bookmark": "bm"}
 *: RESET
 ?: GOODBYE
-

--- a/tests/stub/iteration/scripts/v4x4/tx_pull_1_nested.script
+++ b/tests/stub/iteration/scripts/v4x4/tx_pull_1_nested.script
@@ -10,7 +10,7 @@ C: PULL {"n": 1, "[qid]": 1}
 S: RECORD ["1_1"]
    SUCCESS {"has_more": true}
 {{
-    C: PULL {"n": 1, "qid": 1}
+    C: PULL {"n": 1, "[qid]": 1}
     S: RECORD ["1_2"]
        SUCCESS {}
     C: RUN "CYPHER NESTED" {} {}

--- a/tests/stub/iteration/scripts/v4x4/tx_pull_1_nested.script
+++ b/tests/stub/iteration/scripts/v4x4/tx_pull_1_nested.script
@@ -12,7 +12,7 @@ S: RECORD ["1_1"]
 {{
     C: PULL {"n": 1, "[qid]": 1}
     S: RECORD ["1_2"]
-       SUCCESS {}
+       SUCCESS {"has_more": true}
     C: RUN "CYPHER NESTED" {} {}
     S: SUCCESS {"fields": ["x"], "qid": 2}
     C: PULL {"n": 1, "[qid]": 2}
@@ -20,6 +20,20 @@ S: RECORD ["1_1"]
        SUCCESS {"has_more": true}
     C: PULL {"n": 1, "[qid]": 2}
     S: RECORD ["2_2"]
+       SUCCESS {}
+    C: PULL {"n": 1, "qid": 1}
+    S: RECORD ["1_3"]
+       SUCCESS {}
+    C: RUN "CYPHER NESTED" {} {}
+    S: SUCCESS {"fields": ["x"], "qid": 3}
+    C: PULL {"n": 1, "[qid]": 3}
+    S: RECORD ["3_1"]
+       SUCCESS {}
+    C: RUN "CYPHER NESTED" {} {}
+    S: SUCCESS {"fields": ["x"], "qid": 4}
+    C: PULL {"n": 1, "[qid]": 4}
+    S: RECORD ["4_1"]
+       SUCCESS {}
 ----
     C: RUN "CYPHER NESTED" {} {}
     S: SUCCESS {"fields": ["x"], "qid": 2}
@@ -31,14 +45,18 @@ S: RECORD ["1_1"]
        SUCCESS {}
     C: PULL {"n": 1, "qid": 1}
     S: RECORD ["1_2"]
+       SUCCESS {"has_more": true}
+    C: RUN "CYPHER NESTED" {} {}
+    S: SUCCESS {"fields": ["x"], "qid": 3}
+    C: PULL {"n": 1, "[qid]": 3}
+    S: RECORD ["3_1"]
+       SUCCESS {}
+    C: PULL {"n": 1, "qid": 1}
+    S: RECORD ["1_2"]
+       SUCCESS {}
 }}
-S: SUCCESS {}
-C: RUN "CYPHER NESTED" {} {}
-S: SUCCESS {"fields": ["x"], "qid": 3}
-C: PULL {"n": 1, "[qid]": 3}
-S: RECORD ["3_1"]
-   SUCCESS {}
 C: COMMIT
 S: SUCCESS {"bookmark": "bm"}
 *: RESET
 ?: GOODBYE
+

--- a/tests/stub/iteration/scripts/v4x4/tx_pull_1_nested_list.script
+++ b/tests/stub/iteration/scripts/v4x4/tx_pull_1_nested_list.script
@@ -12,7 +12,7 @@ S: RECORD ["1_1"]
 {{
     C: PULL {"n": 1, "[qid]": 1}
     S: RECORD ["1_2"]
-       SUCCESS {}
+       SUCCESS {"has_more": true}
     C: RUN "CYPHER NESTED" {} {}
     S: SUCCESS {"fields": ["x"], "qid": 2}
     {{
@@ -26,31 +26,86 @@ S: RECORD ["1_1"]
         S: RECORD ["2_1"]
            RECORD ["2_2"]
     }}
+    S: SUCCESS {}
+    C: PULL {"n": 1, "qid": 1}
+    S: RECORD ["1_3"]
+       SUCCESS {}
+    C: RUN "CYPHER NESTED" {} {}
+    S: SUCCESS {"fields": ["x"], "qid": 3}
+    {{
+        C: PULL {"n": 1, "[qid]": 3}
+        S: RECORD ["3_1"]
+           SUCCESS {"has_more": true}
+        C: PULL {"n": -1, "[qid]": 3}
+        S: RECORD ["3_2"]
+    ----
+        C: PULL {"n": -1, "[qid]": 3}
+        S: RECORD ["3_1"]
+           RECORD ["3_2"]
+    }}
+    C: RUN "CYPHER NESTED" {} {}
+    S: SUCCESS {"fields": ["x"], "qid": 4}
+    {{
+        C: PULL {"n": 1, "[qid]": 4}
+        S: RECORD ["3_1"]
+           SUCCESS {"has_more": true}
+        C: PULL {"n": -1, "[qid]": 4}
+        S: RECORD ["3_2"]
+    ----
+        C: PULL {"n": -1, "[qid]": 4}
+        S: RECORD ["3_1"]
+           RECORD ["3_2"]
+    }}
+    S: SUCCESS {}
 ----
     C: RUN "CYPHER NESTED" {} {}
     S: SUCCESS {"fields": ["x"], "qid": 2}
-    C: PULL {"n": -1, "[qid]": 2}
-    S: RECORD ["2_1"]
-       RECORD ["2_2"]
-       SUCCESS {}
+    {{
+        C: PULL {"n": 1, "[qid]": 2}
+        S: RECORD ["2_1"]
+           SUCCESS {"has_more": true}
+        C: PULL {"n": -1, "[qid]": 2}
+        S: RECORD ["2_2"]
+    ----
+        C: PULL {"n": -1, "[qid]": 2}
+        S: RECORD ["2_1"]
+           RECORD ["2_2"]
+    }}
+    S: SUCCESS {}
     C: PULL {"n": 1, "qid": 1}
     S: RECORD ["1_2"]
-}}
-S: SUCCESS {}
-C: RUN "CYPHER NESTED" {} {}
-S: SUCCESS {"fields": ["x"], "qid": 3}
-{{
-    C: PULL {"n": 1, "[qid]": 3}
-    S: RECORD ["3_1"]
        SUCCESS {"has_more": true}
-    C: PULL {"n": -1, "[qid]": 3}
-    S: RECORD ["3_2"]
-----
-    C: PULL {"n": -1, "[qid]": 3}
-    S: RECORD ["3_1"]
-       RECORD ["3_2"]
+    C: RUN "CYPHER NESTED" {} {}
+    S: SUCCESS {"fields": ["x"], "qid": 3}
+    {{
+        C: PULL {"n": 1, "[qid]": 3}
+        S: RECORD ["2_1"]
+           SUCCESS {"has_more": true}
+        C: PULL {"n": -1, "[qid]": 3}
+        S: RECORD ["2_2"]
+    ----
+        C: PULL {"n": -1, "[qid]": 3}
+        S: RECORD ["2_1"]
+           RECORD ["2_2"]
+    }}
+    C: PULL {"n": 1, "qid": 1}
+    S: RECORD ["1_3"]
+       SUCCESS {}
+    C: RUN "CYPHER NESTED" {} {}
+    S: SUCCESS {"fields": ["x"], "qid": 4}
+    {{
+        C: PULL {"n": 1, "[qid]": 4}
+        S: RECORD ["2_1"]
+           SUCCESS {"has_more": true}
+        C: PULL {"n": -1, "[qid]": 4}
+        S: RECORD ["2_2"]
+    ----
+        C: PULL {"n": -1, "[qid]": 4}
+        S: RECORD ["2_1"]
+           RECORD ["2_2"]
+    }}
+    S: SUCCESS {}
 }}
-S: SUCCESS {}
 C: COMMIT
 S: SUCCESS {"bookmark": "bm"}
 *: RESET

--- a/tests/stub/iteration/scripts/v4x4/tx_pull_1_nested_list.script
+++ b/tests/stub/iteration/scripts/v4x4/tx_pull_1_nested_list.script
@@ -10,7 +10,7 @@ C: PULL {"n": 1, "[qid]": 1}
 S: RECORD ["1_1"]
    SUCCESS {"has_more": true}
 {{
-    C: PULL {"n": 1, "qid": 1}
+    C: PULL {"n": 1, "[qid]": 1}
     S: RECORD ["1_2"]
        SUCCESS {}
     C: RUN "CYPHER NESTED" {} {}

--- a/tests/stub/iteration/scripts/v4x4/tx_pull_1_nested_list.script
+++ b/tests/stub/iteration/scripts/v4x4/tx_pull_1_nested_list.script
@@ -43,18 +43,19 @@ S: RECORD ["1_1"]
         S: RECORD ["3_1"]
            RECORD ["3_2"]
     }}
+    S: SUCCESS {}
     C: RUN "CYPHER NESTED" {} {}
     S: SUCCESS {"fields": ["x"], "qid": 4}
     {{
         C: PULL {"n": 1, "[qid]": 4}
-        S: RECORD ["3_1"]
+        S: RECORD ["4_1"]
            SUCCESS {"has_more": true}
         C: PULL {"n": -1, "[qid]": 4}
-        S: RECORD ["3_2"]
+        S: RECORD ["4_2"]
     ----
         C: PULL {"n": -1, "[qid]": 4}
-        S: RECORD ["3_1"]
-           RECORD ["3_2"]
+        S: RECORD ["4_1"]
+           RECORD ["4_2"]
     }}
     S: SUCCESS {}
 ----
@@ -79,15 +80,16 @@ S: RECORD ["1_1"]
     S: SUCCESS {"fields": ["x"], "qid": 3}
     {{
         C: PULL {"n": 1, "[qid]": 3}
-        S: RECORD ["2_1"]
+        S: RECORD ["3_1"]
            SUCCESS {"has_more": true}
         C: PULL {"n": -1, "[qid]": 3}
-        S: RECORD ["2_2"]
+        S: RECORD ["3_2"]
     ----
         C: PULL {"n": -1, "[qid]": 3}
-        S: RECORD ["2_1"]
-           RECORD ["2_2"]
+        S: RECORD ["3_1"]
+           RECORD ["3_2"]
     }}
+    S: SUCCESS {}
     C: PULL {"n": 1, "qid": 1}
     S: RECORD ["1_3"]
        SUCCESS {}
@@ -95,14 +97,14 @@ S: RECORD ["1_1"]
     S: SUCCESS {"fields": ["x"], "qid": 4}
     {{
         C: PULL {"n": 1, "[qid]": 4}
-        S: RECORD ["2_1"]
+        S: RECORD ["4_1"]
            SUCCESS {"has_more": true}
         C: PULL {"n": -1, "[qid]": 4}
-        S: RECORD ["2_2"]
+        S: RECORD ["4_2"]
     ----
         C: PULL {"n": -1, "[qid]": 4}
-        S: RECORD ["2_1"]
-           RECORD ["2_2"]
+        S: RECORD ["4_1"]
+           RECORD ["4_2"]
     }}
     S: SUCCESS {}
 }}

--- a/tests/stub/iteration/scripts/v4x4/tx_pull_1_nested_list.script
+++ b/tests/stub/iteration/scripts/v4x4/tx_pull_1_nested_list.script
@@ -15,19 +15,23 @@ S: RECORD ["1_1"]
        SUCCESS {}
     C: RUN "CYPHER NESTED" {} {}
     S: SUCCESS {"fields": ["x"], "qid": 2}
-    C: PULL {"n": 1, "[qid]": 2}
-    S: RECORD ["2_1"]
-       SUCCESS {"has_more": true}
-    C: PULL {"n": 1, "[qid]": 2}
-    S: RECORD ["2_2"]
+    {{
+        C: PULL {"n": 1, "[qid]": 2}
+        S: RECORD ["2_1"]
+           SUCCESS {"has_more": true}
+        C: PULL {"n": -1, "[qid]": 2}
+        S: RECORD ["2_2"]
+    ----
+        C: PULL {"n": -1, "[qid]": 2}
+        S: RECORD ["2_1"]
+           RECORD ["2_2"]
+    }}
 ----
     C: RUN "CYPHER NESTED" {} {}
     S: SUCCESS {"fields": ["x"], "qid": 2}
-    C: PULL {"n": 1, "[qid]": 2}
+    C: PULL {"n": -1, "[qid]": 2}
     S: RECORD ["2_1"]
-       SUCCESS {"has_more": true}
-    C: PULL {"n": 1, "[qid]": 2}
-    S: RECORD ["2_2"]
+       RECORD ["2_2"]
        SUCCESS {}
     C: PULL {"n": 1, "qid": 1}
     S: RECORD ["1_2"]
@@ -35,9 +39,18 @@ S: RECORD ["1_1"]
 S: SUCCESS {}
 C: RUN "CYPHER NESTED" {} {}
 S: SUCCESS {"fields": ["x"], "qid": 3}
-C: PULL {"n": 1, "[qid]": 3}
-S: RECORD ["3_1"]
-   SUCCESS {}
+{{
+    C: PULL {"n": 1, "[qid]": 3}
+    S: RECORD ["3_1"]
+       SUCCESS {"has_more": true}
+    C: PULL {"n": -1, "[qid]": 3}
+    S: RECORD ["3_2"]
+----
+    C: PULL {"n": -1, "[qid]": 3}
+    S: RECORD ["3_1"]
+       RECORD ["3_2"]
+}}
+S: SUCCESS {}
 C: COMMIT
 S: SUCCESS {"bookmark": "bm"}
 *: RESET

--- a/tests/stub/iteration/test_iteration_session_run.py
+++ b/tests/stub/iteration/test_iteration_session_run.py
@@ -165,9 +165,8 @@ class TestIterationSessionRun(TestkitTestCase):
             if isinstance(rec1, types.NullRecord):
                 break
             seq.append(rec1.values[0].value)
-            seq2 = []
-            for rec2 in session.run("CYPHER NESTED %d" % i).list():
-                seq2.append(rec2.values[0].value)
+            seq2 = [rec.values[0].value
+                    for rec in session.run("CYPHER NESTED %d" % i).list()]
             seqs.append(seq2)
             i += 1
 

--- a/tests/stub/iteration/test_iteration_session_run.py
+++ b/tests/stub/iteration/test_iteration_session_run.py
@@ -136,13 +136,8 @@ class TestIterationSessionRun(TestkitTestCase):
             if isinstance(rec1, types.NullRecord):
                 break
             seq.append(rec1.values[0].value)
-            seq2 = []
             res2 = session.run("CYPHER NESTED %d" % i)
-            while True:
-                rec2 = res2.next()
-                if isinstance(rec2, types.NullRecord):
-                    break
-                seq2.append(rec2.values[0].value)
+            seq2 = [rec.values[0].value for rec in res2]
             seqs.append(seq2)
             i += 1
 

--- a/tests/stub/iteration/test_iteration_session_run.py
+++ b/tests/stub/iteration/test_iteration_session_run.py
@@ -117,3 +117,66 @@ class TestIterationSessionRun(TestkitTestCase):
             for mode in ("write", "read"):
                 with self.subTest(version=version, mode=mode):
                     test(version, script)
+
+    @driver_feature(types.Feature.BOLT_4_4)
+    def test_nested(self):
+        uri = "bolt://%s" % self._server.address
+        driver = Driver(self._backend, uri,
+                        types.AuthorizationToken("basic", principal="",
+                                                 credentials=""))
+        self._server.start(path=self.script_path("v4x4",
+                                                 "pull_1_nested.script"))
+        session = driver.session("w", fetch_size=1)
+        res1 = session.run("CYPHER")
+        seq = []
+        seqs = []
+        i = 0
+        while True:
+            rec1 = res1.next()
+            if isinstance(rec1, types.NullRecord):
+                break
+            seq.append(rec1.values[0].value)
+            seq2 = []
+            res2 = session.run("CYPHER NESTED %d" % i)
+            while True:
+                rec2 = res2.next()
+                if isinstance(rec2, types.NullRecord):
+                    break
+                seq2.append(rec2.values[0].value)
+            seqs.append(seq2)
+            i += 1
+
+        driver.close()
+        self._server.done()
+        self.assertEqual(["1_1", "1_2"], seq)
+        self.assertEqual([["2_1", "2_2"], ["3_1"]], seqs)
+
+    @driver_feature(types.Feature.BOLT_4_4, types.Feature.API_RESULT_LIST,
+                    types.Feature.OPT_RESULT_LIST_FETCH_ALL)
+    def test_nested_using_list(self):
+        uri = "bolt://%s" % self._server.address
+        driver = Driver(self._backend, uri,
+                        types.AuthorizationToken("basic", principal="",
+                                                 credentials=""))
+        self._server.start(path=self.script_path(
+            "v4x4", "pull_1_nested_list.script"))
+        session = driver.session("w", fetch_size=1)
+        res1 = session.run("CYPHER")
+        seq = []
+        seqs = []
+        i = 0
+        while True:
+            rec1 = res1.next()
+            if isinstance(rec1, types.NullRecord):
+                break
+            seq.append(rec1.values[0].value)
+            seq2 = []
+            for rec2 in session.run("CYPHER NESTED %d" % i).list():
+                seq2.append(rec2.values[0].value)
+            seqs.append(seq2)
+            i += 1
+
+        driver.close()
+        self._server.done()
+        self.assertEqual(["1_1", "1_2"], seq)
+        self.assertEqual([["2_1", "2_2"], ["3_1", "3_2"]], seqs)

--- a/tests/stub/iteration/test_iteration_session_run.py
+++ b/tests/stub/iteration/test_iteration_session_run.py
@@ -143,8 +143,8 @@ class TestIterationSessionRun(TestkitTestCase):
 
         driver.close()
         self._server.done()
-        self.assertEqual(["1_1", "1_2"], seq)
-        self.assertEqual([["2_1", "2_2"], ["3_1"]], seqs)
+        self.assertEqual(["1_1", "1_2", "1_3"], seq)
+        self.assertEqual([["2_1", "2_2"], ["3_1"], ["4_1"]], seqs)
 
     @driver_feature(types.Feature.BOLT_4_4, types.Feature.API_RESULT_LIST,
                     types.Feature.OPT_RESULT_LIST_FETCH_ALL)
@@ -172,5 +172,6 @@ class TestIterationSessionRun(TestkitTestCase):
 
         driver.close()
         self._server.done()
-        self.assertEqual(["1_1", "1_2"], seq)
-        self.assertEqual([["2_1", "2_2"], ["3_1", "3_2"]], seqs)
+        self.assertEqual(["1_1", "1_2", "1_3"], seq)
+        self.assertEqual([["2_1", "2_2"], ["3_1", "3_2"], ["4_1", "4_2"]],
+                         seqs)

--- a/tests/stub/iteration/test_iteration_tx_run.py
+++ b/tests/stub/iteration/test_iteration_tx_run.py
@@ -126,5 +126,6 @@ class TestIterationTxRun(TestkitTestCase):
         tx.commit()
         driver.close()
         self._server.done()
-        self.assertEqual(["1_1", "1_2"], seq)
-        self.assertEqual([["2_1", "2_2"], ["3_1", "3_2"]], seqs)
+        self.assertEqual(["1_1", "1_2", "1_3"], seq)
+        self.assertEqual(
+            [["2_1", "2_2"], ["3_1", "3_2"], ["4_1", "4_2"]], seqs)

--- a/tests/stub/iteration/test_iteration_tx_run.py
+++ b/tests/stub/iteration/test_iteration_tx_run.py
@@ -97,8 +97,8 @@ class TestIterationTxRun(TestkitTestCase):
         tx.commit()
         driver.close()
         self._server.done()
-        self.assertEqual(["1_1", "1_2"], seq)
-        self.assertEqual([["2_1", "2_2"], ["3_1"]], seqs)
+        self.assertEqual(["1_1", "1_2", "1_3"], seq)
+        self.assertEqual([["2_1", "2_2"], ["3_1"], ["4_1"]], seqs)
 
     @driver_feature(types.Feature.BOLT_4_4, types.Feature.API_RESULT_LIST,
                     types.Feature.OPT_RESULT_LIST_FETCH_ALL)

--- a/tests/stub/iteration/test_iteration_tx_run.py
+++ b/tests/stub/iteration/test_iteration_tx_run.py
@@ -119,9 +119,8 @@ class TestIterationTxRun(TestkitTestCase):
             if isinstance(rec1, types.NullRecord):
                 break
             seq.append(rec1.values[0].value)
-            seq2 = []
-            for rec2 in tx.run("CYPHER NESTED").list():
-                seq2.append(rec2.values[0].value)
+            res2 = session.run("CYPHER NESTED")
+            seq2 = [rec.values[0].value for rec in res2]
             seqs.append(seq2)
 
         tx.commit()

--- a/tests/stub/iteration/test_iteration_tx_run.py
+++ b/tests/stub/iteration/test_iteration_tx_run.py
@@ -2,7 +2,6 @@ from nutkit.frontend import Driver
 import nutkit.protocol as types
 from tests.shared import (
     driver_feature,
-    get_driver_name,
     TestkitTestCase,
 )
 from tests.stub.shared import StubServer
@@ -70,12 +69,6 @@ class TestIterationTxRun(TestkitTestCase):
 
     @driver_feature(types.Feature.BOLT_4_4)
     def test_nested(self):
-        # ex JAVA - java completely pulls the first query before running the
-        # second
-        if get_driver_name() in ["java"]:
-            self.skipTest(
-                "completely pulls the first query before running the second"
-            )
         uri = "bolt://%s" % self._server.address
         driver = Driver(self._backend, uri,
                         types.AuthorizationToken("basic", principal="",
@@ -93,7 +86,7 @@ class TestIterationTxRun(TestkitTestCase):
                 break
             seq.append(rec1.values[0].value)
             seq2 = []
-            res2 = tx.run("CYPHER")
+            res2 = tx.run("CYPHER NESTED")
             while True:
                 rec2 = res2.next()
                 if isinstance(rec2, types.NullRecord):
@@ -106,3 +99,33 @@ class TestIterationTxRun(TestkitTestCase):
         self._server.done()
         self.assertEqual(["1_1", "1_2"], seq)
         self.assertEqual([["2_1", "2_2"], ["3_1"]], seqs)
+
+    @driver_feature(types.Feature.BOLT_4_4, types.Feature.API_RESULT_LIST,
+                    types.Feature.OPT_RESULT_LIST_FETCH_ALL)
+    def test_nested_using_list(self):
+        uri = "bolt://%s" % self._server.address
+        driver = Driver(self._backend, uri,
+                        types.AuthorizationToken("basic", principal="",
+                                                 credentials=""))
+        self._server.start(path=self.script_path(
+            "v4x4", "tx_pull_1_nested_list.script"))
+        session = driver.session("w", fetch_size=1)
+        tx = session.begin_transaction()
+        res1 = tx.run("CYPHER")
+        seq = []
+        seqs = []
+        while True:
+            rec1 = res1.next()
+            if isinstance(rec1, types.NullRecord):
+                break
+            seq.append(rec1.values[0].value)
+            seq2 = []
+            for rec2 in tx.run("CYPHER NESTED").list():
+                seq2.append(rec2.values[0].value)
+            seqs.append(seq2)
+
+        tx.commit()
+        driver.close()
+        self._server.done()
+        self.assertEqual(["1_1", "1_2"], seq)
+        self.assertEqual([["2_1", "2_2"], ["3_1", "3_2"]], seqs)

--- a/tests/stub/iteration/test_iteration_tx_run.py
+++ b/tests/stub/iteration/test_iteration_tx_run.py
@@ -119,8 +119,8 @@ class TestIterationTxRun(TestkitTestCase):
             if isinstance(rec1, types.NullRecord):
                 break
             seq.append(rec1.values[0].value)
-            res2 = session.run("CYPHER NESTED")
-            seq2 = [rec.values[0].value for rec in res2]
+            seq2 = [rec.values[0].value for rec
+                    in tx.run("CYPHER NESTED").list()]
             seqs.append(seq2)
 
         tx.commit()


### PR DESCRIPTION
Migrated tests:
- `NestedQueriesIT.shouldAllowNestedQueriesInTransactionConsumedAsIterators` -> `TestIterationTxRun.test_nested`
- `NestedQueriesIT.shouldAllowNestedQueriesInTransactionConsumedAsIteratorAndList` -> `TestIterationTxRun.test_nested_using_list`
- `NestedQueriesIT.shouldAllowNestedQueriesInSessionConsumedAsIterators` -> `TestIterationSessionRun.test_nested`
- `NestedQueriesIT.shouldAllowNestedQueriesInSessionConsumedAsIteratorAndList` -> `TestIterationSessionRun.test_nested_using_list`