### PR TITLE
javascript: define message for RxResult in scope test

### DIFF
--- a/tests/stub/iteration/test_result_scope.py
+++ b/tests/stub/iteration/test_result_scope.py
@@ -47,7 +47,11 @@ class TestResultScope(TestkitTestCase):
         elif driver in ["dotnet"]:
             self.assertEqual(exc.errorType, "ResultConsumedError")
         elif driver in ["javascript"]:
-            self.assertEqual(exc.msg, "Result is already consumed")
+            self.assertIn(exc.msg, [
+                "Result is already consumed",
+                "Streaming has already started/consumed with a previous "
+                "records or summary subscription."
+            ])
         elif driver in ["go"]:
             self.assertEqual(exc.msg, "result cursor is not available anymore")
         else:
@@ -67,7 +71,11 @@ class TestResultScope(TestkitTestCase):
         elif driver in ["dotnet"]:
             self.assertEqual(exc.errorType, "ResultConsumedError")
         elif driver in ["javascript"]:
-            self.assertEqual(exc.msg, "Result is already consumed")
+            self.assertIn(exc.msg, [
+                "Result is already consumed",
+                "Streaming has already started/consumed with a previous "
+                "records or summary subscription."
+            ])
         elif driver in ["go"]:
             self.assertEqual(exc.msg, "result cursor is not available anymore")
         else:


### PR DESCRIPTION
The RxResult has already especialized messages for result already consumed which are
quite specific.