### PR TITLE
Remove Python and Ruby from special LockClientStopped handling

### DIFF
--- a/tests/neo4j/test_session_run.py
+++ b/tests/neo4j/test_session_run.py
@@ -158,8 +158,7 @@ class TestSessionRun(TestkitTestCase):
             tx1.rollback()
         # TODO REMOVE THIS BLOCK ONCE ALL IMPLEMENT RETRYABLE EXCEPTIONS
         is_server_affected_with_bug = get_server_info().version <= "4.4"
-        if is_server_affected_with_bug and get_driver_name() in [
-                "ruby", "python", "javascript"]:
+        if is_server_affected_with_bug and get_driver_name() in ["javascript"]:
             self.assertEqual(
                 e.exception.code,
                 "Neo.TransientError.Transaction.LockClientStopped")

--- a/tests/neo4j/test_tx_func_run.py
+++ b/tests/neo4j/test_tx_func_run.py
@@ -204,8 +204,7 @@ class TestTxFuncRun(TestkitTestCase):
             exc = e.exception
             # TODO REMOVE THIS BLOCK ONCE ALL IMPLEMENT RETRYABLE EXCEPTIONS
             server_is_affect_by_bug = get_server_info().version <= "4.4"
-            driver_has_fixed_bug = not get_driver_name() in [
-                "javascript", "ruby", "python"]
+            driver_has_fixed_bug = get_driver_name() not in ["javascript"]
             if (server_is_affect_by_bug
                 and not driver_has_fixed_bug
                 and exc.code
@@ -233,8 +232,7 @@ class TestTxFuncRun(TestkitTestCase):
         self.assertIsInstance(exc, types.DriverError)
         # TODO REMOVE THIS BLOCK ONCE ALL IMPLEMENT RETRYABLE EXCEPTIONS
         server_is_affect_by_bug = get_server_info().version <= "4.4"
-        if server_is_affect_by_bug and get_driver_name() in [
-                "javascript", "ruby", "python"]:
+        if server_is_affect_by_bug and get_driver_name() in ["javascript"]:
             self.assertEqual(
                 exc.code,
                 "Neo.TransientError.Transaction.LockClientStopped")

--- a/tests/neo4j/test_tx_run.py
+++ b/tests/neo4j/test_tx_run.py
@@ -322,8 +322,7 @@ class TestTxRun(TestkitTestCase):
             result.consume()
         # TODO REMOVE THIS BLOCK ONCE ALL IMPLEMENT RETRYABLE EXCEPTIONS
         is_server_affected_with_bug = get_server_info().version <= "4.4"
-        if is_server_affected_with_bug and get_driver_name() in [
-                "javascript", "ruby", "python"]:
+        if is_server_affected_with_bug and get_driver_name() in ["javascript"]:
             self.assertEqual(
                 e.exception.code,
                 "Neo.TransientError.Transaction.LockClientStopped")


### PR DESCRIPTION
 * Python has a fix prepared:
   https://github.com/neo4j/neo4j-python-driver/pull/742
 * Ruby is not part of our pipelines and hence needs no exception just to get
   our TestKit pipelines green. The maintainers should, however, notice through
   failing tests that there is work required, once they upgrade to 5.0