### PR TITLE
Make more error codes fail fast during the rediscovery

### DIFF
--- a/tests/stub/routing/scripts/v3/router_yielding_argument_error.script
+++ b/tests/stub/routing/scripts/v3/router_yielding_argument_error.script
@@ -1,0 +1,13 @@
+!: BOLT #VERSION#
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007"#EXTR_HELLO_ROUTING_PROPS#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": #ROUTINGCTX#} {"[mode]": "r"}
+S: FAILURE {"code": "Neo.ClientError.Statement.ArgumentError", "message": "Kaboooom."}
+{?
+    C: PULL_ALL
+    S: IGNORED
+?}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v3/router_yielding_invalid_request.script
+++ b/tests/stub/routing/scripts/v3/router_yielding_invalid_request.script
@@ -1,0 +1,13 @@
+!: BOLT #VERSION#
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007"#EXTR_HELLO_ROUTING_PROPS#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": #ROUTINGCTX#} {"[mode]": "r"}
+S: FAILURE {"code": "Neo.ClientError.Request.Invalid", "message": "Kaboooom."}
+{?
+    C: PULL_ALL
+    S: IGNORED
+?}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v3/router_yielding_type_error.script
+++ b/tests/stub/routing/scripts/v3/router_yielding_type_error.script
@@ -1,0 +1,13 @@
+!: BOLT #VERSION#
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007"#EXTR_HELLO_ROUTING_PROPS#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+C: RUN "CALL dbms.cluster.routing.getRoutingTable($context)" {"context": #ROUTINGCTX#} {"[mode]": "r"}
+S: FAILURE {"code": "Neo.ClientError.Statement.TypeError", "message": "Kaboooom."}
+{?
+    C: PULL_ALL
+    S: IGNORED
+?}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x1/router_yielding_argument_error.script
+++ b/tests/stub/routing/scripts/v4x1/router_yielding_argument_error.script
@@ -1,0 +1,13 @@
+!: BOLT #VERSION#
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "[database]": "*"} {"[mode]": "r", "db": "system", "bookmarks": ["foobar"]}
+S: FAILURE {"code": "Neo.ClientError.Statement.ArgumentError", "message": "Kaboooom."}
+{?
+    C: PULL {"n": {"Z": "*"}}
+    S: IGNORED
+?}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x1/router_yielding_invalid_request.script
+++ b/tests/stub/routing/scripts/v4x1/router_yielding_invalid_request.script
@@ -1,0 +1,13 @@
+!: BOLT #VERSION#
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "[database]": "*"} {"[mode]": "r", "db": "system", "bookmarks": ["foobar"]}
+S: FAILURE {"code": "Neo.ClientError.Request.Invalid", "message": "Kaboooom."}
+{?
+    C: PULL {"n": {"Z": "*"}}
+    S: IGNORED
+?}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x1/router_yielding_type_error.script
+++ b/tests/stub/routing/scripts/v4x1/router_yielding_type_error.script
@@ -1,0 +1,13 @@
+!: BOLT #VERSION#
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+C: RUN "CALL dbms.routing.getRoutingTable($context, $database)" {"context": #ROUTINGCTX#, "[database]": "*"} {"[mode]": "r", "db": "system", "bookmarks": ["foobar"]}
+S: FAILURE {"code": "Neo.ClientError.Statement.TypeError", "message": "Kaboooom."}
+{?
+    C: PULL {"n": {"Z": "*"}}
+    S: IGNORED
+?}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x3/router_yielding_argument_error.script
+++ b/tests/stub/routing/scripts/v4x3/router_yielding_argument_error.script
@@ -1,0 +1,9 @@
+!: BOLT #VERSION#
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX# , "[patch_bolt]": "*"}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+C: ROUTE #ROUTINGCTX# ["foobar"] "*"
+S: FAILURE {"code": "Neo.ClientError.Statement.ArgumentError", "message": "Kaboooom!"}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x3/router_yielding_invalid_request.script
+++ b/tests/stub/routing/scripts/v4x3/router_yielding_invalid_request.script
@@ -1,0 +1,9 @@
+!: BOLT #VERSION#
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX# , "[patch_bolt]": "*"}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+C: ROUTE #ROUTINGCTX# ["foobar"] "*"
+S: FAILURE {"code": "Neo.ClientError.Request.Invalid", "message": "Kaboooom!"}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x3/router_yielding_type_error.script
+++ b/tests/stub/routing/scripts/v4x3/router_yielding_type_error.script
@@ -1,0 +1,9 @@
+!: BOLT #VERSION#
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX# , "[patch_bolt]": "*"}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+C: ROUTE #ROUTINGCTX# ["foobar"] "*"
+S: FAILURE {"code": "Neo.ClientError.Statement.TypeError", "message": "Kaboooom!"}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x4/router_yielding_argument_error.script
+++ b/tests/stub/routing/scripts/v4x4/router_yielding_argument_error.script
@@ -1,0 +1,9 @@
+!: BOLT #VERSION#
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#, "[patch_bolt]": "*"}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+C: ROUTE #ROUTINGCTX# ["foobar"] {"[db]": "*"}
+S: FAILURE {"code": "Neo.ClientError.Statement.ArgumentError", "message": "Kaboooom."}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x4/router_yielding_invalid_request.script
+++ b/tests/stub/routing/scripts/v4x4/router_yielding_invalid_request.script
@@ -1,0 +1,9 @@
+!: BOLT #VERSION#
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#, "[patch_bolt]": "*"}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+C: ROUTE #ROUTINGCTX# ["foobar"] {"[db]": "*"}
+S: FAILURE {"code": "Neo.ClientError.Request.Invalid", "message": "Kaboooom."}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v4x4/router_yielding_type_error.script
+++ b/tests/stub/routing/scripts/v4x4/router_yielding_type_error.script
@@ -1,0 +1,9 @@
+!: BOLT #VERSION#
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#, "[patch_bolt]": "*"}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+C: ROUTE #ROUTINGCTX# ["foobar"] {"[db]": "*"}
+S: FAILURE {"code": "Neo.ClientError.Statement.TypeError", "message": "Kaboooom."}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v5x0/router_yielding_argument_error.script
+++ b/tests/stub/routing/scripts/v5x0/router_yielding_argument_error.script
@@ -1,0 +1,9 @@
+!: BOLT #VERSION#
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+C: ROUTE #ROUTINGCTX# ["foobar"] {"[db]": "*"}
+S: FAILURE {"code": "Neo.ClientError.Statement.ArgumentError", "message": "Kaboooom."}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v5x0/router_yielding_invalid_request.script
+++ b/tests/stub/routing/scripts/v5x0/router_yielding_invalid_request.script
@@ -1,0 +1,9 @@
+!: BOLT #VERSION#
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+C: ROUTE #ROUTINGCTX# ["foobar"] {"[db]": "*"}
+S: FAILURE {"code": "Neo.ClientError.Request.Invalid", "message": "Kaboooom."}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/scripts/v5x0/router_yielding_type_error.script
+++ b/tests/stub/routing/scripts/v5x0/router_yielding_type_error.script
@@ -1,0 +1,9 @@
+!: BOLT #VERSION#
+
+C: HELLO {"scheme": "basic", "credentials": "c", "principal": "p", "user_agent": "007", "routing": #ROUTINGCTX#}
+S: SUCCESS {"server": "#SERVER_AGENT#", "connection_id": "bolt-123456789"}
+*: RESET
+C: ROUTE #ROUTINGCTX# ["foobar"] {"[db]": "*"}
+S: FAILURE {"code": "Neo.ClientError.Statement.TypeError", "message": "Kaboooom."}
+*: RESET
+?: GOODBYE

--- a/tests/stub/routing/test_routing_v5x0.py
+++ b/tests/stub/routing/test_routing_v5x0.py
@@ -2306,9 +2306,7 @@ class RoutingV5x0(RoutingBase):
             exc.exception.code
         )
 
-    def test_should_fail_with_invalid_route_statement_argument(
-        self
-    ):
+    def test_should_fail_with_invalid_route_statement_argument(self):
         exc = self._test_fast_fail_discover(
             "router_yielding_argument_error.script",
         )
@@ -2318,9 +2316,7 @@ class RoutingV5x0(RoutingBase):
             exc.exception.code
         )
 
