### PR TITLE
[6.x] Add non clustered 5.26 run to TC

### DIFF
--- a/main.py
+++ b/main.py
@@ -127,6 +127,7 @@ def initialise_configurations(settings):
         for (version_, docker_tag, enterprise_, cluster_, scheme_,  stress)
         in (
             # nightly build of official backwards-compatible version(s)
+            ("5.26",     "5",      True,        False,     "neo4j", 0),
             ("5.26",     "5",      True,        True,     "neo4j", 60),
             # nightly build of matching version(s)
             ("2025.dev", "2025",   False,       False,    "bolt",   0),

--- a/main.py
+++ b/main.py
@@ -127,7 +127,7 @@ def initialise_configurations(settings):
         for (version_, docker_tag, enterprise_, cluster_, scheme_,  stress)
         in (
             # nightly build of official backwards-compatible version(s)
-            ("5.26",     "5",      True,        False,     "neo4j", 0),
+            ("5.26",     "5",      True,        False,    "neo4j",  0),
             ("5.26",     "5",      True,        True,     "neo4j", 60),
             # nightly build of matching version(s)
             ("2025.dev", "2025",   False,       False,    "bolt",   0),


### PR DESCRIPTION
Certain tests are skipped on clustered test runs, which may lead to bugs slipping through the cracks if only clustered tests are run on 5.26.