### PR TITLE
Fix linter issues by removing un-necessary ABC

### DIFF
--- a/boltstub/parsing.py
+++ b/boltstub/parsing.py
@@ -184,7 +184,7 @@ class BangLine(Line):
             )
 
 
-class MessageLine(Line, abc.ABC):
+class MessageLine(Line):
     allow_jolt_wildcard = False
     always_parse = True
 

--- a/boltstub/simple_jolt/common/types.py
+++ b/boltstub/simple_jolt/common/types.py
@@ -1,4 +1,3 @@
-import abc
 import re
 
 from .errors import JOLTValueError
@@ -19,7 +18,7 @@ class JoltWildcard(JoltType):
         self.types = types
 
 
-class _JoltParsedType(JoltType, abc.ABC):
+class _JoltParsedType(JoltType):
     # to be overridden in subclasses (this re never matches)
     _parse_re = re.compile(r"^(?= )$")
 


### PR DESCRIPTION
Classes should not be created as abstract if they don't have abstract methods. 