### PR TITLE
Allow scripts to finish when driver ignores timeouts

### DIFF
--- a/tests/stub/configuration_hints/scripts/1_second_exceeds.script
+++ b/tests/stub/configuration_hints/scripts/1_second_exceeds.script
@@ -19,6 +19,6 @@ S: SUCCESS {"server": "Neo4j/4.4.1", "hints": {"connection.recv_timeout_seconds"
     C: PULL {"n": "*"}
     S: RECORD [1]
        SUCCESS {"type": "r"}
-    *: RESET
 }}
+*: RESET
 ?: GOODBYE

--- a/tests/stub/configuration_hints/scripts/1_second_exceeds_tx.script
+++ b/tests/stub/configuration_hints/scripts/1_second_exceeds_tx.script
@@ -15,6 +15,14 @@ S: SUCCESS {}
         S: RECORD [1]
            SUCCESS {"type": "r"}
     ?}
+    {{
+        C: COMMIT
+    ----
+        C: ROLLBACK
+    ----
+        C: RESET
+    }}
+    S: SUCCESS {}
 ----
     C: RUN "in time" "*" "*"
     S: SUCCESS {"fields": ["n"]}
@@ -23,6 +31,6 @@ S: SUCCESS {}
        SUCCESS {"type": "r"}
     C: COMMIT
     S: SUCCESS {}
-    *: RESET
 }}
+*: RESET
 ?: GOODBYE

--- a/tests/stub/configuration_hints/scripts/1_second_exceeds_tx_retry.script
+++ b/tests/stub/configuration_hints/scripts/1_second_exceeds_tx_retry.script
@@ -14,6 +14,14 @@ S: SUCCESS {}
         S: RECORD [1]
            SUCCESS {"type": "r"}
     ?}
+    {{
+        C: COMMIT
+    ----
+        C: ROLLBACK
+    ----
+        C: RESET
+    }}
+    S: SUCCESS {}
 ----
     C: RUN "RETURN 2 AS n" "*" "*"
     S: SUCCESS {"fields": ["n"]}
@@ -22,6 +30,6 @@ S: SUCCESS {}
        SUCCESS {"type": "r"}
     C: COMMIT
     S: SUCCESS {}
-    *: RESET
 }}
+*: RESET
 ?: GOODBYE


### PR DESCRIPTION
Spotted by @klobuczek

Drivers should be able to successfully finish the scripts if they ignore the timeout hint. This way, they will not raise an error as expected by the tests, hence fail them.