-    def test_should_fail_with_invalid_routing_request(
-        self
-    ):
+    def test_should_fail_with_invalid_routing_request(self):
         exc = self._test_fast_fail_discover(
             "router_yielding_invalid_request.script",
         )
@@ -2330,9 +2326,7 @@ class RoutingV5x0(RoutingBase):
             exc.exception.code
         )
 
-    def test_should_fail_with_type_error_request(
-        self
-    ):
+    def test_should_fail_with_type_error_request(self):
         exc = self._test_fast_fail_discover(
             "router_yielding_type_error.script",
         )

--- a/tests/stub/routing/test_routing_v5x0.py
+++ b/tests/stub/routing/test_routing_v5x0.py
@@ -2330,6 +2330,18 @@ class RoutingV5x0(RoutingBase):
             exc.exception.code
         )
 
+    def test_should_fail_with_type_error_request(
+        self
+    ):
+        exc = self._test_fast_fail_discover(
+            "router_yielding_type_error.script",
+        )
+
+        self.assertEqual(
+            "Neo.ClientError.Statement.TypeError",
+            exc.exception.code
+        )
+
     def test_should_read_successfully_from_reachable_db_after_trying_unreachable_db(  # noqa: E501
         self
     ):

--- a/tests/stub/routing/test_routing_v5x0.py
+++ b/tests/stub/routing/test_routing_v5x0.py
@@ -2306,6 +2306,30 @@ class RoutingV5x0(RoutingBase):
             exc.exception.code
         )
 
