### PR TITLE
Update Bookmark Manager interface

### DIFF
--- a/nutkit/frontend/bookmark_manager.py
+++ b/nutkit/frontend/bookmark_manager.py
@@ -17,9 +17,9 @@ from .. import protocol
 
 @dataclass
 class Neo4jBookmarkManagerConfig:
-    initial_bookmarks: Optional[Dict[str, List[str]]] = None
-    bookmarks_supplier: Optional[Callable[[str], List[str]]] = None
-    bookmarks_consumer: Optional[Callable[[str, List[str]], None]] = None
+    initial_bookmarks: Optional[List[str]] = None
+    bookmarks_supplier: Optional[Callable[[], List[str]]] = None
+    bookmarks_consumer: Optional[Callable[[List[str]], None]] = None
 
 
 @dataclass
@@ -58,7 +58,7 @@ class BookmarkManager:
             manager = cls._registry[request.bookmark_manager_id]
             supply = manager.config.bookmarks_supplier
             if supply is not None:
-                bookmarks = supply(request.database)
+                bookmarks = supply()
                 return protocol.BookmarksSupplierCompleted(request.id,
                                                            bookmarks)
         if isinstance(request, protocol.BookmarksConsumerRequest):
@@ -70,7 +70,7 @@ class BookmarkManager:
             manager = cls._registry[request.bookmark_manager_id]
             consume = manager.config.bookmarks_consumer
             if consume is not None:
-                consume(request.database, request.bookmarks)
+                consume(request.bookmarks)
                 return protocol.BookmarksConsumerCompleted(request.id)
 
     def close(self, hooks=None):

--- a/nutkit/protocol/responses.py
+++ b/nutkit/protocol/responses.py
@@ -88,11 +88,10 @@ class BookmarksSupplierRequest:
     bookmarks for all databases.
     """
 
-    def __init__(self, id, bookmarkManagerId, database=None):
+    def __init__(self, id, bookmarkManagerId):
         # id of the callback request
         self.id = id
         self.bookmark_manager_id = bookmarkManagerId
-        self.database = database
 
 
 class BookmarksConsumerRequest:
@@ -103,11 +102,10 @@ class BookmarksConsumerRequest:
     to send the new bookmark set for a given database.
     """
 
-    def __init__(self, id, bookmarkManagerId, database, bookmarks):
+    def __init__(self, id, bookmarkManagerId, bookmarks):
         # id of the callback request
         self.id = id
         self.bookmark_manager_id = bookmarkManagerId
-        self.database = database
         self.bookmarks = bookmarks
 
 

