### PR TITLE
Fix script incompatibility with lazy connection closing

### DIFF
--- a/tests/stub/errors/scripts/error.script
+++ b/tests/stub/errors/scripts/error.script
@@ -16,4 +16,4 @@ S: FAILURE #ERROR#
     }}
 ?}
 +: RESET
-A: GOODBYE
+?: GOODBYE


### PR DESCRIPTION
Some drivers (e.g., our Go driver) may choose to close connection in a background task. Therefore, there's a race condition if the driver is instructed to shut down and right after, the stub server is ended if the script asserts that the connection reaches its end with `GOODBYE`.