+    def test_should_fail_with_invalid_route_statement_argument(
+        self
+    ):
+        exc = self._test_fast_fail_discover(
+            "router_yielding_argument_error.script",
+        )
+
+        self.assertEqual(
+            "Neo.ClientError.Statement.ArgumentError",
+            exc.exception.code
+        )
+
+    def test_should_fail_with_invalid_routing_request(
+        self
+    ):
+        exc = self._test_fast_fail_discover(
+            "router_yielding_invalid_request.script",
+        )
+
+        self.assertEqual(
+            "Neo.ClientError.Request.Invalid",
+            exc.exception.code
+        )
+
     def test_should_read_successfully_from_reachable_db_after_trying_unreachable_db(  # noqa: E501
         self
     ):


### PR DESCRIPTION
(Most) drivers will try really hard to fetch a valid RT. This entails going to the next know router if the previous one failed. In this process many errors that are considered unrecoverable in the transaction context are considered retryable. However, a hand full of errors should not be retried to improve user experience. Namely those, that are caused by malformed user-input. Instead of asking all routers if they can make sense of it and ultimately failing with a generic routing update error, it's better to fail fast and give the raw error of the server to the user.

Currently, these errors are
  - `Neo.ClientError.Database.DatabaseNotFound`
 - `Neo.ClientError.Transaction.InvalidBookmark`
 - `Neo.ClientError.Transaction.InvalidBookmarkMixture`

Added three more:
 - `Neo.ClientError.Statement.ArgumentError`: this happens on failed attempts of impersonation (user or permissions missing)
 - `Neo.ClientError.Request.Invalid`: this happens when trying things like impersonating an integer
 - `Neo.ClientError.Statement.TypeError`: this happens when trying things like set a database as an integer in bolt implementation which doesn't support `ROUTE` 