### PR TITLE
ignore serve_forever throwing 10038 error on windows

### DIFF
--- a/boltstub/__init__.py
+++ b/boltstub/__init__.py
@@ -157,20 +157,16 @@ class BoltStubService:
 
     def start(self):
         if self.script.context.restarting or self.script.context.concurrent:
-            self.serve_forever()
+            self.server.serve_forever()
         else:
             self.server.handle_request()
             self.server.server_close()
 
-    def serve_forever(self):
-        try:
-            self.server.serve_forever()
-        except OSError as err:
-            if err.winerror != 10038:
-                raise
-
     def _close_socket(self):
-        self.server.socket.close()
+        if self.script.context.restarting or self.script.context.concurrent:
+            self.server.shutdown()
+        else:
+            self.server.socket.close()
 
     def _stop_server(self):
         if self.script.context.restarting or self.script.context.concurrent:

--- a/boltstub/__init__.py
+++ b/boltstub/__init__.py
@@ -157,10 +157,17 @@ class BoltStubService:
 
     def start(self):
         if self.script.context.restarting or self.script.context.concurrent:
-            self.server.serve_forever()
+            self.serve_forever()
         else:
             self.server.handle_request()
             self.server.server_close()
+
+    def serve_forever(self):
+        try:
+            self.server.serve_forever()
+        except OSError as err:
+            if err.winerror != 10038:
+                raise
 
     def _close_socket(self):
         self.server.socket.close()


### PR DESCRIPTION
Add an except for an error, further investigation as why this works is required.
```
Traceback (most recent call last):
  File "C:\code\testkit\boltstub\__init__.py", line 167, in serve_forever
    self.server.serve_forever()
  File "C:\Program Files\Python39\lib\socketserver.py", line 232, in serve_forever
    ready = selector.select(poll_interval)
  File "C:\Program Files\Python39\lib\selectors.py", line 324, in select
    r, w, _ = self._select(self._readers, self._writers, [], timeout)
  File "C:\Program Files\Python39\lib\selectors.py", line 315, in _select
    r, w, x = select.select(r, w, w, timeout)
OSError: [WinError 10038] An operation was attempted on something that is not a socket
```
stack, ignoring it seems to have no effect.