### PR TITLE
Verify mapped transient failures are not retried

### DIFF
--- a/tests/neo4j/test_session_run.py
+++ b/tests/neo4j/test_session_run.py
@@ -156,10 +156,10 @@ class TestSessionRun(TestkitTestCase):
             # requires explicit termination of transactions
             tx1.rollback()
         self.assertEqual(e.exception.code,
-                         "Neo.TransientError.Transaction.LockClientStopped")
+                         "Neo.ClientError.Transaction.LockClientStopped")
         if get_driver_name() in ["python"]:
             self.assertEqual(e.exception.errorType,
-                             "<class 'neo4j.exceptions.TransientError'>")
+                             "<class 'neo4j.exceptions.ClientError'>")
 
     @cluster_unsafe_test
     def test_regex_in_parameter(self):

--- a/tests/neo4j/test_session_run.py
+++ b/tests/neo4j/test_session_run.py
@@ -155,11 +155,20 @@ class TestSessionRun(TestkitTestCase):
         if get_driver_name() in ["go"]:
             # requires explicit termination of transactions
             tx1.rollback()
-        self.assertEqual(e.exception.code,
-                         "Neo.ClientError.Transaction.LockClientStopped")
-        if get_driver_name() in ["python"]:
-            self.assertEqual(e.exception.errorType,
-                             "<class 'neo4j.exceptions.ClientError'>")
+        # TODO REMOVE THIS BLOCK ONCE ALL IMPLEMENT RETRYABLE EXCEPTIONS
+        if get_driver_name() in ["javascript", "go", "ruby", "python"]:
+            self.assertEqual(
+                e.exception.code,
+                "Neo.TransientError.Transaction.LockClientStopped")
+            if get_driver_name() in ["python"]:
+                self.assertEqual(e.exception.errorType,
+                                 "<class 'neo4j.exceptions.TransientError'>")
+        else:
+            self.assertEqual(e.exception.code,
+                             "Neo.ClientError.Transaction.LockClientStopped")
+            if get_driver_name() in ["python"]:
+                self.assertEqual(e.exception.errorType,
+                                 "<class 'neo4j.exceptions.ClientError'>")
 
     @cluster_unsafe_test
     def test_regex_in_parameter(self):

--- a/tests/neo4j/test_tx_run.py
+++ b/tests/neo4j/test_tx_run.py
@@ -321,10 +321,10 @@ class TestTxRun(TestkitTestCase):
             result = tx2.run("MATCH (a:Node) SET a.property = 2")
             result.consume()
         self.assertEqual(e.exception.code,
-                         "Neo.TransientError.Transaction.LockClientStopped")
+                         "Neo.ClientError.Transaction.LockClientStopped")
         if get_driver_name() in ["python"]:
             self.assertEqual(e.exception.errorType,
-                             "<class 'neo4j.exceptions.TransientError'>")
+                             "<class 'neo4j.exceptions.ClientError'>")
 
     @cluster_unsafe_test
     def test_consume_after_commit(self):

--- a/tests/neo4j/test_tx_run.py
+++ b/tests/neo4j/test_tx_run.py
@@ -320,11 +320,20 @@ class TestTxRun(TestkitTestCase):
         with self.assertRaises(types.DriverError) as e:
             result = tx2.run("MATCH (a:Node) SET a.property = 2")
             result.consume()
-        self.assertEqual(e.exception.code,
-                         "Neo.ClientError.Transaction.LockClientStopped")
-        if get_driver_name() in ["python"]:
-            self.assertEqual(e.exception.errorType,
-                             "<class 'neo4j.exceptions.ClientError'>")
+        # TODO REMOVE THIS BLOCK ONCE ALL IMPLEMENT RETRYABLE EXCEPTIONS
+        if get_driver_name() in ["javascript", "go", "ruby", "python"]:
+            self.assertEqual(
+                e.exception.code,
+                "Neo.TransientError.Transaction.LockClientStopped")
+            if get_driver_name() in ["python"]:
+                self.assertEqual(e.exception.errorType,
+                                 "<class 'neo4j.exceptions.TransientError'>")
+        else:
+            self.assertEqual(e.exception.code,
+                             "Neo.ClientError.Transaction.LockClientStopped")
+            if get_driver_name() in ["python"]:
+                self.assertEqual(e.exception.errorType,
+                                 "<class 'neo4j.exceptions.ClientError'>")
 
     @cluster_unsafe_test
     def test_consume_after_commit(self):

