### PR TITLE
Adjust tests related to transaction termination for Javascript

### DIFF
--- a/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
+++ b/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
@@ -99,6 +99,8 @@ class TestDirectConnectionRecvTimeout(TestkitTestCase):
             self.assertTrue(
                 e.msg.startswith("Cannot run query in this transaction")
             )
+        elif driver in ["javascript"]:
+            self.assertEqual("Neo4jError", e.errorType)
         else:
             self.fail("no error mapping is defined for %s driver" % driver)
 

--- a/tests/stub/tx_run/test_tx_run.py
+++ b/tests/stub/tx_run/test_tx_run.py
@@ -272,7 +272,7 @@ class TestTxRun(TestkitTestCase):
 
             # initiate another stream that fails on RUN
             with self.assertRaises(types.DriverError) as exc:
-                tx.run("invalid")
+                tx.run("invalid").consume()
             self.assertEqual(exc.exception.code,
                              "Neo.ClientError.Statement.SyntaxError")
             self._assert_is_client_exception(exc)
@@ -313,7 +313,7 @@ class TestTxRun(TestkitTestCase):
 
         # initiate another stream that fails on RUN
         with self.assertRaises(types.DriverError) as exc:
-            tx.run("invalid")
+            tx.run("invalid").consume()
         self.assertEqual(exc.exception.code,
                          "Neo.ClientError.Statement.SyntaxError")
         self._assert_is_client_exception(exc)
@@ -335,13 +335,13 @@ class TestTxRun(TestkitTestCase):
         self._session = self._driver.session("r")
         tx = self._session.begin_transaction()
         with self.assertRaises(types.DriverError) as exc:
-            tx.run("invalid")
+            tx.run("invalid").consume()
         self.assertEqual(exc.exception.code,
                          "Neo.ClientError.MadeUp.Code")
         self._assert_is_client_exception(exc)
 
         with self.assertRaises(types.DriverError) as exc:
-            tx.run("RETURN 1 AS n")
+            tx.run("RETURN 1 AS n").consume()
         # new actions on the transaction result in a tx terminated
         # exception, a subclass of the client exception
         self._assert_is_tx_terminated_exception(exc)
@@ -378,7 +378,7 @@ class TestTxRun(TestkitTestCase):
             self._assert_is_client_exception(exc1)
 
             with self.assertRaises(types.DriverError) as exc2:
-                tx.run("invalid")
+                tx.run("invalid").consume()
             driver = get_driver_name()
             if driver in ["go"]:
                 # Go will return the same error the transaction failed with
@@ -522,6 +522,8 @@ class TestTxRun(TestkitTestCase):
             self.assertIn("Neo.ClientError.", e.exception.msg)
         elif driver in ["dotnet"]:
             self.assertEqual("ClientError", e.exception.errorType)
+        elif driver in ["javascript"]:
+            self.assertEqual("Neo4jError", e.exception.errorType)
         else:
             self.fail("no error mapping is defined for %s driver" % driver)
 
@@ -548,6 +550,8 @@ class TestTxRun(TestkitTestCase):
                     "Cannot run query in this transaction"
                 )
             )
+        elif driver in ["javascript"]:
+            self.assertEqual("Neo4jError", e.exception.errorType)
         else:
             self.fail("no error mapping is defined for %s driver" % driver)
 


### PR DESCRIPTION
This PR force the consumption of the result since Javascript Driver doesn't throw on `run`, but only on try to consume the result.

Also add a type mapping to javascript adding error type equals to `Neo4jError`.