### PR TITLE
Allow new connection in test_sequence_of_writing_and_reading_tx

### DIFF
--- a/tests/stub/bookmarks/scripts/v3/send_and_receive_bookmark_two_write_tx.script
+++ b/tests/stub/bookmarks/scripts/v3/send_and_receive_bookmark_two_write_tx.script
@@ -1,23 +1,38 @@
 !: BOLT 3
+!: ALLOW CONCURRENT
 
 A: HELLO {"{}": "*"}
 *: RESET
-C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx42"]}
-S: SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name AS name" {} {}
-   PULL_ALL
-S: SUCCESS {"fields": ["name"]}
-   SUCCESS {}
-C: COMMIT
-S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx4242"}
-*: RESET
-C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx4242"]}
-S: SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name AS name" {} {}
-   PULL_ALL
-S: SUCCESS {"fields": ["name"]}
-   SUCCESS {}
-C: COMMIT
-S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx424242"}
-*: RESET
+{{
+    C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx42"]}
+    S: SUCCESS {}
+    C: RUN "MATCH (n) RETURN n.name AS name" {} {}
+       PULL_ALL
+    S: SUCCESS {"fields": ["name"]}
+       SUCCESS {}
+    C: COMMIT
+    S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx4242"}
+    *: RESET
+    {?
+        C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx4242"]}
+        S: SUCCESS {}
+        C: RUN "MATCH (n) RETURN n.name AS name" {} {}
+           PULL_ALL
+        S: SUCCESS {"fields": ["name"]}
+           SUCCESS {}
+        C: COMMIT
+        S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx424242"}
+        *: RESET
+    ?}
+----
+    C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx4242"]}
+    S: SUCCESS {}
+    C: RUN "MATCH (n) RETURN n.name AS name" {} {}
+       PULL_ALL
+    S: SUCCESS {"fields": ["name"]}
+       SUCCESS {}
+    C: COMMIT
+    S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx424242"}
+    *: RESET
+}}
 ?: GOODBYE

--- a/tests/stub/bookmarks/scripts/v4/send_and_receive_bookmark_two_write_tx.script
+++ b/tests/stub/bookmarks/scripts/v4/send_and_receive_bookmark_two_write_tx.script
@@ -1,23 +1,38 @@
 !: BOLT 4.4
+!: ALLOW CONCURRENT
 
 A: HELLO {"{}": "*"}
 *: RESET
-C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx42"]}
-S: SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name AS name" {} {}
-S: SUCCESS {"fields": ["name"]}
-C: PULL {"n": 1000}
-S: SUCCESS {}
-C: COMMIT
-S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx4242"}
-*: RESET
-C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx4242"]}
-S: SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name AS name" {} {}
-S: SUCCESS {"fields": ["name"]}
-C: PULL {"n": 1000}
-S: SUCCESS {}
-C: COMMIT
-S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx424242"}
-*: RESET
+{{
+    C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx42"]}
+    S: SUCCESS {}
+    C: RUN "MATCH (n) RETURN n.name AS name" {} {}
+    S: SUCCESS {"fields": ["name"]}
+    C: PULL {"n": 1000}
+    S: SUCCESS {}
+    C: COMMIT
+    S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx4242"}
+    *: RESET
+    {?
+        C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx4242"]}
+        S: SUCCESS {}
+        C: RUN "MATCH (n) RETURN n.name AS name" {} {}
+        S: SUCCESS {"fields": ["name"]}
+        C: PULL {"n": 1000}
+        S: SUCCESS {}
+        C: COMMIT
+        S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx424242"}
+        *: RESET
+    ?}
+----
+    C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx4242"]}
+    S: SUCCESS {}
+    C: RUN "MATCH (n) RETURN n.name AS name" {} {}
+    S: SUCCESS {"fields": ["name"]}
+    C: PULL {"n": 1000}
+    S: SUCCESS {}
+    C: COMMIT
+    S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx424242"}
+    *: RESET
+}}
 ?: GOODBYE

--- a/tests/stub/bookmarks/scripts/v5/send_and_receive_bookmark_two_write_tx.script
+++ b/tests/stub/bookmarks/scripts/v5/send_and_receive_bookmark_two_write_tx.script
@@ -1,23 +1,38 @@
 !: BOLT 4.4
+!: ALLOW CONCURRENT
 
 A: HELLO {"{}": "*"}
 *: RESET
-C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx42"]}
-S: SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name AS name" {} {}
-S: SUCCESS {"fields": ["name"]}
-C: PULL {"n": 1000}
-S: SUCCESS {}
-C: COMMIT
-S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx4242"}
-*: RESET
-C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx4242"]}
-S: SUCCESS {}
-C: RUN "MATCH (n) RETURN n.name AS name" {} {}
-S: SUCCESS {"fields": ["name"]}
-C: PULL {"n": 1000}
-S: SUCCESS {}
-C: COMMIT
-S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx424242"}
-*: RESET
+{{
+    C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx42"]}
+    S: SUCCESS {}
+    C: RUN "MATCH (n) RETURN n.name AS name" {} {}
+    S: SUCCESS {"fields": ["name"]}
+    C: PULL {"n": 1000}
+    S: SUCCESS {}
+    C: COMMIT
+    S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx4242"}
+    *: RESET
+    {?
+        C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx4242"]}
+        S: SUCCESS {}
+        C: RUN "MATCH (n) RETURN n.name AS name" {} {}
+        S: SUCCESS {"fields": ["name"]}
+        C: PULL {"n": 1000}
+        S: SUCCESS {}
+        C: COMMIT
+        S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx424242"}
+        *: RESET
+    ?}
+----
+    C: BEGIN {"bookmarks": ["neo4j:bookmark:v1:tx4242"]}
+    S: SUCCESS {}
+    C: RUN "MATCH (n) RETURN n.name AS name" {} {}
+    S: SUCCESS {"fields": ["name"]}
+    C: PULL {"n": 1000}
+    S: SUCCESS {}
+    C: COMMIT
+    S: SUCCESS {"bookmark": "neo4j:bookmark:v1:tx424242"}
+    *: RESET
+}}
 ?: GOODBYE


### PR DESCRIPTION
This update ensures that the driver is permitted to create a new connection for running the second transaction.