### PR TITLE
Fix integration tests with nightly dev servers

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,11 +122,11 @@ def initialise_configurations(settings):
             # nightly build of official backwards-compatible version
             ("4.4",    "4.4",      True,        True,     "neo4j", 60),
             # latest version
-            ("5.7",    "dev",      False,       False,    "bolt",   0),
-            ("5.7",    "dev",      False,       False,    "neo4j",  0),
-            ("5.7",    "dev",      True,        False,    "bolt",  90),
-            ("5.7",    "dev",      True,        False,    "neo4j",  0),
-            ("5.7",    "dev",      True,        True,     "neo4j", 90),
+            ("5.dev",  "dev",      False,       False,    "bolt",   0),
+            ("5.dev",  "dev",      False,       False,    "neo4j",  0),
+            ("5.dev",  "dev",      True,        False,    "bolt",  90),
+            ("5.dev",  "dev",      True,        False,    "neo4j",  0),
+            ("5.dev",  "dev",      True,        True,     "neo4j", 90),
         )
     ]
 

--- a/neo4j.py
+++ b/neo4j.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 import os
 from os.path import join
+import re
 
 import docker
 
@@ -36,8 +37,12 @@ class Standalone:
         self._container = None
         self._hostname = hostname
         self._port = port
-        self._version = tuple(int(i) for i in version.split("."))
-        assert len(self._version) == 2
+        match = re.match(r"(\d+)\.dev", version)
+        if match:
+            self._version = (int(match.group(1)), float("inf"))
+        else:
+            self._version = tuple(int(i) for i in version.split("."))
+            assert len(self._version) == 2
         self._edition = edition
 
     def start(self, network):
@@ -122,8 +127,12 @@ class Core:
         self._index = index
         self._artifacts_path = join(artifacts_path, self.name)
         self._container = None
-        self._version = tuple(int(i) for i in version.split("."))
-        assert len(self._version) == 2
+        match = re.match(r"(\d+)\.dev", version)
+        if match:
+            self._version = (int(match.group(1)), float("inf"))
+        else:
+            self._version = tuple(int(i) for i in version.split("."))
+            assert len(self._version) == 2
 
     def start(self, image, initial_members, network):
         env_map = {

--- a/tests/neo4j/shared.py
+++ b/tests/neo4j/shared.py
@@ -94,6 +94,10 @@ class ServerInfo:
             raise ValueError(
                 "We can't predict the server's agent string for aura!"
             )
+        if re.match(r"(\d+)\.dev", self.version):
+            raise ValueError(
+                "We can't predict the server's agent string for dev versions!"
+            )
         return "Neo4j/" + self.version
 
     @property
@@ -102,7 +106,11 @@ class ServerInfo:
 
     @property
     def max_protocol_version(self):
-        version = tuple(int(i) for i in self.version.split(".")[:2])
+        match = re.match(r"(\d+)\.dev", self.version)
+        if match:
+            version = (int(match.group(1)), float("inf"))
+        else:
+            version = tuple(int(i) for i in self.version.split(".")[:2])
         if version >= (5, 7):
             return "5.2"
         if version >= (5, 5):

--- a/tests/neo4j/suites.py
+++ b/tests/neo4j/suites.py
@@ -1,6 +1,7 @@
 """Defines suites of test to run in different setups."""
 
 import os
+import re
 import sys
 import unittest
 
@@ -56,12 +57,16 @@ if __name__ == "__main__":
         print("Missing suite name parameter")
         sys.exit(-10)
     name = sys.argv[1]
-    try:
-        version = tuple(int(i) for i in name.split("."))
-    except ValueError:
-        print(f"Invalid suite name: {name}. "
-              "Should be X.Y for X and Y integer.")
-        sys.exit(-2)
+    match = re.match(r"(\d+)\.dev", name)
+    if match:
+        version = (int(match.group(1)), float("inf"))
+    else:
+        try:
+            version = tuple(int(i) for i in name.split("."))
+        except ValueError:
+            print(f"Invalid suite name: {name}. "
+                  "Should be X.Y for X and Y integer.")
+            sys.exit(-2)
     if version >= (5, 7):
         suite = suite_5x7
     elif version >= (5, 5):

--- a/tests/neo4j/test_summary.py
+++ b/tests/neo4j/test_summary.py
@@ -109,6 +109,10 @@ class TestSummary(TestkitTestCase):
         if server_info.edition == "aura":
             # for aura the agent string tends to be all over the place...
             self.assertTrue(version.startswith("Neo4j/"))
+        elif re.match(r"(\d+)\.dev", server_info.version):
+            self.assertTrue(version.startswith(
+                "Neo4j/" + server_info.version.split(".")[0]
+            ))
         else:
             version = ".".join(summary.server_info.agent.split(".")[:2])
             self.assertEqual(version, get_server_info().server_agent)


### PR DESCRIPTION
In particular the agent string check would break with every version bump in the dev build.