--- a/tests/stub/driver_parameters/scripts/transaction_chaining.script
+++ b/tests/stub/driver_parameters/scripts/transaction_chaining.script
@@ -7,7 +7,7 @@ A: HELLO {"{}": "*"}
     {{
         C: BEGIN {"tx_metadata": {"return_bookmark": "bm1"}, "[bookmarks]": "*", "[db]": "*"}
         S: SUCCESS {}
-        C: RUN "RETURN 1 as n" {} {}
+        C: RUN "RETURN 1 AS n" {} {}
         S: SUCCESS {"fields": ["n"]}
         C: PULL {"n": 1000}
         S: SUCCESS {"type": "r"}
@@ -16,7 +16,7 @@ A: HELLO {"{}": "*"}
     ----
         C: BEGIN {"tx_metadata": {"return_bookmark": "bm2"}, "[bookmarks]": "*", "[db]": "*"}
         S: SUCCESS {}
-        C: RUN "RETURN 1 as n" {} {}
+        C: RUN "RETURN 1 AS n" {} {}
         S: SUCCESS {"fields": ["n"]}
         C: PULL {"n": 1000}
         S: SUCCESS {"type": "r"}
@@ -25,7 +25,7 @@ A: HELLO {"{}": "*"}
     ----
         C: BEGIN {"tx_metadata": {"return_bookmark": "empty"}, "[bookmarks]": "*", "[db]": "*", "mode": "r"}
         S: SUCCESS {}
-        C: RUN "RETURN 1 as n" {} {}
+        C: RUN "RETURN 1 AS n" {} {}
         S: SUCCESS {"fields": ["n"]}
         C: PULL {"n": 1000}
         S: SUCCESS {"type": "r"}
@@ -34,7 +34,7 @@ A: HELLO {"{}": "*"}
     ----
         C: BEGIN {"tx_metadata": {"return_bookmark": "bm3"}, "[bookmarks]": "*", "[db]": "*"}
         S: SUCCESS {}
-        C: RUN "RETURN 1 as n" {} {}
+        C: RUN "RETURN 1 AS n" {} {}
         S: SUCCESS {"fields": ["n"]}
         C: PULL {"n": 1000}
         S: SUCCESS {"type": "r"}
@@ -43,7 +43,7 @@ A: HELLO {"{}": "*"}
     ----
         C: BEGIN {"tx_metadata": {"return_bookmark": "bm4"}, "[bookmarks]": "*", "[db]": "*"}
         S: SUCCESS {}
-        C: RUN "RETURN 1 as n" {} {}
+        C: RUN "RETURN 1 AS n" {} {}
         S: SUCCESS {"fields": ["n"]}
         C: PULL {"n": 1000}
         S: SUCCESS {"type": "r"}
@@ -52,7 +52,7 @@ A: HELLO {"{}": "*"}
     ----
         C: BEGIN {"tx_metadata": {"order": "adb"}, "[bookmarks]": "*", "[db]": "*"}
         S: SUCCESS {}
-        C: RUN "USE adb RETURN 1 as n" {} {}
+        C: RUN "USE adb RETURN 1 AS n" {} {}
         S: SUCCESS {"fields": ["n"]}
         C: PULL {"n": 1000}
         S: SUCCESS {"type": "r"}

--- a/tests/stub/driver_parameters/test_bookmark_manager.py
+++ b/tests/stub/driver_parameters/test_bookmark_manager.py
@@ -333,7 +333,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmarks=["bm1"]
         )
 
-    def test_should_send_all_db_bookmarks_and_update_only_relevant(self):
+    def test_should_send_all_db_bookmarks_and_replace_it_by_the_new_one(self):
         self._start_server(self._router, "router_with_db_name.script")
         self._start_server(self._server, "transaction_chaining.script")
 
@@ -373,7 +373,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
         )
         self.assert_begin(
             begin_requests[1],
-            bookmarks=["bm1", "adb:bm1"]
+            bookmarks=["bm1"]
         )
 
     def test_should_handle_database_redirection_in_tx(self):

--- a/tests/stub/driver_parameters/test_bookmark_manager.py
+++ b/tests/stub/driver_parameters/test_bookmark_manager.py
@@ -560,7 +560,14 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
         tx2.commit()
         s2.close()
 
-        self.assertEqual(5, get_bookmarks_calls)
+        self.assertIn(get_bookmarks_calls, [
+            # multiple calls for name resolution
+            # and acquire connection
+            5,
+            # single call for name resolution
+            # and acquire connection
+            4
+        ])
 
     def test_should_enrich_bookmarks_with_bookmark_supplier_result(self):
         self._start_server(self._router, "router_with_db_name.script")

--- a/tests/stub/driver_parameters/test_bookmark_manager.py
+++ b/tests/stub/driver_parameters/test_bookmark_manager.py
@@ -239,7 +239,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmarks=["bm3"]
         )
 
-    def test_should_ignore_bookmark_manager_not_set_in_a_sesssion(self):
+    def test_should_ignore_bookmark_manager_not_set_in_a_session(self):
         self._start_server(self._router, "router_with_db_name.script")
         self._start_server(self._server, "transaction_chaining.script")
 
@@ -290,13 +290,13 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmarks=["bm1"]
         )
 
