### PR TITLE
Fix comment placement in TestHomeDbMixedCluster

### DIFF
--- a/tests/stub/homedb/test_homedb.py
+++ b/tests/stub/homedb/test_homedb.py
@@ -1397,7 +1397,7 @@ class TestHomeDbMixedCluster(TestkitTestCase):
             "writer_no_ssr.script",
             vars_={
                 **self.VARS_WRITER_NO_SSR,
-                "#EXTRA_BANG_LINES#": "!: HANDSHAKE_DELAY 1.1",
+                "#EXTRA_BANG_LINES#": "!: HANDSHAKE_DELAY 2.1",
             },
         )
 

--- a/tests/stub/homedb/test_homedb.py
+++ b/tests/stub/homedb/test_homedb.py
@@ -1375,9 +1375,9 @@ class TestHomeDbMixedCluster(TestkitTestCase):
         self._test_mixed_cluster()
 
     # This test ensures that the connection acquisition timeout covers the full
-    # acquisition under the same timer without resetting. This must include both
-    # optimistic routing and falling back. If this is not the case, this test
-    # can be skipped on the driver side until the behavior is unified.
+    # acquisition under the same timer without resetting. This must include
+    # both optimistic routing and falling back. If this is not the case, this
+    # test can be skipped on the driver side until the behavior is unified.
     @driver_feature(types.Feature.API_CONNECTION_ACQUISITION_TIMEOUT)
     def test_connection_acquisition_timeout_during_fallback(self):
         self.start_server(
@@ -1425,7 +1425,6 @@ class TestHomeDbMixedCluster(TestkitTestCase):
         self._writer1.done()
         # acquisition timeout kicks in => not finishing the script
         self._writer2.reset()
-
 
     @driver_feature(
         types.Feature.BOLT_5_7,

--- a/tests/stub/homedb/test_homedb.py
+++ b/tests/stub/homedb/test_homedb.py
@@ -1374,6 +1374,10 @@ class TestHomeDbMixedCluster(TestkitTestCase):
 
         self._test_mixed_cluster()
 
+    # This test ensures that the connection acquisition timeout covers the full
+    # acquisition under the same timer without resetting. This must include both
+    # optimistic routing and falling back. If this is not the case, this test
+    # can be skipped on the driver side until the behavior is unified.
     @driver_feature(types.Feature.API_CONNECTION_ACQUISITION_TIMEOUT)
     def test_connection_acquisition_timeout_during_fallback(self):
         self.start_server(
@@ -1397,7 +1401,7 @@ class TestHomeDbMixedCluster(TestkitTestCase):
             "writer_no_ssr.script",
             vars_={
                 **self.VARS_WRITER_NO_SSR,
-                "#EXTRA_BANG_LINES#": "!: HANDSHAKE_DELAY 2.1",
+                "#EXTRA_BANG_LINES#": "!: HANDSHAKE_DELAY 1.1",
             },
         )
 
@@ -1422,10 +1426,7 @@ class TestHomeDbMixedCluster(TestkitTestCase):
         # acquisition timeout kicks in => not finishing the script
         self._writer2.reset()
 
-    # This test ensures that the connection acquisition timeout covers the full
-    # acqusition under the same timer without resetting. This must include both
-    # optimistic routing and falling back. If this is not the case, this test
-    # can be skipped on the driver side until the behavior is unified.
+
     @driver_feature(
         types.Feature.BOLT_5_7,
         types.Feature.API_DRIVER_MAX_CONNECTION_LIFETIME,


### PR DESCRIPTION
Moved a comment to the correct location so it is clear which test should be skipped.