### PR TITLE
Fix issues with linter

### DIFF
--- a/boltstub/parsing.py
+++ b/boltstub/parsing.py
@@ -154,7 +154,8 @@ class BangLine(Line):
         if self._type == BangLine.TYPE_AUTO:
             if self._arg in ctx.auto:
                 warnings.warn(
-                    'Specified AUTO for "{}" multiple times'.format(self._arg)
+                    'Specified AUTO for "{}" multiple times'.format(self._arg),
+                    stacklevel=2
                 )
             ctx.auto.add(self._arg)
             ctx.bang_lines["auto"][self._arg] = self
@@ -165,23 +166,33 @@ class BangLine(Line):
             ctx.bang_lines["bolt_version"] = self
         elif self._type == BangLine.TYPE_RESTART:
             if ctx.restarting:
-                warnings.warn('Specified "!: ALLOW RESTART" multiple times')
+                warnings.warn(
+                    'Specified "!: ALLOW RESTART" multiple times',
+                    stacklevel=2
+                )
             ctx.restarting = True
             ctx.bang_lines["restarting"] = self
         elif self._type == BangLine.TYPE_CONCURRENT:
             if ctx.concurrent:
-                warnings.warn('Specified "!: ALLOW CONCURRENT" multiple times')
+                warnings.warn(
+                    'Specified "!: ALLOW CONCURRENT" multiple times',
+                    stacklevel=2
+                )
             ctx.concurrent = True
             ctx.bang_lines["concurrent"] = self
         elif self._type == BangLine.TYPE_HANDSHAKE:
             if ctx.handshake:
-                warnings.warn('Specified "!: HANDSHAKE" multiple times')
+                warnings.warn(
+                    'Specified "!: HANDSHAKE" multiple times',
+                    stacklevel=2
+                )
             ctx.handshake = self._arg
             ctx.bang_lines["handshake"] = self
         if ctx.restarting and ctx.concurrent:
             warnings.warn(
                 'Specified "!: ALLOW RESTART" and "!: ALLOW CONCURRENT" '
-                "(concurrent scripts are implicitly restarting)"
+                "(concurrent scripts are implicitly restarting)",
+                stacklevel=2
             )
 
 

--- a/boltstub/parsing.py
+++ b/boltstub/parsing.py
@@ -153,9 +153,8 @@ class BangLine(Line):
     def update_context(self, ctx: "ScriptContext"):
         if self._type == BangLine.TYPE_AUTO:
             if self._arg in ctx.auto:
