### PR TITLE
Add dotnet error mappings

### DIFF
--- a/tests/stub/authorization/test_auth_token_manager.py
+++ b/tests/stub/authorization/test_auth_token_manager.py
@@ -337,7 +337,6 @@ class TestAuthTokenManager5x1(AuthorizationBase):
 
     @staticmethod
     def _get_error_code(error):
-        print(error)
         return json.loads(error)["code"]
 
     def test_error_on_pull_using_session_run(self):

--- a/tests/stub/authorization/test_authorization.py
+++ b/tests/stub/authorization/test_authorization.py
@@ -187,6 +187,8 @@ class AuthorizationBase(TestkitTestCase):
         elif driver in ["java"]:
             expected_type = \
                 "org.neo4j.driver.exceptions.SecurityRetryableException"
+        elif driver in ["dotnet"]:
+            expected_type = "OtherSecurityException"
         else:
             self.fail("no error mapping is defined for %s driver" % driver)
         if expected_type is not None:
@@ -206,6 +208,8 @@ class AuthorizationBase(TestkitTestCase):
             pass
         elif driver in ["java"]:
             expected_type = "org.neo4j.driver.exceptions.TransientException"
+        elif driver in ["dotnet"]:
+            expected_type = "DriverError"
         else:
             self.fail("no error mapping is defined for %s driver" % driver)
         if expected_type is not None:
@@ -225,6 +229,8 @@ class AuthorizationBase(TestkitTestCase):
             pass
         elif driver in ["java"]:
             expected_type = "org.neo4j.driver.exceptions.ClientException"
+        elif driver in ["dotnet"]:
+            expected_type = "ClientError"
         else:
             self.fail("no error mapping is defined for %s driver" % driver)
         if expected_type is not None:


### PR DESCRIPTION
These mappings were missing, hidden due to a weird teamcity-related thing in PyCharm