### PR TITLE
Correct Acquisition Timeout Unification Tests

### DIFF
--- a/tests/stub/driver_parameters/test_connection_acquisition_timeout_ms.py
+++ b/tests/stub/driver_parameters/test_connection_acquisition_timeout_ms.py
@@ -276,8 +276,9 @@ class TestConnectionAcquisitionTimeoutMs(TestkitTestCase):
         self._session = None
         self._driver.close()
         self._driver = None
-        self._router.done()
+        self._router.reset()
         self._server.done(ignore_never_started=True)
+        self.assertEqual(self._router.count_requests("ROUTE"), 1)
         self.assertEqual(self._server.count_responses("<ACCEPT>"), 0)
 
     @driver_feature(types.Feature.OPT_EAGER_TX_BEGIN)

--- a/tests/stub/driver_parameters/test_connection_acquisition_timeout_ms.py
+++ b/tests/stub/driver_parameters/test_connection_acquisition_timeout_ms.py
@@ -277,7 +277,8 @@ class TestConnectionAcquisitionTimeoutMs(TestkitTestCase):
         self._driver.close()
         self._driver = None
         self._router.done()
-        self._server.done()
+        self._server.done(ignore_never_started=True)
+        self.assertEqual(self._server.count_responses("<ACCEPT>"), 0)
 
     @driver_feature(types.Feature.OPT_EAGER_TX_BEGIN)
     def test_should_regulate_the_time_for_acquiring_connections(self):


### PR DESCRIPTION
Ensures no messages reach server if the acquisition timeout is exceeded during routing