-                warnings.warn(
-                    'Specified AUTO for "{}" multiple times'.format(self._arg),
-                    stacklevel=2
+                warnings.warn(  # noqa: B028
+                    f'Specified AUTO for "{self._arg}" multiple times'
                 )
             ctx.auto.add(self._arg)
             ctx.bang_lines["auto"][self._arg] = self
@@ -166,33 +165,29 @@ class BangLine(Line):
             ctx.bang_lines["bolt_version"] = self
         elif self._type == BangLine.TYPE_RESTART:
             if ctx.restarting:
-                warnings.warn(
-                    'Specified "!: ALLOW RESTART" multiple times',
-                    stacklevel=2
+                warnings.warn(  # noqa: B028
+                    'Specified "!: ALLOW RESTART" multiple times'
                 )
             ctx.restarting = True
             ctx.bang_lines["restarting"] = self
         elif self._type == BangLine.TYPE_CONCURRENT:
             if ctx.concurrent:
-                warnings.warn(
-                    'Specified "!: ALLOW CONCURRENT" multiple times',
-                    stacklevel=2
+                warnings.warn(  # noqa: B028
+                    'Specified "!: ALLOW CONCURRENT" multiple times'
                 )
             ctx.concurrent = True
             ctx.bang_lines["concurrent"] = self
         elif self._type == BangLine.TYPE_HANDSHAKE:
             if ctx.handshake:
-                warnings.warn(
-                    'Specified "!: HANDSHAKE" multiple times',
-                    stacklevel=2
+                warnings.warn(  # noqa: B028
+                    'Specified "!: HANDSHAKE" multiple times'
                 )
             ctx.handshake = self._arg
             ctx.bang_lines["handshake"] = self
         if ctx.restarting and ctx.concurrent:
-            warnings.warn(
+            warnings.warn(  # noqa: B028
                 'Specified "!: ALLOW RESTART" and "!: ALLOW CONCURRENT" '
-                "(concurrent scripts are implicitly restarting)",
-                stacklevel=2
+                "(concurrent scripts are implicitly restarting)"
             )
 
 

--- a/driver/wait_for_port.py
+++ b/driver/wait_for_port.py
@@ -10,7 +10,7 @@ def wait_for_port(address, port):
         try:
             with socket.create_connection((address, port), timeout):
                 return True
-        except OSError or ConnectionRefusedError:
+        except OSError:
             time.sleep(0.1)
             if time.perf_counter() - start > timeout:
                 print("ERROR: Timeout while waiting for port %s on %s"

--- a/nutkit/protocol/cypher.py
+++ b/nutkit/protocol/cypher.py
@@ -153,7 +153,8 @@ class Node:
         if elementId is None:
             import warnings
             warnings.warn(
-                "Backend needs to support new style IDs for nodes"
+                "Backend needs to support new style IDs for nodes",
+                stacklevel=2
             )
         self.id = id
         self.labels = labels
@@ -190,7 +191,8 @@ class Relationship:
         if None in (elementId, startNodeElementId, endNodeElementId):
             import warnings
             warnings.warn(
-                "Backend needs to support new style IDs for relationships"
+                "Backend needs to support new style IDs for relationships",
+                stacklevel=2
             )
         self.id = id
         self.startNodeId = startNodeId

--- a/nutkit/protocol/cypher.py
+++ b/nutkit/protocol/cypher.py
@@ -152,9 +152,8 @@ class Node:
         # TODO: remove once all backends support new style relationships
         if elementId is None:
             import warnings
-            warnings.warn(
-                "Backend needs to support new style IDs for nodes",
-                stacklevel=2
+            warnings.warn(  # noqa: B028
+                "Backend needs to support new style IDs for nodes"
             )
         self.id = id
         self.labels = labels
@@ -190,9 +189,8 @@ class Relationship:
         # TODO: remove once all backends support new style relationships
         if None in (elementId, startNodeElementId, endNodeElementId):
             import warnings
-            warnings.warn(
-                "Backend needs to support new style IDs for relationships",
-                stacklevel=2
+            warnings.warn(  # noqa: B028
+                "Backend needs to support new style IDs for relationships"
             )
         self.id = id
         self.startNodeId = startNodeId

--- a/nutkit/protocol/responses.py
+++ b/nutkit/protocol/responses.py
@@ -312,7 +312,8 @@ class Summary:
                 import warnings
                 warnings.warn(
                     "Backend supports address field in Summary.serverInfo. "
-                    "Remove the backwards compatibility check!"
+                    "Remove the backwards compatibility check!",
+                    stacklevel=2
                 )
             else:
                 data["serverInfo"]["address"] = AnyAddress()
@@ -328,14 +329,16 @@ class Summary:
                 import warnings
                 warnings.warn(
                     "Backend supports well-formatted counter. "
-                    "Remove the backwards compatibility check!"
+                    "Remove the backwards compatibility check!",
+                    stacklevel=2
                 )
         if get_driver_name() in ["javascript", "go", "dotnet"]:
             if "counters" in data:
                 import warnings
                 warnings.warn(
                     "Backend supports counters field in Summary. "
-                    "Remove the backwards compatibility check!"
+                    "Remove the backwards compatibility check!",
+                    stacklevel=2
                 )
             else:
                 data["counters"] = {
@@ -358,7 +361,8 @@ class Summary:
                 import warnings
                 warnings.warn(
                     "Backend supports query field in Summary. "
-                    "Remove the backwards compatibility check!"
+                    "Remove the backwards compatibility check!",
+                    stacklevel=2
                 )
             else:
                 data["query"] = {
@@ -373,7 +377,8 @@ class Summary:
                     import warnings
                     warnings.warn(
                         "Backend supports %s field in Summary. "
-                        "Remove the backwards compatibility check!" % field
+                        "Remove the backwards compatibility check!" % field,
+                        stacklevel=2
                     )
                 else:
                     data[field] = None

--- a/nutkit/protocol/responses.py
+++ b/nutkit/protocol/responses.py
@@ -310,10 +310,9 @@ class Summary:
         if get_driver_name() in ["javascript", "go", "dotnet", "ruby"]:
             if "address" in data["serverInfo"]:
                 import warnings
-                warnings.warn(
+                warnings.warn(  # noqa: B028
                     "Backend supports address field in Summary.serverInfo. "
-                    "Remove the backwards compatibility check!",
-                    stacklevel=2
+                    "Remove the backwards compatibility check!"
                 )
             else:
                 data["serverInfo"]["address"] = AnyAddress()
@@ -327,18 +326,16 @@ class Summary:
                 del data["counters"]
             else:
                 import warnings
-                warnings.warn(
+                warnings.warn(  # noqa: B028
                     "Backend supports well-formatted counter. "
-                    "Remove the backwards compatibility check!",
-                    stacklevel=2
+                    "Remove the backwards compatibility check!"
                 )
         if get_driver_name() in ["javascript", "go", "dotnet"]:
             if "counters" in data:
                 import warnings
-                warnings.warn(
+                warnings.warn(  # noqa: B028
                     "Backend supports counters field in Summary. "
-                    "Remove the backwards compatibility check!",
-                    stacklevel=2
+                    "Remove the backwards compatibility check!"
                 )
             else:
                 data["counters"] = {
@@ -359,10 +356,9 @@ class Summary:
                 }
             if "query" in data:
                 import warnings
-                warnings.warn(
+                warnings.warn(  # noqa: B028
                     "Backend supports query field in Summary. "
-                    "Remove the backwards compatibility check!",
-                    stacklevel=2
+                    "Remove the backwards compatibility check!"
                 )
             else:
                 data["query"] = {
@@ -375,10 +371,9 @@ class Summary:
             ):
                 if field in data:
                     import warnings
-                    warnings.warn(
+                    warnings.warn(  # noqa: B028
                         "Backend supports %s field in Summary. "
-                        "Remove the backwards compatibility check!" % field,
-                        stacklevel=2
+                        "Remove the backwards compatibility check!" % field
                     )
                 else:
                     data[field] = None

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -135,7 +135,7 @@ def get_driver_features(backend):
         print("features", features)
         return features
     except (OSError, protocol.BaseError) as e:
-        warnings.warn("Could not fetch FeatureList: %s" % e)
+        warnings.warn("Could not fetch FeatureList: %s" % e, stacklevel=2)
         return set()
 
 

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -135,7 +135,7 @@ def get_driver_features(backend):
         print("features", features)
         return features
     except (OSError, protocol.BaseError) as e:
-        warnings.warn("Could not fetch FeatureList: %s" % e, stacklevel=2)
+        warnings.warn(f"Could not fetch FeatureList: {e}")  # noqa: B028
         return set()
 
 


### PR DESCRIPTION
The warning should be log with stacktrace equals to 2, which doesn't make sense in the context. So, the lint for rule B028 was muted.

The except block in wait_for_port was triggering B030 since the construction was not quite right. Changing it to `except (OSError, ConnectionRefusedError):` caused a redundancy since `ConnectionRefusedError` extends `OSError`, so the except block could be reduce to treat only the base class.