-    def test_should_use_initial_bookmark_set_in_the_fist_tx(self):
+    def test_should_use_initial_bookmark_set_in_the_first_tx(self):
         self._start_server(self._router, "router_with_db_name.script")
         self._start_server(self._server, "transaction_chaining.script")
 
         self._driver, manager = self._new_driver_and_bookmark_manager(
             Neo4jBookmarkManagerConfig(
-                initial_bookmarks=["fist_bm"]
+                initial_bookmarks=["first_bm"]
             )
         )
 
@@ -326,7 +326,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
         self.assertEqual(len(begin_requests), 2)
         self.assert_begin(
             begin_requests[0],
-            bookmarks=["fist_bm"]
+            bookmarks=["first_bm"]
         )
         self.assert_begin(
             begin_requests[1],
@@ -339,7 +339,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         self._driver, manager = self._new_driver_and_bookmark_manager(
             Neo4jBookmarkManagerConfig(
-                initial_bookmarks=["fist_bm", "adb:bm1"]
+                initial_bookmarks=["first_bm", "adb:bm1"]
             )
         )
 
@@ -369,7 +369,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
         self.assertEqual(len(begin_requests), 2)
         self.assert_begin(
             begin_requests[0],
-            bookmarks=["fist_bm", "adb:bm1"]
+            bookmarks=["first_bm", "adb:bm1"]
         )
         self.assert_begin(
             begin_requests[1],
@@ -533,7 +533,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
         get_bookmarks_calls = 0
 
         def get_bookmarks():
-            global get_bookmarks_calls
+            nonlocal get_bookmarks_calls
             get_bookmarks_calls = get_bookmarks_calls + 1
             return []
 
@@ -597,6 +597,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
         s2.close()
 
         self._server.reset()
+        self._server._dump()
         begin_requests = self._server.get_requests("BEGIN")
 
         self.assertEqual(len(begin_requests), 2)

--- a/tests/stub/driver_parameters/test_bookmark_manager.py
+++ b/tests/stub/driver_parameters/test_bookmark_manager.py
@@ -532,9 +532,6 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
         adb_bookmarks = ["adb:bm1"]
         get_bookmarks_calls = 0
 
-        # TODO: return different bookmarks to check that the driver is
-        #       enriching with the correct bookmarks
-
         def get_bookmarks():
             nonlocal get_bookmarks_calls
             get_bookmarks_calls += 1

--- a/tests/stub/driver_parameters/test_bookmark_manager.py
+++ b/tests/stub/driver_parameters/test_bookmark_manager.py
@@ -597,7 +597,6 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
         s2.close()
 
         self._server.reset()
-        self._server._dump()
         begin_requests = self._server.get_requests("BEGIN")
 
         self.assertEqual(len(begin_requests), 2)

--- a/tests/stub/driver_parameters/test_bookmark_manager.py
+++ b/tests/stub/driver_parameters/test_bookmark_manager.py
@@ -436,11 +436,11 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
         )
         self.assert_begin(
             begin_requests[2],
-            bookmarks=["bm1", "adb:bm4"]
+            bookmarks=["adb:bm4"]
         )
         self.assert_begin(
             begin_requests[3],
-            bookmarks=["bm2", "adb:bm4"]
+            bookmarks=["bm2"]
         )
 
     def test_should_handle_database_redirection_in_session_run(self):

--- a/tests/stub/driver_parameters/test_bookmark_manager.py
+++ b/tests/stub/driver_parameters/test_bookmark_manager.py
@@ -79,19 +79,19 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s1 = self._driver.session("w", bookmark_manager=manager)
         tx1 = s1.begin_transaction(tx_meta={"return_bookmark": "bm1"})
-        list(tx1.run("RETURN 1 as n"))
+        list(tx1.run("RETURN 1 AS n"))
         tx1.commit()
         s1.close()
 
         s2 = self._driver.session("w", bookmark_manager=manager)
         tx2 = s2.begin_transaction(tx_meta={"return_bookmark": "bm2"})
-        list(tx2.run("RETURN 1 as n"))
+        list(tx2.run("RETURN 1 AS n"))
         tx2.commit()
         s2.close()
 
         s3 = self._driver.session("w", bookmark_manager=manager)
         tx3 = s3.begin_transaction(tx_meta={"return_bookmark": "bm2"})
-        list(tx3.run("RETURN 1 as n"))
+        list(tx3.run("RETURN 1 AS n"))
         tx3.commit()
         s3.close()
 
@@ -118,19 +118,19 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s1 = self._driver.session("w", bookmark_manager=manager)
         tx1 = s1.begin_transaction(tx_meta={"return_bookmark": "bm1"})
-        list(tx1.run("RETURN 1 as n"))
+        list(tx1.run("RETURN 1 AS n"))
         tx1.commit()
         s1.close()
 
         s2 = self._driver.session("r", bookmark_manager=manager)
         tx2 = s2.begin_transaction(tx_meta={"return_bookmark": "empty"})
-        list(tx2.run("RETURN 1 as n"))
+        list(tx2.run("RETURN 1 AS n"))
         tx2.commit()
         s2.close()
 
         s3 = self._driver.session("w", bookmark_manager=manager)
         tx3 = s3.begin_transaction(tx_meta={"return_bookmark": "bm3"})
-        list(tx3.run("RETURN 1 as n"))
+        list(tx3.run("RETURN 1 AS n"))
         tx3.commit()
         s3.close()
 
@@ -157,11 +157,11 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s1 = self._driver.session("w", bookmark_manager=manager)
         tx1 = s1.begin_transaction(tx_meta={"return_bookmark": "bm1"})
-        list(tx1.run("RETURN 1 as n"))
+        list(tx1.run("RETURN 1 AS n"))
 
         s2 = self._driver.session("w", bookmark_manager=manager)
         tx2 = s2.begin_transaction(tx_meta={"return_bookmark": "bm2"})
-        list(tx2.run("RETURN 1 as n"))
+        list(tx2.run("RETURN 1 AS n"))
 
         tx1.commit()
         s1.close()
@@ -170,7 +170,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s3 = self._driver.session("w", bookmark_manager=manager)
         tx3 = s3.begin_transaction(tx_meta={"return_bookmark": "bm2"})
-        list(tx3.run("RETURN 1 as n"))
+        list(tx3.run("RETURN 1 AS n"))
         tx3.commit()
         s3.close()
 
@@ -195,13 +195,13 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s1 = self._driver.session("w", bookmark_manager=manager)
         tx1 = s1.begin_transaction(tx_meta={"return_bookmark": "bm1"})
-        list(tx1.run("RETURN 1 as n"))
+        list(tx1.run("RETURN 1 AS n"))
         tx1.commit()
         s1.close()
 
         s2 = self._driver.session("w", bookmarks=[], bookmark_manager=manager)
         tx2 = s2.begin_transaction(tx_meta={"return_bookmark": "bm2"})
-        list(tx2.run("RETURN 1 as n"))
+        list(tx2.run("RETURN 1 AS n"))
         tx2.commit()
         s2.close()
 
@@ -211,13 +211,13 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmark_manager=manager
         )
         tx3 = s3.begin_transaction(tx_meta={"return_bookmark": "bm3"})
