### PR TITLE
Py Stub: fix race condition in error handling

### DIFF
--- a/boltstub/__init__.py
+++ b/boltstub/__init__.py
@@ -162,19 +162,23 @@ class BoltStubService:
         self.server.timeout = timeout or self.default_timeout
 
     def start(self):
-        if self.script.context.restarting or self.script.context.concurrent:
-            try:
+        try:
+            if (
+                self.script.context.restarting
+                or self.script.context.concurrent
+            ):
                 self.server.serve_forever()
-            except OSError as exc:
-                if not self._shutting_down:
-                    raise
-                # Specifically on Windows `serve_forever` might exit with an
-                # error when `self._close_socket` just pulls the plug.
-                # Other OSes might also raise an error in this case.
-                # This is fine and we can ignore it.
-                log.warning("Ignored OSError during shutdown", exc_info=exc)
-        else:
-            self.server.handle_request()
+            else:
+                self.server.handle_request()
+        except OSError as exc:
+            if not self._shutting_down:
+                raise
+            # Specifically on Windows `serve_forever` might exit with an
+            # error when `self._close_socket` just pulls the plug.
+            # Other OSes might also raise an error in this case.
+            # This is fine and we can ignore it.
+            log.warning("Ignored OSError during shutdown", exc_info=exc)
+        finally:
             self.server.server_close()
 
     def _close_socket(self):

--- a/tests/stub/driver_parameters/test_connection_acquisition_timeout_ms.py
+++ b/tests/stub/driver_parameters/test_connection_acquisition_timeout_ms.py
@@ -242,7 +242,8 @@ class TestConnectionAcquisitionTimeoutMs(TestkitTestCase):
         self._driver.close()
         self._driver = None
         self._router.done()
-        self._server.done()
+        self._server.reset()  # script has not been played to the end
+        self.assertEqual(self._server.count_requests("HELLO"), 1)
 
     def test_router_handshake_has_own_timeout_too_slow(self):
         self._start_server(self._router, "router_hello_delay.script")


### PR DESCRIPTION
Fixes: DRIVERS-237

Encountered (twice) in this PR: https://github.com/neo4j/neo4j-python-driver/pull/1276

TC logs: https://live.neo4j-build.io/buildConfiguration/Drivers_ScriptedBuilds_Id6xNeo4jPythonDriverPullRequestTestkitNeo4jPythonDriverTestkitStubPy310async/27308334?buildTab=log&linesState=568.678.3032&logView=flowAware&focusLine=3032#%2Fartifacts.zip;%2Fartifacts.zip!%2Fdriver_backend;%2Fartifacts.zip;%2Fartifacts.zip!%2Fdriver_backend