### PR TITLE
Update stub script to accommodate the UTC patch negotiation

### DIFF
--- a/tests/stub/disconnects/scripts/exit_after_hello.script
+++ b/tests/stub/disconnects/scripts/exit_after_hello.script
@@ -1,4 +1,4 @@
 !: BOLT 4.3
 
-C: HELLO {"user_agent": "Modesty", "scheme": "basic", "principal": "neo4j", "credentials": "pass" #EXTRA_HELLO_PARAMS# }
+C: HELLO {"user_agent": "Modesty", "scheme": "basic", "principal": "neo4j", "credentials": "pass", "[patch_bolt]": "*" #EXTRA_HELLO_PARAMS# }
 S: <EXIT>

--- a/tests/stub/retry/scripts/clustering/router.script
+++ b/tests/stub/retry/scripts/clustering/router.script
@@ -3,7 +3,7 @@
 !: AUTO GOODBYE
 !: ALLOW RESTART
 
-C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "[patch_bolt]": "*" "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "[patch_bolt]": "*", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
 {+
     C: ROUTE #ROUTINGCTX# [] null

--- a/tests/stub/retry/scripts/clustering/router.script
+++ b/tests/stub/retry/scripts/clustering/router.script
@@ -3,7 +3,7 @@
 !: AUTO GOODBYE
 !: ALLOW RESTART
 
-C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "[patch_bolt]": "*" "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
 {+
     C: ROUTE #ROUTINGCTX# [] null

--- a/tests/stub/retry/scripts/clustering/router_no_retry.script
+++ b/tests/stub/retry/scripts/clustering/router_no_retry.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO GOODBYE
 
-C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX#, "[patch_bolt]": "*" #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
 C: ROUTE #ROUTINGCTX# [] null
 S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9002"], "role":"READ"}, {"addresses": ["#HOST#:9003"], "role":"WRITE"}]}}

--- a/tests/stub/retry/scripts/clustering/router_swap_reader_and_writer.script
+++ b/tests/stub/retry/scripts/clustering/router_swap_reader_and_writer.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO GOODBYE
 
-C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #HELLO_ROUTINGCTX#, "[patch_bolt]": "*" #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "Neo4j/4.0.0", "connection_id": "bolt-123456789"}
 C: ROUTE #ROUTINGCTX# [] null
 S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9001"], "role":"ROUTE"}, {"addresses": ["#HOST#:9002"], "role":"READ"}, {"addresses": ["#HOST#:9003"], "role":"WRITE"}]}}

--- a/tests/stub/routing/scripts/v4x3/reader_with_explicit_hello.script
+++ b/tests/stub/routing/scripts/v4x3/reader_with_explicit_hello.script
@@ -2,7 +2,7 @@
 !: AUTO GOODBYE
 !: AUTO RESET
 
-C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#, "[patch_bolt]": "*" #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 C: RUN "RETURN 1 as n" {} {"mode": "r", "db": "adb"}
 S: SUCCESS {"fields": ["n"]}

--- a/tests/stub/routing/scripts/v4x3/router_adb.script
+++ b/tests/stub/routing/scripts/v4x3/router_adb.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO GOODBYE
 
-C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#, "[patch_bolt]": "*" #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 C: ROUTE #ROUTINGCTX# "*" "adb"
 S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9021"], "role":"WRITE"}]}}

--- a/tests/stub/routing/scripts/v4x3/router_adb_multi_no_bookmarks.script
+++ b/tests/stub/routing/scripts/v4x3/router_adb_multi_no_bookmarks.script
@@ -3,7 +3,7 @@
 !: AUTO GOODBYE
 !: ALLOW RESTART
 
-C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#, "[patch_bolt]": "*" #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 {+
     C: ROUTE #ROUTINGCTX# [] "adb"

--- a/tests/stub/routing/scripts/v4x3/router_and_reader.script
+++ b/tests/stub/routing/scripts/v4x3/router_and_reader.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: ALLOW RESTART
 
-C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#, "[patch_bolt]": "*" #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 {?
     C: ROUTE #ROUTINGCTX# [] "adb"

--- a/tests/stub/routing/scripts/v4x3/router_and_reader_with_empty_routing_context.script
+++ b/tests/stub/routing/scripts/v4x3/router_and_reader_with_empty_routing_context.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: ALLOW RESTART
 
-C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": {"address": "#HOST#:9000"} #EXTRA_HELLO_PROPS#}
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": {"address": "#HOST#:9000"}, "[patch_bolt]": "*" #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 {?
     C: ROUTE {"address": "#HOST#:9000"} [] "adb"

--- a/tests/stub/routing/scripts/v4x3/router_create_adb_with_bookmarks.script
+++ b/tests/stub/routing/scripts/v4x3/router_create_adb_with_bookmarks.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO GOODBYE
 
-C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#, "[patch_bolt]": "*" #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 C: BEGIN {"db": "system"}
 S: SUCCESS {}

--- a/tests/stub/routing/scripts/v4x3/router_default_db.script
+++ b/tests/stub/routing/scripts/v4x3/router_default_db.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO GOODBYE
 
-C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX# #EXTRA_HELLO_PROPS#, "[patch_bolt]": "*" }
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 C: ROUTE #ROUTINGCTX# [] null
 S: SUCCESS { "rt": { "ttl": 1000, "servers": [{"addresses": ["#HOST#:9000"], "role":"ROUTE"}, {"addresses": ["#HOST#:9010", "#HOST#:9011"], "role":"READ"}, {"addresses": ["#HOST#:9020", "#HOST#:9021"], "role":"WRITE"}]}}

--- a/tests/stub/routing/scripts/v4x3/router_system_then_adb_with_bookmarks.script
+++ b/tests/stub/routing/scripts/v4x3/router_system_then_adb_with_bookmarks.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: ALLOW RESTART
 
-C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#, "[patch_bolt]": "*" #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 {?
     C: ROUTE #ROUTINGCTX# [] "system"

--- a/tests/stub/routing/scripts/v4x3/router_yielding_db_not_found_failure.script
+++ b/tests/stub/routing/scripts/v4x3/router_yielding_db_not_found_failure.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO GOODBYE
 
-C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#, "[patch_bolt]": "*" #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 C: ROUTE #ROUTINGCTX# [] "adb"
 S: FAILURE {"code": "Neo.ClientError.Database.DatabaseNotFound", "message": "wut!"}

--- a/tests/stub/routing/scripts/v4x3/router_yielding_empty_response.script
+++ b/tests/stub/routing/scripts/v4x3/router_yielding_empty_response.script
@@ -2,7 +2,7 @@
 !: AUTO RESET
 !: AUTO GOODBYE
 
-C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX# #EXTRA_HELLO_PROPS#}
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#, "[patch_bolt]": "*" #EXTRA_HELLO_PROPS#}
 S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
 C: ROUTE #ROUTINGCTX# [] "adb"
 S: SUCCESS { "rt": { "ttl": 1000, "servers": []}}


### PR DESCRIPTION
In 4.3, this only concerns the Go driver.

As a consequence, only the scripts exercised for the Go driver
have been updated.