-        list(tx3.run("RETURN 1 as n"))
+        list(tx3.run("RETURN 1 AS n"))
         tx3.commit()
         s3.close()
 
         s4 = self._driver.session("w", bookmark_manager=manager)
         tx4 = s4.begin_transaction(tx_meta={"return_bookmark": "bm3"})
-        list(tx4.run("RETURN 1 as n"))
+        list(tx4.run("RETURN 1 AS n"))
         tx4.commit()
         s4.close()
 
@@ -248,13 +248,13 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s1 = self._driver.session("w", bookmark_manager=manager)
         tx1 = s1.begin_transaction(tx_meta={"return_bookmark": "bm1"})
-        list(tx1.run("RETURN 1 as n"))
+        list(tx1.run("RETURN 1 AS n"))
         tx1.commit()
         s1.close()
 
         s2 = self._driver.session("w")
         tx2 = s2.begin_transaction(tx_meta={"return_bookmark": "bm2"})
-        list(tx2.run("RETURN 1 as n"))
+        list(tx2.run("RETURN 1 AS n"))
         tx2.commit()
         s2.close()
 
@@ -263,13 +263,13 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmarks=["unmanaged"]
         )
         tx3 = s3.begin_transaction(tx_meta={"return_bookmark": "bm3"})
-        list(tx3.run("RETURN 1 as n"))
+        list(tx3.run("RETURN 1 AS n"))
         tx3.commit()
         s3.close()
 
         s4 = self._driver.session("w", bookmark_manager=manager)
         tx4 = s4.begin_transaction(tx_meta={"return_bookmark": "bm3"})
