### PR TITLE
Reintroduce 5.0 integration tests.

### DIFF
--- a/tests/neo4j/suites.py
+++ b/tests/neo4j/suites.py
@@ -50,6 +50,11 @@ suite_4x3 = suite_4x2
 #######################
 suite_4x4 = suite_4x3
 
+#######################
+# Suite for Neo4j 5.0 #
+#######################
+suite_5x0 = suite_4x4
+
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
@@ -69,6 +74,8 @@ if __name__ == "__main__":
         suite = suite_4x3
     elif name == "4.4":
         suite = suite_4x4
+    elif name == "5.0":
+        suite = suite_5x0
 
     if not suite:
         print("Unknown suite name: " + name)


### PR DESCRIPTION
Partially reverts https://github.com/neo4j-drivers/testkit/pull/489
where it got removed by accident.