### PR TITLE
StubServer: add milliseconds to log output

### DIFF
--- a/boltstub/watcher.py
+++ b/boltstub/watcher.py
@@ -121,8 +121,7 @@ class Watcher(object):
         super(Watcher, self).__init__()
         self.logger_name = logger_name
         self.logger = getLogger(self.logger_name)
-        self.formatter = ColourFormatter("%(asctime)s  %(message)s",
-                                         "%H:%M:%S")
+        self.formatter = ColourFormatter("%(asctime)s  %(message)s")
 
     def watch(self, level=INFO, out=stdout):
         self.stop()

--- a/boltstub/watcher.py
+++ b/boltstub/watcher.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 
+import time
 from logging import (
     CRITICAL,
     DEBUG,
@@ -110,6 +111,14 @@ class ColourFormatter(Formatter):
         elif record.levelno == DEBUG:
             bits[1] = cyan(bits[1])
         return "  ".join(bits)
+
+    def formatTime(self, record, datefmt=None):  # noqa: N802
+        if datefmt:
+            raise NotImplementedError("custom datefmt not supported")
+        ct = self.converter(record.created)
+        t = time.strftime("%H:%M:%S", ct)
+        ms = int(record.msecs)
+        return f"{t}.{ms:03d}"
 
 
 class Watcher(object):

--- a/tests/stub/shared.py
+++ b/tests/stub/shared.py
@@ -325,7 +325,8 @@ class StubServer:
         self._wait_for_silence(silence_period)
         res = []
         for line in self._stdout_lines:
-            # lines start with something like "10:08:33  [#EBE0>#2332]  "
+            # lines start with something like
+            # "2023-01-01 10:08:33,420  [#EBE0>#2332]  "
             # plus some color escape sequences and ends on a newline
             line = re.sub(r"\x1b\[[\d;]+m", "", line[:-1])
             line = re.sub(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\s+"
@@ -352,7 +353,8 @@ class StubServer:
         self._wait_for_silence(silence_period)
         res = []
         for line in self._stdout_lines:
-            # lines start with something like "10:08:33  [#EBE0>#2332]  "
+            # lines start with something like
+            # "2023-01-01 10:08:33,420  [#EBE0>#2332]  "
             # plus some color escape sequences and ends on a newline
             line = re.sub(r"\x1b\[[\d;]+m", "", line[:-1])
             line = re.sub(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\s+"
@@ -376,7 +378,8 @@ class StubServer:
         self._wait_for_silence(silence_period)
         lines = []
         for line in self._stdout_lines:
-            # lines start with something like "10:08:33  [#EBE0>#2332]  "
+            # lines start with something like
+            # "2023-01-01 10:08:33,420  [#EBE0>#2332]  "
             # plus some color escape sequences and ends on a newline
             line = re.sub(r"\x1b\[[\d;]+m", "", line[:-1])
             line = re.sub(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\s+"

--- a/tests/stub/shared.py
+++ b/tests/stub/shared.py
@@ -328,8 +328,8 @@ class StubServer:
             # lines start with something like "10:08:33  [#EBE0>#2332]  "
             # plus some color escape sequences and ends on a newline
             line = re.sub(r"\x1b\[[\d;]+m", "", line[:-1])
-            line = re.sub(r"^\d{2}:\d{2}:\d{2}\s+\[[0-9A-Fa-f#>]+\]\s+", "",
-                          line)
+            line = re.sub(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\s+"
+                          r"\[[0-9A-Fa-f#>]+\]\s+", "", line)
             match = re.match(r"^(C: )|(\(\s*\d+\) C: )", line)
             if not match:
                 continue
@@ -355,8 +355,8 @@ class StubServer:
             # lines start with something like "10:08:33  [#EBE0>#2332]  "
             # plus some color escape sequences and ends on a newline
             line = re.sub(r"\x1b\[[\d;]+m", "", line[:-1])
-            line = re.sub(r"^\d{2}:\d{2}:\d{2}\s+\[[0-9A-Fa-f#>]+\]\s+", "",
-                          line)
+            line = re.sub(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\s+"
+                          r"\[[0-9A-Fa-f#>]+\]\s+", "", line)
             match = re.match(r"^(S: )|(\(\s*\d+\) S: )|(\(\s*\d+\)\s+)", line)
             if not match:
                 continue
@@ -379,8 +379,8 @@ class StubServer:
             # lines start with something like "10:08:33  [#EBE0>#2332]  "
             # plus some color escape sequences and ends on a newline
             line = re.sub(r"\x1b\[[\d;]+m", "", line[:-1])
-            line = re.sub(r"^\d{2}:\d{2}:\d{2}\s+\[[0-9A-Fa-f#>]+\]\s+", "",
-                          line)
+            line = re.sub(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\s+"
+                          r"\[[0-9A-Fa-f#>]+\]\s+", "", line)
             match = re.match(
                 r"^((?:C: )|(?:\(\s*\d+\) C: ))"
                 r"|((?:S: )|(?:\(\s*\d+\) S: )|(?:\(\s*\d+\)\s+))",

--- a/tests/stub/shared.py
+++ b/tests/stub/shared.py
@@ -325,12 +325,11 @@ class StubServer:
         self._wait_for_silence(silence_period)
         res = []
         for line in self._stdout_lines:
-            # lines start with something like
-            # "2023-01-01 10:08:33,420  [#EBE0>#2332]  "
+            # lines start with something like "10:08:33.420  [#EBE0>#2332]  "
             # plus some color escape sequences and ends on a newline
             line = re.sub(r"\x1b\[[\d;]+m", "", line[:-1])
-            line = re.sub(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\s+"
-                          r"\[[0-9A-Fa-f#>]+\]\s+", "", line)
+            line = re.sub(r"^\d{2}:\d{2}:\d{2}\.\d{3}\s+\[[0-9A-Fa-f#>]+\]\s+",
+                          "", line)
             match = re.match(r"^(C: )|(\(\s*\d+\) C: )", line)
             if not match:
                 continue
@@ -353,12 +352,11 @@ class StubServer:
         self._wait_for_silence(silence_period)
         res = []
         for line in self._stdout_lines:
-            # lines start with something like
-            # "2023-01-01 10:08:33,420  [#EBE0>#2332]  "
+            # lines start with something like "10:08:33.420  [#EBE0>#2332]  "
             # plus some color escape sequences and ends on a newline
             line = re.sub(r"\x1b\[[\d;]+m", "", line[:-1])
-            line = re.sub(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\s+"
-                          r"\[[0-9A-Fa-f#>]+\]\s+", "", line)
+            line = re.sub(r"^\d{2}:\d{2}:\d{2}\.\d{3}\s+\[[0-9A-Fa-f#>]+\]\s+",
+                          "", line)
             match = re.match(r"^(S: )|(\(\s*\d+\) S: )|(\(\s*\d+\)\s+)", line)
             if not match:
                 continue
@@ -378,12 +376,11 @@ class StubServer:
         self._wait_for_silence(silence_period)
         lines = []
         for line in self._stdout_lines:
-            # lines start with something like
-            # "2023-01-01 10:08:33,420  [#EBE0>#2332]  "
+            # lines start with something like "10:08:33.420  [#EBE0>#2332]  "
             # plus some color escape sequences and ends on a newline
             line = re.sub(r"\x1b\[[\d;]+m", "", line[:-1])
-            line = re.sub(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\s+"
-                          r"\[[0-9A-Fa-f#>]+\]\s+", "", line)
+            line = re.sub(r"^\d{2}:\d{2}:\d{2}\.\d{3}\s+\[[0-9A-Fa-f#>]+\]\s+",
+                          "", line)
             match = re.match(
                 r"^((?:C: )|(?:\(\s*\d+\) C: ))"
                 r"|((?:S: )|(?:\(\s*\d+\) S: )|(?:\(\s*\d+\)\s+))",


### PR DESCRIPTION
This should make it easier to compare timestamps between driver and stub server logs.