-        list(tx4.run("RETURN 1 as n"))
+        list(tx4.run("RETURN 1 AS n"))
         tx4.commit()
         s4.close()
 
@@ -306,7 +306,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmark_manager=manager
         )
         tx1 = s1.begin_transaction(tx_meta={"return_bookmark": "bm1"})
-        list(tx1.run("RETURN 1 as n"))
+        list(tx1.run("RETURN 1 AS n"))
         tx1.commit()
         s1.close()
 
@@ -316,7 +316,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmark_manager=manager
         )
         tx2 = s2.begin_transaction(tx_meta={"return_bookmark": "bm2"})
-        list(tx2.run("RETURN 1 as n"))
+        list(tx2.run("RETURN 1 AS n"))
         tx2.commit()
         s2.close()
 
@@ -349,7 +349,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmark_manager=manager
         )
         tx1 = s1.begin_transaction(tx_meta={"return_bookmark": "bm1"})
-        list(tx1.run("RETURN 1 as n"))
+        list(tx1.run("RETURN 1 AS n"))
         tx1.commit()
         s1.close()
 
@@ -359,7 +359,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmark_manager=manager
         )
         tx2 = s2.begin_transaction(tx_meta={"return_bookmark": "bm2"})
-        list(tx2.run("RETURN 1 as n"))
+        list(tx2.run("RETURN 1 AS n"))
         tx2.commit()
         s2.close()
 
@@ -389,7 +389,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmark_manager=manager
         )
         tx1 = s1.begin_transaction(tx_meta={"return_bookmark": "bm1"})
-        list(tx1.run("RETURN 1 as n"))
+        list(tx1.run("RETURN 1 AS n"))
         tx1.commit()
         s1.close()
 
@@ -399,7 +399,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmark_manager=manager
         )
         tx2 = s2.begin_transaction(tx_meta={"order": "adb"})
-        list(tx2.run("USE adb RETURN 1 as n"))
+        list(tx2.run("USE adb RETURN 1 AS n"))
         tx2.commit()
         s2.close()
 
@@ -409,7 +409,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmark_manager=manager
         )
         tx3 = s3.begin_transaction(tx_meta={"return_bookmark": "bm2"})
-        list(tx3.run("RETURN 1 as n"))
+        list(tx3.run("RETURN 1 AS n"))
         tx3.commit()
         s3.close()
 
@@ -419,7 +419,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmark_manager=manager
         )
         tx4 = s4.begin_transaction(tx_meta={"return_bookmark": "bm3"})
-        list(tx4.run("RETURN 1 as n"))
+        list(tx4.run("RETURN 1 AS n"))
         tx4.commit()
         s4.close()
 
@@ -496,13 +496,13 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s1 = self._driver.session("w", bookmark_manager=manager)
         tx1 = s1.begin_transaction(tx_meta={"return_bookmark": "bm1"})
-        list(tx1.run("RETURN 1 as n"))
+        list(tx1.run("RETURN 1 AS n"))
         tx1.commit()
         s1.close()
 
         s2 = self._driver.session("w", bookmark_manager=manager)
         tx2 = s2.begin_transaction(tx_meta={"return_bookmark": "bm2"})
