### PR TITLE
[5.0] Add non clustered 2025.dev run to TC

### DIFF
--- a/main.py
+++ b/main.py
@@ -139,7 +139,7 @@ def initialise_configurations(settings):
             ("5.dev",    "5",      True,        False,    "neo4j",  0),
             ("5.dev",    "5",      True,        True,     "neo4j", 90),
             # nightly build of official forwards-compatible version(s)
-            ("2025.dev", "2025",   True,        False,     "neo4j", 0),
+            ("2025.dev", "2025",   True,        False,    "neo4j",  0),
             ("2025.dev", "2025",   True,        True,     "neo4j", 60),
         )
     ]

--- a/main.py
+++ b/main.py
@@ -133,6 +133,8 @@ def initialise_configurations(settings):
             # nightly build of official backwards-compatible version(s)
             ("4.4",      "4.4",    True,        True,     "neo4j", 60),
             # nightly build of matching version(s)
+            ("5.dev",    "5",      False,       False,    "bolt",   0),
+            ("5.dev",    "5",      False,       False,    "neo4j",  0),
             ("5.dev",    "5",      True,        False,    "bolt",  90),
             ("5.dev",    "5",      True,        False,    "neo4j",  0),
             ("5.dev",    "5",      True,        True,     "neo4j", 90),

--- a/main.py
+++ b/main.py
@@ -133,8 +133,6 @@ def initialise_configurations(settings):
             # nightly build of official backwards-compatible version(s)
             ("4.4",      "4.4",    True,        True,     "neo4j", 60),
             # nightly build of matching version(s)
-            ("5.dev",    "5",      False,       False,    "bolt",   0),
-            ("5.dev",    "5",      False,       False,    "neo4j",  0),
             ("5.dev",    "5",      True,        False,    "bolt",  90),
             ("5.dev",    "5",      True,        False,    "neo4j",  0),
             ("5.dev",    "5",      True,        True,     "neo4j", 90),

--- a/main.py
+++ b/main.py
@@ -139,6 +139,7 @@ def initialise_configurations(settings):
             ("5.dev",    "5",      True,        False,    "neo4j",  0),
             ("5.dev",    "5",      True,        True,     "neo4j", 90),
             # nightly build of official forwards-compatible version(s)
+            ("2025.dev", "2025",   True,        False,     "neo4j", 0),
             ("2025.dev", "2025",   True,        True,     "neo4j", 60),
         )
     ]

--- a/tests/neo4j/test_session_run.py
+++ b/tests/neo4j/test_session_run.py
@@ -395,7 +395,7 @@ class TestSessionRun(TestkitTestCase):
 
     @cluster_unsafe_test
     def test_long_string(self):
-        string = "A" * 2 ** 20
+        string = "A" * 2 ** 15
         query = "RETURN '{}'".format(string)
         for _ in range(6):
             session = self._driver.session("r")


### PR DESCRIPTION
Certain tests are skipped on clustered test runs, which may lead to bugs slipping through the cracks if only clustered tests are run on 2025.x.