### PR TITLE
Add recv_timeout_seconds test to LivenessCheck

### DIFF
--- a/tests/stub/driver_parameters/scripts/v5x4/liveness_check_recv_timeout.script
+++ b/tests/stub/driver_parameters/scripts/v5x4/liveness_check_recv_timeout.script
@@ -43,8 +43,7 @@ S: SUCCESS {}
     C: COMMIT
     S: SUCCESS {}
 
-    C: RESET
-    S: SUCCESS {}
+    #EXTRA_RESET#
 
     C: RESET
 *}

--- a/tests/stub/driver_parameters/scripts/v5x4/liveness_check_recv_timeout.script
+++ b/tests/stub/driver_parameters/scripts/v5x4/liveness_check_recv_timeout.script
@@ -1,0 +1,52 @@
+!: BOLT 5.4
+!: ALLOW RESTART
+
+C: HELLO {"{}": "*"}
+C: LOGON {"{}": "*"}
+S: SUCCESS {"server": "Neo4j/4.4.1", "hints": {"connection.recv_timeout_seconds": 2}, "connection_id": "bolt-1"}
+S: SUCCESS {}
+
+*: RESET
+
+C: BEGIN {"db": "adb"}
+S: SUCCESS {}
+C: RUN {"U": "*"} {"{}": "*"} {"{}": "*"}
+S: SUCCESS {"fields": ["n"]}
+C: PULL {"n": {"Z": "*"}}
+S: RECORD [1]
+S: SUCCESS {"type": "r"}
+C: COMMIT
+S: SUCCESS {}
+
+*: RESET
+
+{*
+    C: BEGIN {"db": "adb"}
+    S: SUCCESS {}
+    C: RUN {"U": "*"} {"{}": "*"} {"{}": "*"}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL {"n": {"Z": "*"}}
+    S: RECORD [1]
+    S: SUCCESS {"type": "r"}
+    C: COMMIT
+    S: SUCCESS {}
+
+    *: RESET
+
+    C: BEGIN {"db": "adb"}
+    S: SUCCESS {}
+    C: RUN {"U": "*"} {"{}": "*"} {"{}": "*"}
+    S: SUCCESS {"fields": ["n"]}
+    C: PULL {"n": {"Z": "*"}}
+    S: RECORD [1]
+    S: SUCCESS {"type": "r"}
+    C: COMMIT
+    S: SUCCESS {}
+
+    C: RESET
+    S: SUCCESS {}
+
+    C: RESET
+*}
+
+?: GOODBYE

--- a/tests/stub/driver_parameters/test_liveness_check.py
+++ b/tests/stub/driver_parameters/test_liveness_check.py
@@ -63,7 +63,7 @@ class TestLivenessCheck(TestkitTestCase):
         server.start(self.script_path("v5x4", script),
                      vars_={"#HOST#": self._router.host})
 
-    def start_servers(self, server_script = "liveness_check.script"):
+    def start_servers(self, server_script="liveness_check.script"):
         self._start_server(self._server, server_script)
 
     def servers_done(self):
@@ -171,7 +171,6 @@ class TestLivenessCheck(TestkitTestCase):
                 self.assert_one_more_reset(counts_ref, counts)
         self.servers_done()
 
-    
     def test_timeout_recv_timeout(self):
         timeout = 2000
         self.start_servers("liveness_check_recv_timeout.script")

--- a/tests/stub/driver_parameters/test_liveness_check.py
+++ b/tests/stub/driver_parameters/test_liveness_check.py
@@ -60,8 +60,13 @@ class TestLivenessCheck(TestkitTestCase):
         self._router.reset()
 
     def _start_server(self, server, script):
+        extra_reset = ""
+        if not self.driver_supports_features(types.Feature.OPT_MINIMAL_RESETS):
+            extra_reset = "A: RESET"
+
         server.start(self.script_path("v5x4", script),
-                     vars_={"#HOST#": self._router.host})
+                     vars_={"#HOST#": self._router.host,
+                            "#EXTRA_RESET#": extra_reset})
 
     def start_servers(self, server_script="liveness_check.script"):
         self._start_server(self._server, server_script)

