### PR TITLE
Fix bookmark manager related test for executeQuery

### DIFF
--- a/tests/stub/driver_execute_query/scripts/transaction_chaining_custom_bmm.script
+++ b/tests/stub/driver_execute_query/scripts/transaction_chaining_custom_bmm.script
@@ -3,7 +3,7 @@
 A: HELLO {"{}": "*"}
 *: RESET
 
-C: BEGIN {"bookmarks": ["other_db:bm1"], "[db]": "*"}
+C: BEGIN {"bookmarks": ["bm1"], "[db]": "*"}
 S: SUCCESS {}
 C: RUN "CREATE (p:Person {name:$name}) RETURN p.name AS name" {"name": "a person"} {}
 S: SUCCESS {"fields": ["name"]}
@@ -11,20 +11,11 @@ C: PULL {"n": 1000}
 S: RECORD ["a person"]
    SUCCESS {"type": "w"}
 C: COMMIT
-S: SUCCESS {"bookmark": "bm1"}
+S: SUCCESS {"bookmark": "bm2"}
 *: RESET
 
 {{
-    C: BEGIN {"bookmarks": ["other_db:bm1"], "[db]": "*"}
-    S: SUCCESS {}
-    C: RUN "MATCH (p:Person {name:$name}) RETURN p.name AS name" {"name": "a person"} {}
-    S: SUCCESS {"fields": ["name"]}
-    C: PULL {"n": 1000}
-    S: SUCCESS {"type": "r"}
-    C: COMMIT
-    S: SUCCESS {"bookmark": "bm1"}
-----
-    C: BEGIN {"bookmarks{}": ["bm1", "other_db:bm1"], "[db]": "*"}
+    C: BEGIN {"bookmarks{}": ["bm2"], "[db]": "*"}
     S: SUCCESS {}
     C: RUN "MATCH (p:Person {name:$name}) RETURN p.name AS name" {"name": "a person"} {}
     S: SUCCESS {"fields": ["name"]}
@@ -33,6 +24,15 @@ S: SUCCESS {"bookmark": "bm1"}
        SUCCESS {"type": "r"}
     C: COMMIT
     S: SUCCESS {"bookmark": "bm2"}
+----
+    C: BEGIN {"{}": "*"}
+    S: SUCCESS {}
+    C: RUN "MATCH (p:Person {name:$name}) RETURN p.name AS name" {"name": "a person"} {}
+    S: SUCCESS {"fields": ["name"]}
+    C: PULL {"n": 1000}
+    S: SUCCESS {"type": "r"}
+    C: COMMIT
+    S: SUCCESS {"bookmark": "bm1"}
 }}
 *: RESET
 

--- a/tests/stub/driver_execute_query/test_driver_execute_query.py
+++ b/tests/stub/driver_execute_query/test_driver_execute_query.py
@@ -205,7 +205,7 @@ class TestDriverExecuteQuery(TestkitTestCase):
         bookmark_manager = BookmarkManager(
             self._backend,
             config=Neo4jBookmarkManagerConfig(
-                initial_bookmarks={"other_db": ["other_db:bm1"]}
+                initial_bookmarks=["bm1"]
             )
         )
         self._driver = self._new_driver()


### PR DESCRIPTION
Since the test was conceived, the bookmark manager was altered to not track bookmarks per database.