### PR TITLE
Update TestNeo4jBookmarkManager to list results

### DIFF
--- a/tests/stub/driver_parameters/test_bookmark_manager.py
+++ b/tests/stub/driver_parameters/test_bookmark_manager.py
@@ -38,15 +38,15 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
         self._driver = self._new_driver()
 
         s1 = self._driver.session("w")
-        s1.run("RETURN BOOKMARK bm1").consume()
+        list(s1.run("RETURN BOOKMARK bm1"))
         s1.close()
 
         s2 = self._driver.session("w")
-        s2.run("RETURN BOOKMARK bm2").consume()
+        list(s2.run("RETURN BOOKMARK bm2"))
         s2.close()
 
         s3 = self._driver.session("w")
-        s3.run("RETURN BOOKMARK bm3").consume()
+        list(s3.run("RETURN BOOKMARK bm3"))
         s3.close()
 
         self._router.reset()
@@ -72,19 +72,19 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s1 = self._driver.session("w")
         tx1 = s1.begin_transaction({"return_bookmark": "bm1"})
-        tx1.run("RETURN 1 as n").consume()
+        list(tx1.run("RETURN 1 as n"))
         tx1.commit()
         s1.close()
 
         s2 = self._driver.session("w")
         tx2 = s2.begin_transaction({"return_bookmark": "bm2"})
-        tx2.run("RETURN 1 as n").consume()
+        list(tx2.run("RETURN 1 as n"))
         tx2.commit()
         s2.close()
 
         s3 = self._driver.session("w")
         tx3 = s3.begin_transaction({"return_bookmark": "bm2"})
-        tx3.run("RETURN 1 as n").consume()
+        list(tx3.run("RETURN 1 as n"))
         tx3.commit()
         s3.close()
 
@@ -110,19 +110,19 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s1 = self._driver.session("w")
         tx1 = s1.begin_transaction({"return_bookmark": "bm1"})
-        tx1.run("RETURN 1 as n").consume()
+        list(tx1.run("RETURN 1 as n"))
         tx1.commit()
         s1.close()
 
         s2 = self._driver.session("r")
         tx2 = s2.begin_transaction({"return_bookmark": "empty"})
-        tx2.run("RETURN 1 as n").consume()
+        list(tx2.run("RETURN 1 as n"))
         tx2.commit()
         s2.close()
 
         s3 = self._driver.session("w")
         tx3 = s3.begin_transaction({"return_bookmark": "bm3"})
-        tx3.run("RETURN 1 as n").consume()
+        list(tx3.run("RETURN 1 as n"))
         tx3.commit()
         s3.close()
 
@@ -148,11 +148,11 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s1 = self._driver.session("w")
         tx1 = s1.begin_transaction({"return_bookmark": "bm1"})
-        tx1.run("RETURN 1 as n").consume()
+        list(tx1.run("RETURN 1 as n"))
 
         s2 = self._driver.session("w")
         tx2 = s2.begin_transaction({"return_bookmark": "bm2"})
-        tx2.run("RETURN 1 as n").consume()
+        list(tx2.run("RETURN 1 as n"))
 
         tx1.commit()
         s1.close()
@@ -161,7 +161,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s3 = self._driver.session("w")
         tx3 = s3.begin_transaction({"return_bookmark": "bm2"})
-        tx3.run("RETURN 1 as n").consume()
+        list(tx3.run("RETURN 1 as n"))
         tx3.commit()
         s3.close()
 
@@ -185,25 +185,25 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s1 = self._driver.session("w")
         tx1 = s1.begin_transaction({"return_bookmark": "bm1"})
-        tx1.run("RETURN 1 as n").consume()
+        list(tx1.run("RETURN 1 as n"))
         tx1.commit()
         s1.close()
 
         s2 = self._driver.session("w", bookmarks=[])
         tx2 = s2.begin_transaction({"return_bookmark": "bm2"})
-        tx2.run("RETURN 1 as n").consume()
+        list(tx2.run("RETURN 1 as n"))
         tx2.commit()
         s2.close()
 
         s3 = self._driver.session("w", bookmarks=["bm2", "unmanaged"])
         tx3 = s3.begin_transaction({"return_bookmark": "bm3"})
-        tx3.run("RETURN 1 as n").consume()
+        list(tx3.run("RETURN 1 as n"))
         tx3.commit()
         s3.close()
 
         s4 = self._driver.session("w")
         tx4 = s4.begin_transaction({"return_bookmark": "bm3"})
-        tx4.run("RETURN 1 as n").consume()
+        list(tx4.run("RETURN 1 as n"))
         tx4.commit()
         s4.close()
 
@@ -233,13 +233,13 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s1 = self._driver.session("w")
         tx1 = s1.begin_transaction({"return_bookmark": "bm1"})
-        tx1.run("RETURN 1 as n").consume()
+        list(tx1.run("RETURN 1 as n"))
         tx1.commit()
         s1.close()
 
         s2 = self._driver.session("w", ignore_bookmark_manager=True)
         tx2 = s2.begin_transaction({"return_bookmark": "bm2"})
