### PR TITLE
Fix integration tests to also work with the latest 5.0 drop

### DIFF
--- a/tests/neo4j/test_tx_func_run.py
+++ b/tests/neo4j/test_tx_func_run.py
@@ -220,8 +220,12 @@ class TestTxFuncRun(TestkitTestCase):
             with self.assertRaises(types.DriverError) as e:
                 tx.run("MATCH (a:Node) SET a.property = 2").consume()
             exc = e.exception
-            if (exc.code
-                    != "Neo.TransientError.Transaction.LockClientStopped"):
+            if (exc.code not in (
+                    # Neo4j 4.4-
+                    "Neo.ClientError.Transaction.LockClientStopped",
+                    # Neo4j 5.0+
+                    "Neo.TransientError.Transaction.LockClientStopped"
+            )):
                 # This is not the error we are looking for. Maybe there was  a
                 # leader election or so. Give the driver the chance to retry.
                 raise exc


### PR DESCRIPTION
There's lots to discuss about this, I'm afraid.

First the reason why we do this: the Aura drops run integration tests with out drivers. Since 5.0 drops are in the making, but the 5.0 drivers are not yet ready and users that connect to those drops might still be running on an older driver, those ITs run against 4.4 drivers.

Technically, we don't support older drivers connecting to newer servers. But no connection option for the new drops isn't viable either. So here goes: making TestKit 4.4 more compatible with the current dev state of the 5.0 server.