### PR TITLE
Update backend socket timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Environment variables:
     you also need to set:
   * `TEST_AWS_ECR_URI`  
     The URL to the docker container registry where nightly builds are stored.
+  * `TEST_BACKEND_TIMEOUT`  
+    The default socket timeout to use when waiting for the TestKit backend to
+    respond. This can be any finite float value (in seconds).
+    The default is `60.0` seconds.
 
 ```console
 export TEST_DRIVER_NAME=go
@@ -120,7 +124,8 @@ TestKit or for debugging local backends:
     Set to `1` to disable TestKit timing out if the backend takes longer than
     the usually enforced timeout. This is very handy if you want to step through
     the backend or driver with a debugger without TestKit canceling the tests
-    due to a timed out connection.
+    due to a timed out connection.  
+    You may not set this variable if `TEST_BACKEND_TIMEOUT` is already set.
 
 
 ### Running tests against a specific backend

--- a/nutkit/backend/backend.py
+++ b/nutkit/backend/backend.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+import math
 import os
 import socket
 from contextlib import contextmanager
@@ -10,11 +11,9 @@ import nutkit.protocol as protocol
 PROTOCOL_CLASSES = dict(
     m for m in inspect.getmembers(protocol, inspect.isclass)
 )
-DEBUG_MESSAGES = os.environ.get("TEST_DEBUG_REQRES", "0").lower() in (
-    "1", "y", "yes", "true", "t", "on"
-)
-DEBUG_TIMEOUT = os.environ.get("TEST_DEBUG_NO_BACKEND_TIMEOUT", "0") in (
-    "1", "y", "yes", "true", "t", "on"
+DEBUG_MESSAGES = (
+    os.environ.get("TEST_DEBUG_REQRES", "").lower()
+    in ("1", "y", "yes", "true", "t", "on")
 )
 
 
@@ -41,8 +40,35 @@ def decode_hook(x):
     return PROTOCOL_CLASSES[name](**data)
 
 
+def _get_default_backend_timeout():
+    test_debug_no_backend_timeout = (
+        os.environ.get("TEST_DEBUG_NO_BACKEND_TIMEOUT", "").lower()
+        in ("1", "y", "yes", "true", "t", "on")
+    )
+    default_timeout = os.environ.get("TEST_BACKEND_TIMEOUT")
+    if test_debug_no_backend_timeout:
+        if default_timeout is not None:
+            raise Exception(
+                "TEST_BACKEND_TIMEOUT and TEST_DEBUG_NO_BACKEND_TIMEOUT "
+                "are mutually exclusive"
+            )
+        return None
+    if default_timeout is None:
+        return 60.0
+    try:
+        default_timeout = float(default_timeout)
+        if not math.isfinite(default_timeout):
+            raise ValueError("not finite")
+    except (TypeError, ValueError) as e:
+        raise Exception(
+            "TEST_BACKEND_TIMEOUT must be a finite float, "
+            f"got {default_timeout}: {e}"
+        )
+    return default_timeout
+
+
 # How long to wait before backend responds
-DEFAULT_TIMEOUT = None if DEBUG_TIMEOUT else 10
+DEFAULT_TIMEOUT = _get_default_backend_timeout()
 
 
 class Backend:


### PR DESCRIPTION
 * Increase the default timeout to 60 seconds for higher resilience at the small risk of longer hanging CI jobs.
 * Make the default timeout configurable via the environment variable `TEST_BACKEND_TIMEOUT`