-        list(tx2.run("RETURN 1 as n"))
+        list(tx2.run("RETURN 1 AS n"))
         tx2.commit()
         s2.close()
 
@@ -550,13 +550,13 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmark_manager=manager
         )
         tx1 = s1.begin_transaction(tx_meta={"return_bookmark": "bm1"})
-        list(tx1.run("RETURN 1 as n"))
+        list(tx1.run("RETURN 1 AS n"))
         tx1.commit()
         s1.close()
 
         s2 = self._driver.session("w", bookmark_manager=manager)
         tx2 = s2.begin_transaction(tx_meta={"return_bookmark": "bm2"})
-        list(tx2.run("RETURN 1 as n"))
+        list(tx2.run("RETURN 1 AS n"))
         tx2.commit()
         s2.close()
 
@@ -622,7 +622,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmark_manager=manager
         )
         tx1 = s1.begin_transaction(tx_meta={"return_bookmark": "empty"})
-        list(tx1.run("RETURN 1 as n"))
+        list(tx1.run("RETURN 1 AS n"))
         tx1.commit()
         s1.close()
 
@@ -632,7 +632,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmark_manager=manager
         )
         tx2 = s2.begin_transaction(tx_meta={"return_bookmark": "bm1"})
-        list(tx2.run("RETURN 1 as n"))
+        list(tx2.run("RETURN 1 AS n"))
         tx2.commit()
         s2.close()
 
@@ -642,7 +642,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmark_manager=manager
         )
         tx3 = s3.begin_transaction(tx_meta={"return_bookmark": "bm2"})
-        list(tx3.run("RETURN 1 as n"))
+        list(tx3.run("RETURN 1 AS n"))
         tx3.commit()
         s3.close()
 
@@ -682,13 +682,13 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmark_manager=manager
         )
         tx1 = s1.begin_transaction(tx_meta={"return_bookmark": "bm1"})
-        list(tx1.run("RETURN 1 as n"))
+        list(tx1.run("RETURN 1 AS n"))
         tx1.commit()
         s1.close()
 
         s2 = self._driver.session("w", bookmark_manager=manager)
         tx2 = s2.begin_transaction(tx_meta={"order": "adb"})
-        list(tx2.run("USE adb RETURN 1 as n"))
+        list(tx2.run("USE adb RETURN 1 AS n"))
         tx2.commit()
         s2.close()
 
@@ -722,7 +722,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         s1 = self._driver.session("w", bookmark_manager=manager)
         tx1 = s1.begin_transaction(tx_meta={"return_bookmark": "bm1"})
-        list(tx1.run("RETURN 1 as n"))
+        list(tx1.run("RETURN 1 AS n"))
         tx1.commit()
         s1.close()
 
@@ -754,25 +754,25 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
 
         manager1_s1 = self._driver.session("w", bookmark_manager=manager1)
         tx1 = manager1_s1.begin_transaction(tx_meta={"return_bookmark": "bm1"})
-        list(tx1.run("RETURN 1 as n"))
+        list(tx1.run("RETURN 1 AS n"))
         tx1.commit()
         manager1_s1.close()
 
         manager2_s1 = self._driver.session("w", bookmark_manager=manager2)
         tx2 = manager2_s1.begin_transaction(tx_meta={"return_bookmark": "bm2"})
-        list(tx2.run("RETURN 1 as n"))
+        list(tx2.run("RETURN 1 AS n"))
         tx2.commit()
         manager2_s1.close()
 
         manager2_s2 = self._driver.session("w", bookmark_manager=manager2)
         tx3 = manager2_s2.begin_transaction(tx_meta={"return_bookmark": "bm3"})
-        list(tx3.run("RETURN 1 as n"))
+        list(tx3.run("RETURN 1 AS n"))
         tx3.commit()
         manager2_s2.close()
 
         manager1_s2 = self._driver.session("w", bookmark_manager=manager1)
         tx4 = manager1_s2.begin_transaction(tx_meta={"return_bookmark": "bm4"})