--- a/tests/stub/driver_parameters/test_liveness_check.py
+++ b/tests/stub/driver_parameters/test_liveness_check.py
@@ -211,6 +211,7 @@ class TestLivenessCheck(TestkitTestCase):
         while True:
             yield types.AuthorizationToken("basic", principal=f"neo4j_{i}",
                                            credentials="pass")
+            i += 1
 
     def test_timeout_with_re_auth(self):
         timeout = 2000

--- a/tests/stub/driver_parameters/test_liveness_check.py
+++ b/tests/stub/driver_parameters/test_liveness_check.py
@@ -131,8 +131,6 @@ class TestLivenessCheck(TestkitTestCase):
                 time_mock.tick(59 * 60 * 1000)  # 59 minutes
 
                 # count RESETs after potential timeout
-                # abusing impersonation to identify the request also in the
-                # stub router
                 counts_pre = self.get_reset_counts()
                 self._execute_query(driver, "test", database=self._DB)
                 counts = self.get_new_reset_counts(counts_pre)
@@ -155,8 +153,6 @@ class TestLivenessCheck(TestkitTestCase):
 
                 time_mock.tick_to_before_timeout()
 
-                # abusing impersonation to identify the request also in the
-                # stub router
                 counts_pre = self.get_reset_counts()
                 self._execute_query(driver, "test pre timeout",
                                     database=self._DB)
@@ -166,13 +162,13 @@ class TestLivenessCheck(TestkitTestCase):
                 self.assertEqual(counts_ref, counts)
 
                 time_mock.tick_to_after_timeout()
-                # now we should have an extra RESET
+                # now we should get an extra RESET
                 counts_pre = self.get_reset_counts()
                 self._execute_query(driver, "test post timeout",
                                     database=self._DB)
                 counts = self.get_new_reset_counts(counts_pre)
 
-                # assert no extra RESETs
+                # assert one extra RESET
                 self.assert_one_more_reset(counts_ref, counts)
         self.servers_done()
 
@@ -190,8 +186,6 @@ class TestLivenessCheck(TestkitTestCase):
 
                 time_mock.tick_to_before_timeout()
 
-                # abusing impersonation to identify the request also in the
-                # stub router
                 counts_pre = self.get_reset_counts()
                 self._execute_query(driver, "test pre timeout",
                                     database=self._DB)
@@ -201,13 +195,13 @@ class TestLivenessCheck(TestkitTestCase):
                 self.assertEqual(counts_ref, counts)
 
                 time_mock.tick_to_after_timeout()
-                # now we should have an extra RESET
+                # now we should get an extra RESET
                 counts_pre = self.get_reset_counts()
                 self._execute_query(driver, "test post timeout",
                                     database=self._DB)
                 counts = self.get_new_reset_counts(counts_pre)
 
-                # assert no extra RESETs
+                # assert one extra RESET
                 self.assert_one_more_reset(counts_ref, counts)
         self.servers_done()
 
@@ -234,8 +228,6 @@ class TestLivenessCheck(TestkitTestCase):
 
                 time_mock.tick_to_before_timeout()
 
-                # abusing impersonation to identify the request also in the
-                # stub router
                 counts_pre = self.get_reset_counts()
                 self._execute_query(
                     driver, "test pre timeout", database=self._DB,
@@ -247,7 +239,7 @@ class TestLivenessCheck(TestkitTestCase):
                 self.assertEqual(counts_ref, counts)
 
                 time_mock.tick_to_after_timeout()
-                # now we should have an extra RESET
+                # now we should get an extra RESET
                 counts_pre = self.get_reset_counts()
                 self._execute_query(
                     driver, "test post timeout", database=self._DB,
@@ -255,7 +247,7 @@ class TestLivenessCheck(TestkitTestCase):
                 )
                 counts = self.get_new_reset_counts(counts_pre)
 
-                # assert no extra RESETs
+                # assert one extra RESET
                 self.assert_one_more_reset(counts_ref, counts)
         self.servers_done()
 


### PR DESCRIPTION
The liveness check `RESET` message should be take in consideration the connection hint `connection.recv_timeout_seconds` to avoid the the check hands forever in case the server doesn't reply.