### PR TITLE
Add error checks for 4.4/5.0 changing code

### DIFF
--- a/nutkit/protocol/feature.py
+++ b/nutkit/protocol/feature.py
@@ -129,7 +129,7 @@ class Feature(Enum):
     DETAIL_DEFAULT_SECURITY_CONFIG_VALUE_EQUALITY = \
         "Detail:DefaultSecurityConfigValueEquality"
     # The driver will map previously named Transient Error codes to Client
-    # when using 5.0 protocol for errors:
+    # when using a protocol < 5.0 for errors:
     # - Neo.TransientError.Transaction.Terminated
     # - Neo.TransientError.Transaction.LockClientStopped
     DETAIL_MAPS_ERROR_CODE = "Detail:MapsErrorCode"

--- a/nutkit/protocol/feature.py
+++ b/nutkit/protocol/feature.py
@@ -128,6 +128,11 @@ class Feature(Enum):
     # configuration as long as values match.
     DETAIL_DEFAULT_SECURITY_CONFIG_VALUE_EQUALITY = \
         "Detail:DefaultSecurityConfigValueEquality"
+    # The driver will map previously named Transient Error codes to Client
+    # when using 5.0 protocol for errors:
+    # - Neo.TransientError.Transaction.Terminated
+    # - Neo.TransientError.Transaction.LockClientStopped
+    DETAIL_MAPS_ERROR_CODE = "Detail:MapsErrorCode"
     # The driver sets the id of nodes and relationships to Null if the server
     # doesn't provide them. If the driver does not report this feature flag,
     # TestKit will assert the value to be -1 instead.

--- a/tests/neo4j/test_session_run.py
+++ b/tests/neo4j/test_session_run.py
@@ -1,4 +1,5 @@
 import nutkit.protocol as types
