### PR TITLE
Improve test output in TeamCity

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,11 +24,7 @@ import driver
 import neo4j
 import runner
 import settings
-from tests.testenv import (
-    begin_test_suite,
-    end_test_suite,
-    in_teamcity,
-)
+from tests.testenv import in_teamcity
 
 # TODO: Move to docker.py
 networks = ["testkit_1", "testkit_2"]
@@ -336,9 +332,9 @@ def main(settings, configurations):
     print("Finished building driver and test backend")
 
     if test_flags["UNIT_TESTS"]:
-        begin_test_suite("Unit tests")
+        print(">>> Start test suite: driver's unit tests")
         run_fail_wrapper(driver_container.run_unit_tests)
-        end_test_suite("Unit tests")
+        print(">>> End test suite: driver's unit tests")
 
     print("Start test backend in driver container")
     driver_container.start_backend(backend_artifacts_path)

--- a/runner.py
+++ b/runner.py
@@ -81,7 +81,7 @@ class Container:
             "TEST_NEO4J_CLUSTER": neo4j_config.cluster
         })
         self._container.exec(
-            ["python3", "-m", "tests.neo4j.suites", suite],
+            ["python3", "-m", "tests.neo4j.suites", suite, neo4j_config.name],
             env_map=self._env
         )
 
@@ -98,7 +98,10 @@ class Container:
             self._env.update({"TEST_NEO4J_HOST": "host.docker.internal"})
         suite = os.environ.get("TEST_NEO4J_VERSION", "4.4")
         self._container.exec(
-            ["python3", "-m", "tests.neo4j.suites", suite],
+            [
+                "python3", "-m", "tests.neo4j.suites", suite,
+                f"external-{suite}"
+            ],
             env_map=self._env
         )
 