-        list(tx4.run("RETURN 1 as n"))
+        list(tx4.run("RETURN 1 AS n"))
         tx4.commit()
         manager1_s2.close()
 

--- a/tests/stub/driver_parameters/test_bookmark_manager.py
+++ b/tests/stub/driver_parameters/test_bookmark_manager.py
@@ -333,7 +333,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmarks=["bm1"]
         )
 
-    def test_should_send_all_db_bookmarks_and_replace_it_by_the_new_one(self):
+    def test_should_send_all_bookmarks_and_replace_it_by_the_new_one(self):
         self._start_server(self._router, "router_with_db_name.script")
         self._start_server(self._server, "transaction_chaining.script")
 
@@ -484,7 +484,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmarks=["bm2"]
         )
 
-    def test_should_resolve_database_name_with_system_bookmarks(self):
+    def test_should_resolve_database_name_with_bookmarks(self):
         self._start_server(self._router, "router_with_db_name.script")
         self._start_server(self._server, "transaction_chaining.script")
 

--- a/tests/stub/driver_parameters/test_bookmark_manager.py
+++ b/tests/stub/driver_parameters/test_bookmark_manager.py
@@ -677,7 +677,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
         s1.close()
 
         self.assertEqual(1, len(bookmarks_consumer_calls))
-        self.assertEquals(bookmarks_consumer_calls, [
+        self.assertEqual(bookmarks_consumer_calls, [
             [
                 # first tx
                 "bm1"

--- a/tests/stub/driver_parameters/test_bookmark_manager.py
+++ b/tests/stub/driver_parameters/test_bookmark_manager.py
@@ -477,11 +477,11 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
         )
         self.assert_run(
             run_requests[2],
-            bookmarks=["bm1", "adb:bm4"]
+            bookmarks=["adb:bm4"]
         )
         self.assert_run(
             run_requests[3],
-            bookmarks=["bm2", "adb:bm4"]
+            bookmarks=["bm2"]
         )
 
     def test_should_resolve_database_name_with_system_bookmarks(self):

--- a/tests/stub/driver_parameters/test_bookmark_manager.py
+++ b/tests/stub/driver_parameters/test_bookmark_manager.py
@@ -606,8 +606,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
         )
         self.assert_begin(
             begin_requests[1],
-            bookmarks=["bm1", *system_bookmarks, *neo4j_bookmarks,
-                       *adb_bookmarks]
+            bookmarks=["bm1", *system_bookmarks, *neo4j_bookmarks]
         )
 
     def test_should_call_bookmarks_consumer_when_new_bookmarks_arrive(self):

--- a/tests/stub/driver_parameters/test_bookmark_manager.py
+++ b/tests/stub/driver_parameters/test_bookmark_manager.py
@@ -186,7 +186,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
             bookmarks=["bm1", "bm2"]
         )
 
-    def test_should_manage_explicity_session_bookmarks(self):
+    def test_should_manage_explicitly_session_bookmarks(self):
         self._start_server(self._router, "router_with_db_name.script")
         self._start_server(self._server, "transaction_chaining.script")
 

--- a/tests/stub/driver_parameters/test_bookmark_manager.py
+++ b/tests/stub/driver_parameters/test_bookmark_manager.py
@@ -522,7 +522,7 @@ class TestNeo4jBookmarkManager(TestkitTestCase):
         )
         self.assert_begin(
             begin_requests[1],
-            bookmarks=["sys:bm1", "bm1"]
+            bookmarks=["bm1"]
         )
 
     def test_should_call_bookmark_supplier_for_all_get_bookmarks_calls(self):


### PR DESCRIPTION
Starting with 5.0, Fabric is enabled by default.
It
 1. allows multiple databases to be interacted with in a single transaction, and
 2. ensures bookmarks encode the state of all databases. Hence, the Bookmark Manager can be simplified while also improving its performance (by having to send less bookmarks to the server).

This PR implements the changes need on the bookmark manager API and behaviour.