### PR TITLE
Rusty stub: Fix cancellation shutdown

### DIFF
--- a/boltstub_rs/src/net_actor.rs
+++ b/boltstub_rs/src/net_actor.rs
@@ -579,11 +579,11 @@ impl<'a, C: Connection> NetActor<'a, C> {
                         "list child block done: moving block list ({ctx}) to {}/{initial_size}",
                         initial_size.saturating_sub(blocks.len()),
                     );
+                    if error.is_some() {
+                        break;
+                    }
                 }
-                match error {
-                    None => Ok(()),
-                    Some(err) => Err(err),
-                }
+                error.map_or_else(|| Ok(()), Err)
             }
             BlockWithState::ServerMessageSend(state, ctx, sender) => match state.done {
                 true => Ok(()),
@@ -1496,11 +1496,11 @@ impl<'a> BlockWithState<'a> {
                 false => state.count >= *rep,
             },
             BlockWithState::ClientMessageValidate(state, _, _)
-            | BlockWithState::ServerMessageSend(state, _, _)
-            | BlockWithState::ServerActionLine(state, _, _)
-            | BlockWithState::Python(state, _, _)
             | BlockWithState::AutoMessage(state, _, _) => state.done,
-            BlockWithState::NoOp(_) => true,
+            BlockWithState::NoOp(_)
+            | BlockWithState::ServerMessageSend(_, _, _)
+            | BlockWithState::ServerActionLine(_, _, _)
+            | BlockWithState::Python(_, _, _) => true,
         }
     }
 }


### PR DESCRIPTION
* If a server action inside a loop fails (e.g., because it was canceled), the error should be propagated straight away and not deferred until the whole block has been handled.

* Mark action lines as skippable

  When only action lines (server lines, Python lines, etc.) are left, the block can be considered skipable as no client-side action is required.
  
Closes DRIVERS-213