--- a/teamcity/__init__.py
+++ b/teamcity/__init__.py
@@ -1,14 +1,5 @@
-import os
-
-from teamcity.testresult import (
-    escape,
-    TeamCityTestResult,
+from .env import in_teamcity
+from .testresult import (
+    team_city_test_result,
+    test_kit_basic_test_result,
 )
-
-
-def evaluate_env_variable():
-    env = os.environ.get("TEST_IN_TEAMCITY", "False").upper()
-    return env == "TRUE" or env == "1"
-
-
-in_teamcity = evaluate_env_variable()

--- a/teamcity/env.py
+++ b/teamcity/env.py
@@ -1,0 +1,9 @@
+import os
+
+
+def evaluate_env_variable():
+    return (os.environ.get("TEST_IN_TEAMCITY", "").upper()
+            in ("TRUE", "1", "Y", "YES", "ON"))
+
+
+in_teamcity = evaluate_env_variable()

--- a/teamcity/testresult.py
+++ b/teamcity/testresult.py
@@ -1,5 +1,7 @@
 import unittest
 
+from .env import in_teamcity
+
 
 def escape(s):
     s = s.replace("|", "||")
@@ -11,29 +13,79 @@ def escape(s):
     return s
 
 
-class TeamCityTestResult(unittest.TextTestResult):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+def test_kit_basic_test_result(name):
+    class TestKitBasicTestResult(unittest.TextTestResult):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
 
-    def startTest(self, test):  # noqa: N802  # noqa: N802
-        print("##teamcity[testStarted name='%s']" % escape(str(test)))
-        return super().startTest(test)
+        def startTestRun(self):  # noqa: N802
+            if in_teamcity:
+                self.stream.writeln("##teamcity[testSuiteStarted name='%s']"
+                                    % escape(name))
+            else:
+                self.stream.writeln(">>> Start test suite: %s" % name)
+            self.stream.flush()
 
-    def stopTest(self, test):  # noqa: N802
-        print("##teamcity[testFinished name='%s']\n" % escape(str(test)))
-        return super().stopTest(test)
+        def stopTestRun(self):  # noqa: N802
+            if in_teamcity:
+                self.stream.writeln("##teamcity[testSuiteFinished name='%s']"
+                                    % escape(name))
+            else:
+                self.stream.writeln(">>> End test suite: %s" % name)
+            self.stream.flush()
 
-    def addError(self, test, err):  # noqa: N802
-        print("##teamcity[testFailed name='%s' message='%s' details='%s']"
-              % (escape(str(test)), escape(str(err[1])), escape(str(err[2]))))
-        return super().addError(test, err)
+    return TestKitBasicTestResult
 
-    def addFailure(self, test, err):  # noqa: N802
-        print("##teamcity[testFailed name='%s' message='%s' details='%s']"
-              % (escape(str(test)), escape(str(err[1])), escape(str(err[2]))))
-        return super().addFailure(test, err)
 
-    def addSkip(self, test, reason):  # noqa: N802
-        print("##teamcity[testIgnored name='%s' message='%s']"
-              % (escape(str(test)), escape(str(reason))))
-        return super().addSkip(test, reason)
+def team_city_test_result(name):
+    base = test_kit_basic_test_result(name)
+
+    class TeamCityTestResult(base):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+        def startTest(self, test):  # noqa: N802  # noqa: N802
+            self.stream.writeln("##teamcity[testStarted name='%s']"
+                                % escape(str(test)))
+            self.stream.flush()
+            super().startTest(test)
+
+        def stopTest(self, test):  # noqa: N802
+            super().stopTest(test)
+            self.stream.writeln("##teamcity[testFinished name='%s']\n"
+                                % escape(str(test)))
+            self.stream.flush()
+
+        def addError(self, test, err):  # noqa: N802
+            self.stream.writeln(
+                "##teamcity[testFailed name='%s' message='%s' details='%s']"
+                % (escape(str(test)), escape(str(err[1])), escape(str(err[2])))
+            )
+            self.stream.flush()
+            super().addError(test, err)
+            self.stream.write("%s" % self.errors[-1][1])
+            self.stream.flush()
+
+        def addFailure(self, test, err):  # noqa: N802
+            self.stream.writeln(
+                "##teamcity[testFailed name='%s' message='%s' details='%s']"
+                % (escape(str(test)), escape(str(err[1])), escape(str(err[2])))
+            )
+            self.stream.flush()
+            super().addFailure(test, err)
+            self.stream.write("%s" % self.failures[-1][1])
+            self.stream.flush()
+
+        def addSkip(self, test, reason):  # noqa: N802
+            self.stream.writeln(
+                "##teamcity[testIgnored name='%s' message='%s']"
+                % (escape(str(test)), escape(str(reason)))
+            )
+            self.stream.flush()
+            super().addSkip(test, reason)
+
+        def printErrors(self):  # noqa: N802
+            # errors and failures are printed already at the end of the tests
+            pass
+
+    return TeamCityTestResult

--- a/tests/neo4j/suites.py
+++ b/tests/neo4j/suites.py
@@ -6,11 +6,7 @@ import sys
 import unittest
 
 from tests.neo4j.shared import env_neo4j_version
-from tests.testenv import (
-    begin_test_suite,
-    end_test_suite,
-    get_test_result_class,
-)
+from tests.testenv import get_test_result_class
 
 #######################
 # Suite for Neo4j 4.2 #
@@ -56,15 +52,17 @@ if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("Missing suite name parameter")
         sys.exit(-10)
-    name = sys.argv[1]
-    match = re.match(r"(\d+)\.dev", name)
+    version = sys.argv[1]
+    if len(sys.argv) > 2:
+        name = sys.argv[2]
+    match = re.match(r"(\d+)\.dev", version)
     if match:
         version = (int(match.group(1)), float("inf"))
     else:
         try:
-            version = tuple(int(i) for i in name.split("."))
+            version = tuple(int(i) for i in version.split("."))
         except ValueError:
-            print(f"Invalid suite name: {name}. "
+            print(f"Invalid suite version: {version}. "
                   "Should be X.Y for X and Y integer.")
             sys.exit(-2)
     if version >= (5, 7):
@@ -80,17 +78,17 @@ if __name__ == "__main__":
     elif version >= (4, 2):
         suite = suite_4x2
     else:
-        print("Unknown suite name: " + name)
+        print(f"Unknown suite version: {version}")
         sys.exit(-1)
 
     import os
-    os.environ[env_neo4j_version] = os.environ.get(env_neo4j_version, name)
+    os.environ[env_neo4j_version] = os.environ.get(env_neo4j_version, version)
 
-    suite_name = "Integration tests " + name
-    begin_test_suite(suite_name)
-    runner = unittest.TextTestRunner(resultclass=get_test_result_class(),
-                                     verbosity=100)
+    suite_name = f"Integration tests {name}"
+    runner = unittest.TextTestRunner(
+        resultclass=get_test_result_class(suite_name),
+        verbosity=100, stream=sys.stdout,
+    )
     result = runner.run(suite)
-    end_test_suite(suite_name)
     if result.errors or result.failures:
         sys.exit(-1)

--- a/tests/stub/suites.py
+++ b/tests/stub/suites.py
@@ -4,11 +4,7 @@ import os
 import sys
 import unittest
 
-from tests.testenv import (
-    begin_test_suite,
-    end_test_suite,
-    get_test_result_class,
-)
+from tests.testenv import get_test_result_class
 
 loader = unittest.TestLoader()
 
@@ -23,10 +19,10 @@ stub_suite.addTest(loader.discover(
 
 if __name__ == "__main__":
     suite_name = "Stub tests"
-    begin_test_suite(suite_name)
-    runner = unittest.TextTestRunner(resultclass=get_test_result_class(),
-                                     verbosity=100)
+    runner = unittest.TextTestRunner(
+        resultclass=get_test_result_class(suite_name),
+        verbosity=100, stream=sys.stdout,
+    )
     result = runner.run(stub_suite)
-    end_test_suite(suite_name)
     if result.errors or result.failures:
         sys.exit(-1)

--- a/tests/testenv.py
+++ b/tests/testenv.py
@@ -1,25 +1,11 @@
 from teamcity import (
-    escape,
     in_teamcity,
-    TeamCityTestResult,
+    team_city_test_result,
+    test_kit_basic_test_result,
 )
 
 
-def begin_test_suite(name):
-    if in_teamcity:
-        print("##teamcity[testSuiteStarted name='%s']" % escape(name))
-    else:
-        print(">>> Start test suite: %s" % name)
-
-
-def end_test_suite(name):
-    if in_teamcity:
-        print("##teamcity[testSuiteFinished name='%s']" % escape(name))
-    else:
-        print(">>> End test suite: %s" % name)
-
-
-def get_test_result_class():
+def get_test_result_class(name):
     if not in_teamcity:
-        return None
-    return TeamCityTestResult
+        return test_kit_basic_test_result(name)
+    return team_city_test_result(name)

--- a/tests/tls/suites.py
+++ b/tests/tls/suites.py
@@ -3,11 +3,7 @@
 import sys
 import unittest
 
-from tests.testenv import (
-    begin_test_suite,
-    end_test_suite,
-    get_test_result_class,
-)
+from tests.testenv import get_test_result_class
 from tests.tls import (
     test_secure_scheme,
     test_self_signed_scheme,
@@ -25,10 +21,10 @@ tls_suite.addTests(loader.loadTestsFromModule(test_unsecure_scheme))
 
 if __name__ == "__main__":
     suite_name = "TLS tests"
-    begin_test_suite(suite_name)
-    runner = unittest.TextTestRunner(resultclass=get_test_result_class(),
-                                     verbosity=100)
+    runner = unittest.TextTestRunner(
+        resultclass=get_test_result_class(suite_name),
+        verbosity=100, stream=sys.stdout,
+    )
     result = runner.run(tls_suite)
-    end_test_suite(suite_name)
     if result.errors or result.failures:
         sys.exit(-1)


### PR DESCRIPTION
Multiple improvements:

The first one is that `unittest.TextTestResult` by default logs to stderr (or generally to what ever stream the test runner tells it to), but our custom `TestResult` only ever used `print` with no `file` parameter. So it was always going to stdout. And apparently TC is too dumb to join stdout and stderr without stuff getting all messed up. Or maybe it was because the streams weren't flushed properly. Either way, that looks better now.

Secondly, I changed the custom `TestResult` to print errors in place.

Finally, before, the integration test suites were just called `5.3` etc. But TestKit potentially runs multiple suites with the same server version (but cluster vs single instance, bolt vs neo4j scheme, EE vs CE, ...). So now the suites name contains all that information as well.