### PR TITLE
Fix connection acquisition timeout

### DIFF
--- a/tests/stub/driver_parameters/test_connection_acquisition_timeout_ms.py
+++ b/tests/stub/driver_parameters/test_connection_acquisition_timeout_ms.py
@@ -1,5 +1,3 @@
-import pytest
-
 from nutkit.frontend import Driver
 import nutkit.protocol as types
 from tests.shared import (
@@ -211,7 +209,7 @@ class TestConnectionAcquisitionTimeoutMs(TestkitTestCase):
                               connection_acquisition_timeout_ms=2000,
                               connection_timeout_ms=720000)
         self._session = self._driver.session("r")
-        with pytest.raises(types.DriverError):
+        with self.assertRaises(types.DriverError):
             list(self._session.run("RETURN 1 AS n"))
 
     def test_does_not_encompass_router_route_response(self):

--- a/tests/stub/driver_parameters/test_connection_acquisition_timeout_ms.py
+++ b/tests/stub/driver_parameters/test_connection_acquisition_timeout_ms.py
@@ -1,3 +1,5 @@
+import pytest
+
 from nutkit.frontend import Driver
 import nutkit.protocol as types
 from tests.shared import (
@@ -178,15 +180,15 @@ class TestConnectionAcquisitionTimeoutMs(TestkitTestCase):
         with self.assertRaises(types.DriverError):
             list(self._session.run("RETURN 1 AS n"))
 
-    def test_does_not_encompass_router_handshake(self):
+    def test_router_handshake_has_own_timeout_in_time(self):
         self._start_server(self._router, "router_hello_delay.script")
-        self._start_server(self._server, "session_run.script")
+        self._start_server(self._server, "session_run_auth_delay.script")
 
         uri = "neo4j://%s" % self._router.address
         auth = types.AuthorizationToken("basic", principal="neo4j",
                                         credentials="pass")
         self._driver = Driver(self._backend, uri, auth,
-                              connection_acquisition_timeout_ms=2000,
+                              connection_acquisition_timeout_ms=6000,
                               connection_timeout_ms=720000)
         self._session = self._driver.session("r")
         list(self._session.run("RETURN 1 AS n"))
@@ -197,6 +199,20 @@ class TestConnectionAcquisitionTimeoutMs(TestkitTestCase):
         self._driver = None
         self._router.done()
         self._server.done()
+
+    def test_router_handshake_has_own_timeout_too_slow(self):
+        self._start_server(self._router, "router_hello_delay.script")
+        self._start_server(self._server, "session_run.script")
+
+        uri = "neo4j://%s" % self._router.address
+        auth = types.AuthorizationToken("basic", principal="neo4j",
+                                        credentials="pass")
+        self._driver = Driver(self._backend, uri, auth,
+                              connection_acquisition_timeout_ms=2000,
+                              connection_timeout_ms=720000)
+        self._session = self._driver.session("r")
+        with pytest.raises(types.DriverError):
+            list(self._session.run("RETURN 1 AS n"))
 
     def test_does_not_encompass_router_route_response(self):
         self._start_server(self._router, "router_route_delay.script")


### PR DESCRIPTION
When the driver is performing routing, the connection acquisition for a
connection to the router should also be affected by the connection acquisition
timeout. However, it should have its own timeout because it's a separate
acquisition.

Depends on:
 - https://github.com/neo4j/neo4j-go-driver/pull/385
 - https://github.com/neo4j/neo4j-java-driver/pull/1281