-        tx2.run("RETURN 1 as n").consume()
+        list(tx2.run("RETURN 1 as n"))
         tx2.commit()
         s2.close()
 
@@ -249,13 +249,13 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmarks=["unmanaged"]
         )
         tx3 = s3.begin_transaction({"return_bookmark": "bm3"})
-        tx3.run("RETURN 1 as n").consume()
+        list(tx3.run("RETURN 1 as n"))
         tx3.commit()
         s3.close()
 
         s4 = self._driver.session("w")
         tx4 = s4.begin_transaction({"return_bookmark": "bm3"})
-        tx4.run("RETURN 1 as n").consume()
+        list(tx4.run("RETURN 1 as n"))
         tx4.commit()
         s4.close()
 
@@ -286,13 +286,13 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s1 = self._driver.session("w", database="neo4j")
         tx1 = s1.begin_transaction({"return_bookmark": "bm1"})
-        tx1.run("RETURN 1 as n").consume()
+        list(tx1.run("RETURN 1 as n"))
         tx1.commit()
         s1.close()
 
         s2 = self._driver.session("w", database="neo4j")
         tx2 = s2.begin_transaction({"return_bookmark": "bm2"})
-        tx2.run("RETURN 1 as n").consume()
+        list(tx2.run("RETURN 1 as n"))
         tx2.commit()
         s2.close()
 
@@ -319,13 +319,13 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s1 = self._driver.session("w", database="neo4j")
         tx1 = s1.begin_transaction({"return_bookmark": "bm1"})
-        tx1.run("RETURN 1 as n").consume()
+        list(tx1.run("RETURN 1 as n"))
         tx1.commit()
         s1.close()
 
         s2 = self._driver.session("w", database="neo4j")
         tx2 = s2.begin_transaction({"return_bookmark": "bm2"})
-        tx2.run("RETURN 1 as n").consume()
+        list(tx2.run("RETURN 1 as n"))
         tx2.commit()
         s2.close()
 
@@ -350,25 +350,25 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s1 = self._driver.session("w", database="neo4j")
         tx1 = s1.begin_transaction({"return_bookmark": "bm1"})
-        tx1.run("RETURN 1 as n").consume()
+        list(tx1.run("RETURN 1 as n"))
         tx1.commit()
         s1.close()
 
         s2 = self._driver.session("w", database="neo4j")
         tx2 = s2.begin_transaction({"order": "adb"})
-        tx2.run("USE adb RETURN 1 as n").consume()
+        list(tx2.run("USE adb RETURN 1 as n"))
         tx2.commit()
         s2.close()
 
         s3 = self._driver.session("w", database="neo4j")
         tx3 = s3.begin_transaction({"return_bookmark": "bm2"})
-        tx3.run("RETURN 1 as n").consume()
+        list(tx3.run("RETURN 1 as n"))
         tx3.commit()
         s3.close()
 
         s4 = self._driver.session("w", database="neo4j")
         tx4 = s4.begin_transaction({"return_bookmark": "bm3"})
-        tx4.run("RETURN 1 as n").consume()
+        list(tx4.run("RETURN 1 as n"))
         tx4.commit()
         s4.close()
 
@@ -399,19 +399,19 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
         self._driver = self._new_driver()
 
         s1 = self._driver.session("w")
-        s1.run("RETURN BOOKMARK bm1").consume()
+        list(s1.run("RETURN BOOKMARK bm1"))
         s1.close()
 
         s2 = self._driver.session("w")
-        s2.run("USE adb RETURN BOOKMARK adb:bm4").consume()
+        list(s2.run("USE adb RETURN BOOKMARK adb:bm4"))
         s2.close()
 
         s3 = self._driver.session("w")
-        s3.run("RETURN BOOKMARK bm2").consume()
+        list(s3.run("RETURN BOOKMARK bm2"))
         s3.close()
 
         s4 = self._driver.session("w")
-        s4.run("RETURN BOOKMARK bm3").consume()
+        list(s4.run("RETURN BOOKMARK bm3"))
         s4.close()
 
         self._server.reset()
@@ -442,13 +442,13 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s1 = self._driver.session("w")
         tx1 = s1.begin_transaction({"return_bookmark": "bm1"})
-        tx1.run("RETURN 1 as n").consume()
+        list(tx1.run("RETURN 1 as n"))
         tx1.commit()
         s1.close()
 
         s2 = self._driver.session("w")
         tx2 = s2.begin_transaction({"return_bookmark": "bm2"})
-        tx2.run("RETURN 1 as n").consume()
+        list(tx2.run("RETURN 1 as n"))
         tx2.commit()
         s2.close()
 


### PR DESCRIPTION
Explicit listing is needed for those drivers that may not necessarily consume all result and may do a `DISCARD` instead. For instance, reactive.