--- a/tests/stub/retry/scripts/tx_pull_yielding_failure.script
+++ b/tests/stub/retry/scripts/tx_pull_yielding_failure.script
@@ -6,7 +6,6 @@ S: SUCCESS {}
 C: RUN "RETURN 1 as n" {} {}
 S: SUCCESS {"fields": ["n"]}
 C: PULL {"n": 1000}
-S: RECORD [1]
-   FAILURE #FAILURE#
+S: FAILURE #FAILURE#
 *: RESET
 ?: GOODBYE

--- a/tests/stub/retry/scripts/tx_pull_yielding_failure.script
+++ b/tests/stub/retry/scripts/tx_pull_yielding_failure.script
@@ -1,0 +1,12 @@
+!: BOLT 4.3
+
+A: HELLO {"{}": "*"}
+C: BEGIN {}
+S: SUCCESS {}
+C: RUN "RETURN 1 as n" {} {}
+S: SUCCESS {"fields": ["n"]}
+C: PULL {"n": 1000}
+S: RECORD [1]
+   FAILURE #FAILURE#
+*: RESET
+?: GOODBYE

--- a/tests/stub/retry/test_retry_clustering.py
+++ b/tests/stub/retry/test_retry_clustering.py
@@ -186,7 +186,7 @@ class TestRetryClustering(TestkitTestCase):
         self._routingServer.done()
         self._readServer.done()
 
-    def test_should_not_retry_on_mapped_transient_failures(self):
+    def test_should_not_retry_non_retryable_tx_failures(self):
         def _test():
             self._routingServer.start(
                 path=self.script_path("clustering",
@@ -197,7 +197,7 @@ class TestRetryClustering(TestkitTestCase):
                 path=self.script_path("tx_pull_yielding_failure.script"),
                 vars_={
                     "#FAILURE#": '{"code": "%s", "message": "message"}'
-                                 % error[0]
+                                 % failure[0]
                 }
             )
             num_retries = 0
@@ -215,19 +215,33 @@ class TestRetryClustering(TestkitTestCase):
             with self.assertRaises(types.DriverError) as exc:
                 session.write_transaction(once)
 
-            self.assertEqual(exc.exception.code, error[1])
+            self.assertEqual(exc.exception.code, failure[1])
 
             self.assertEqual(num_retries, 1)
             session.close()
             driver.close()
             self._routingServer.done()
-            self._writeServer.done()
+            self._writeServer.done()  #
 
-        for error in (["Neo.TransientError.Transaction.Terminated",
-                       "Neo.ClientError.Transaction.Terminated"],
-                      ["Neo.TransientError.Transaction.LockClientStopped",
-                       "Neo.ClientError.Transaction.LockClientStopped"]):
-            with self.subTest(error=error):
+        failures = []
+        # TODO REMOVE THIS BLOCK ONCE ALL IMPLEMENT RETRYABLE EXCEPTIONS
+        if get_driver_name() in ["javascript", "go", "ruby", "python"]:
+            failures.append(
+                ["Neo.TransientError.Transaction.Terminated",
+                 "Neo.TransientError.Transaction.Terminated"])
+            failures.append(
+                ["Neo.TransientError.Transaction.Terminated",
+                 "Neo.TransientError.Transaction.Terminated"])
+        else:
+            failures.append(
+                ["Neo.TransientError.Transaction.Terminated",
+                 "Neo.ClientError.Transaction.Terminated"])
+            failures.append(
+                ["Neo.TransientError.Transaction.LockClientStopped",
+                 "Neo.ClientError.Transaction.LockClientStopped"])
+
+        for failure in (failures):
+            with self.subTest(failure=failure):
                 _test()
             self._routingServer.reset()
             self._writeServer.reset()


### PR DESCRIPTION
In 5.0 the following failures have been mapped to different category:
- `Neo.TransientError.Transaction.Terminated` -> `Neo.ClientError.Transaction.Terminated`
- `Neo.TransientError.Transaction.LockClientStopped` -> `Neo.ClientError.Transaction.LockClientStopped`

The added tests verify that in event of receiving previous errors (may happen when connecting to pre 5.0 server) the error code gets mapped to the new category and no retries happen.