+from nutkit.protocol import Feature
 from tests.neo4j.shared import (
     cluster_unsafe_test,
     get_driver,
@@ -155,8 +156,12 @@ class TestSessionRun(TestkitTestCase):
         if get_driver_name() in ["go"]:
             # requires explicit termination of transactions
             tx1.rollback()
-        self.assertEqual(e.exception.code,
-                         "Neo.TransientError.Transaction.LockClientStopped")
+
+        expected_code = "Neo.TransientError.Transaction.LockClientStopped"
+        if self.driver_supports_features(Feature.DETAIL_MAPS_ERROR_CODE):
+            expected_code = "Neo.ClientError.Transaction.LockClientStopped"
+        self.assertEqual(e.exception.code, expected_code)
+
         if get_driver_name() in ["python"]:
             self.assertEqual(e.exception.errorType,
                              "<class 'neo4j.exceptions.TransientError'>")

--- a/tests/stub/errors/scripts/test_error.script
+++ b/tests/stub/errors/scripts/test_error.script
@@ -1,4 +1,4 @@
-!: BOLT 4.4
+!: BOLT #BOLT_PROTOCOL#
 
 A: HELLO {"{}": "*"}
 *: RESET

--- a/tests/stub/errors/scripts/test_error.script
+++ b/tests/stub/errors/scripts/test_error.script
@@ -1,0 +1,13 @@
+!: BOLT 4.4
+
+A: HELLO {"{}": "*"}
+*: RESET
+C: RUN { "U": "*"} {"{}": "*"} {"{}": "*"}
+S: FAILURE {"code": "#ERROR_CODE#", "message": "Something went wrong"}
+{?
+    # For drivers that pipeline a PULL after RUN
+    C: PULL {"n": {"Z": "*"}}
+    S: IGNORED
+?}
++: RESET
+?: GOODBYE

--- a/tests/stub/errors/test_errors.py
+++ b/tests/stub/errors/test_errors.py
@@ -20,9 +20,10 @@ class TestErrors(TestkitTestCase):
         self._server.reset()
         super().tearDown()
 
-    def _test(self, script, throw_code, expected_code):
+    def _test(self, script, protocol, throw_code, expected_code):
         params = {
-            "#ERROR_CODE#": throw_code
+            "#ERROR_CODE#": throw_code,
+            "#BOLT_PROTOCOL#": protocol
         }
         uri = "bolt://%s" % self._server.address
         driver = Driver(self._backend, uri,
@@ -46,24 +47,24 @@ class TestErrors(TestkitTestCase):
 
     @driver_feature(types.Feature.BOLT_4_4)
     def test_terminated_4x4_throws_as_client_error(self):
-        self._test("test_error.script",
+        self._test("test_error.script", "4.4",
                    "Neo.TransientError.Transaction.Terminated",
                    "Neo.ClientError.Transaction.Terminated")
 
     @driver_feature(types.Feature.BOLT_5_0)
     def test_terminated_5x0_throws_as_client_error(self):
-        self._test("test_error.script",
+        self._test("test_error.script", "5.0",
                    "Neo.ClientError.Transaction.Terminated",
                    "Neo.ClientError.Transaction.Terminated")
 
     @driver_feature(types.Feature.BOLT_4_4)
     def test_lock_client_stopped_4x4_throws_as_client_error(self):
-        self._test("test_error.script",
+        self._test("test_error.script", "4.4",
                    "Neo.TransientError.Transaction.LockClientStopped",
                    "Neo.ClientError.Transaction.LockClientStopped")
 
     @driver_feature(types.Feature.BOLT_5_0)
     def test_lock_client_stopped_5x0_throws_as_client_error(self):
-        self._test("test_error.script",
+        self._test("test_error.script", "5.0",
                    "Neo.ClientError.Transaction.LockClientStopped",
                    "Neo.ClientError.Transaction.LockClientStopped")

--- a/tests/stub/errors/test_errors.py
+++ b/tests/stub/errors/test_errors.py
@@ -1,0 +1,66 @@
+from nutkit import protocol as types
+from nutkit.frontend import Driver
+from tests.shared import (
+    driver_feature,
+    TestkitTestCase,
+)
+from tests.stub.shared import StubServer
+
+
+class TestErrors(TestkitTestCase):
+    def setUp(self):
+        super().setUp()
+        self._server = StubServer(9001)
+        self._session = None
+
+    def tearDown(self):
+        self._server.reset()
+        super().tearDown()
+
+    def _test(self, script, throw_code, expected_code):
+        params = {
+            "#ERROR_CODE#": throw_code
+        }
+        uri = "bolt://%s" % self._server.address
+        driver = Driver(self._backend, uri,
+                        types.AuthorizationToken("basic", principal="",
+                                                 credentials=""))
+        self._server.start(path=self.script_path(script),
+                           vars_=params)
+        session = driver.session("r", fetch_size=1)
+
+        with self.assertRaises(types.DriverError) as err:
+            result_handle = session.run("MATCH (n) RETURN n LIMIT 1")
+            result_handle.next()
+
+        self.assertEqual(expected_code,
+                         err.exception.code)
+
+        session.close()
+        driver.close()
+        self._server.done()
+        self._server.reset()
+
+    @driver_feature(types.Feature.BOLT_4_4)
+    def test_terminated_4x4_throws_as_client_error(self):
+        self._test("test_error.script",
+                   "Neo.TransientError.Transaction.Terminated",
+                   "Neo.ClientError.Transaction.Terminated")
+
+    @driver_feature(types.Feature.BOLT_5_0)
+    def test_terminated_5x0_throws_as_client_error(self):
+        self._test("test_error.script",
+                   "Neo.ClientError.Transaction.Terminated",
+                   "Neo.ClientError.Transaction.Terminated")
+
+    @driver_feature(types.Feature.BOLT_4_4)
+    def test_lock_client_stopped_4x4_throws_as_client_error(self):
+        self._test("test_error.script",
+                   "Neo.TransientError.Transaction.LockClientStopped",
+                   "Neo.ClientError.Transaction.LockClientStopped")
+
+    @driver_feature(types.Feature.BOLT_5_0)
+    def test_lock_client_stopped_5x0_throws_as_client_error(self):
+        self._test("test_error.script",
+                   "Neo.ClientError.Transaction.LockClientStopped",
+                   "Neo.ClientError.Transaction.LockClientStopped")

--- a/tests/stub/errors/test_errors.py
+++ b/tests/stub/errors/test_errors.py
@@ -1,5 +1,6 @@
 from nutkit import protocol as types
 from nutkit.frontend import Driver
+from nutkit.protocol import Feature
 from tests.shared import (
     driver_feature,
     TestkitTestCase,
@@ -8,6 +9,8 @@ from tests.stub.shared import StubServer
 
 
 class TestErrors(TestkitTestCase):
+    required_features = Feature.DETAIL_MAPS_ERROR_CODE,
+
     def setUp(self):
         super().setUp()
         self._server = StubServer(9001)


### PR DESCRIPTION
Implement error code mapping for error codes that changed.
- what tests could we add?
- could we include if an error is retriable.