### PR TITLE
.NET transaction terminated validation

### DIFF
--- a/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
+++ b/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
@@ -95,10 +95,7 @@ class TestDirectConnectionRecvTimeout(TestkitTestCase):
                 e.errorType.startswith("cannot use this transaction")
             )
         elif driver in ["dotnet"]:
-            self.assertEqual("ClientError", e.errorType)
-            self.assertTrue(
-                e.msg.startswith("Cannot run query in this transaction")
-            )
+            self.assertEqual("TransactionTerminatedError", e.errorType)
         elif driver in ["javascript"]:
             self.assertEqual("Neo4jError", e.errorType)
         else:


### PR DESCRIPTION
Update timeout tests to use the transaction terminated exception.
Similar to: https://github.com/neo4j-drivers/testkit/pull/601