### PR TITLE
error mapping for ruby

### DIFF
--- a/tests/stub/authorization/test_authorization.py
+++ b/tests/stub/authorization/test_authorization.py
@@ -77,6 +77,9 @@ class AuthorizationBase(TestkitTestCase):
         elif driver == "java":
             expected_type = \
                 "org.neo4j.driver.exceptions.TokenExpiredRetryableException"
+        elif driver == "ruby":
+            expected_type = \
+                "Neo4j::Driver::Exceptions::TokenExpiredRetryableException"
         else:
             self.fail("no error mapping is defined for %s driver" % driver)
         if expected_type is not None:
@@ -108,6 +111,11 @@ class AuthorizationBase(TestkitTestCase):
         elif driver in ["java"]:
             self.assertEqual(
                 "org.neo4j.driver.exceptions.UnsupportedFeatureException",
+                error.errorType
+            )
+        elif driver in ["ruby"]:
+            self.assertEqual(
+                "Neo4j::Driver::Exceptions::UnsupportedFeatureException",
                 error.errorType
             )
         elif driver in ["go"]:

--- a/tests/stub/iteration/test_result_scope.py
+++ b/tests/stub/iteration/test_result_scope.py
@@ -44,6 +44,11 @@ class TestResultScope(TestkitTestCase):
                 exc.errorType,
                 "org.neo4j.driver.exceptions.ResultConsumedException"
             )
+        elif driver in ["ruby"]:
+            self.assertEqual(
+                exc.errorType,
+                "Neo4j::Driver::Exceptions::ResultConsumedException"
+            )
         elif driver in ["dotnet"]:
             self.assertEqual(exc.errorType, "ResultConsumedError")
         elif driver in ["javascript"]:
@@ -67,6 +72,11 @@ class TestResultScope(TestkitTestCase):
             self.assertEqual(
                 exc.errorType,
                 "org.neo4j.driver.exceptions.ResultConsumedException"
+            )
+        elif driver in ["ruby"]:
+            self.assertEqual(
+                exc.errorType,
+                "Neo4j::Driver::Exceptions::ResultConsumedException"
             )
         elif driver in ["dotnet"]:
             self.assertEqual(exc.errorType, "ResultConsumedError")

--- a/tests/stub/tx_lifetime/test_tx_lifetime.py
+++ b/tests/stub/tx_lifetime/test_tx_lifetime.py
@@ -46,6 +46,9 @@ class TestTxLifetime(TestkitTestCase):
         elif driver in ["java"]:
             self.assertEqual(exc.errorType,
                              "org.neo4j.driver.exceptions.ClientException")
+        elif driver in ["ruby"]:
+            self.assertEqual(exc.errorType,
+                             "Neo4j::Driver::Exceptions::ClientException")
         else:
             self.fail("no error mapping is defined for %s driver" % driver)
 


### PR DESCRIPTION
@robsdedude it would be great if we could come up with something to avoid this duplication. For example some error mapping file in the driver's testkit directory that would be evaluated by default in all the error checks. I know you have been planning something for a long time. But even something temporary would be helpful. I will gladly remove all the `elif driver == "ruby":` from the code and change it again on our side when you come up with the final solution 