### PR TITLE
Schema notification category tests added to stub tests

### DIFF
--- a/tests/stub/notifications_config/notifications_base.py
+++ b/tests/stub/notifications_config/notifications_base.py
@@ -79,6 +79,18 @@ class NotificationsBase(TestkitTestCase):
             },
             {
                 "protocol": {
+                    "min_sev": "INFORMATION",
+                    "dis_cats": ["SCHEMA"]
+                },
+                "script": {
+                    "#NOTIS#": '"notifications_minimum_severity": '
+                               '"INFORMATION", '
+                               '"notifications_disabled_categories": '
+                               '["SCHEMA"], '
+                }
+            },
+            {
+                "protocol": {
                     "min_sev": "WARNING",
                     "dis_cats": ["UNRECOGNIZED", "UNSUPPORTED"]
                 },

--- a/tests/stub/notifications_config/test_notification_mapping.py
+++ b/tests/stub/notifications_config/test_notification_mapping.py
@@ -188,6 +188,22 @@ class TestNotificationMapping(NotificationsBase):
             {
                 "notifications": [
                     {
+                        "category": "SCHEMA",
+                        "severity": "INFORMATION"
+                    }
+                ],
+                "expect": [
+                    {
+                        "category": "SCHEMA",
+                        "category_string": "SCHEMA",
+                        "severity": "INFORMATION",
+                        "severity_string": "INFORMATION",
+                    }
+                ]
+            },
+            {
+                "notifications": [
+                    {
                         "category": "MADE_UP",
                         "severity": "WARNING"
                     }


### PR DESCRIPTION
Adds the `SCHEMA` notification category to the stub tests `tests.stub.notifications_config.test_driver_notifications_config` and `tests.stub.notifications_config.test_notification_mapping`.

These test that the driver can return this category when a notification belongs to it, and that it can be passed through the configuration as a disabled categrory.

Some unpatched drivers may pass `tests.stub.notifications_config.test_driver_notifications_config` as some drivers (including the javascript driver) passes the disabled categories as raw strings.