### PR TITLE
Update .NET validations for tx_run tests.

### DIFF
--- a/tests/stub/tx_run/test_tx_run.py
+++ b/tests/stub/tx_run/test_tx_run.py
@@ -544,11 +544,9 @@ class TestTxRun(TestkitTestCase):
                 e.exception.errorType.startswith("cannot use this transaction")
             )
         elif driver in ["dotnet"]:
-            self.assertEqual("ClientError", e.exception.errorType)
-            self.assertTrue(
-                e.exception.msg.startswith(
-                    "Cannot run query in this transaction"
-                )
+            self.assertEqual(
+                "TransactionTerminatedError",
+                e.exception.errorType
             )
         elif driver in ["javascript"]:
             self.assertEqual("Neo4jError", e.exception.errorType)


### PR DESCRIPTION
When testing .NET for transaction terminated, use the type instead of message.