### PR TITLE
Improve profile and plan stub tests

### DIFF
--- a/nutkit/protocol/feature.py
+++ b/nutkit/protocol/feature.py
@@ -84,6 +84,10 @@ class Feature(Enum):
     # The result summary provides a way to access the transaction's
     # GqlStatusObject.
     API_SUMMARY_GQL_STATUS_OBJECTS = "Feature:API:Summary:GqlStatusObjects"
+    # The profile in the summary provides a way to discern absent values for
+    # fields `rows`, `dbHits`, `time`, and `pageCacheHits`.
+    API_SUMMARY_PROFILE_OPTIONAL_STATS = \
+        "Feature:API:Summary:Profile:OptionalStats"
     # The driver supports sending and receiving geospatial data types.
     API_TYPE_SPATIAL = "Feature:API:Type.Spatial"
     # The driver supports sending and receiving temporal data types.

--- a/tests/neo4j/test_summary.py
+++ b/tests/neo4j/test_summary.py
@@ -76,7 +76,7 @@ class TestSummary(TestkitTestCase):
     def test_no_notification_info(self):
         summary = self.get_summary("CREATE (n) RETURN n")
         notifications = summary.notifications
-        self.assertTrue(notifications is None or summary.notifications == [])
+        self.assertIn(notifications, (None, []))
 
     def _test_status(self, query, expected_code):
         summary = self.get_summary(query)

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -149,6 +149,7 @@ def get_driver_name():
 class TestkitTestCase(unittest.TestCase):
 
     required_features = ()
+    maxDiff = None
 
     def setUp(self):
         super().setUp()

--- a/tests/stub/summary/scripts/v6x0/summary_with_plan.script
+++ b/tests/stub/summary/scripts/v6x0/summary_with_plan.script
@@ -1,0 +1,23 @@
+!: BOLT 6.0
+
+A: HELLO {"{}": "*"}
+A: LOGON {"{}": "*"}
+*: RESET
+C: RUN "*" "*" "*"
+S: SUCCESS {"t_first": 2001, "fields": ["n"]}
+{{
+    {+
+        C: PULL {"n": 1}
+        S: RECORD [1]
+        S: SUCCESS {"has_more": true}
+    +}
+    C: DISCARD {"n": -1}
+----
+    C: PULL {"n": "*"}
+    S: RECORD [1]
+----
+    C: DISCARD {"n": -1}
+}}
+S: SUCCESS {"type": "r", "db": "apple", "t_last": 2002, "plan": #PLAN#}
+*: RESET
+?: GOODBYE

--- a/tests/stub/summary/scripts/v6x0/summary_with_profile.script
+++ b/tests/stub/summary/scripts/v6x0/summary_with_profile.script
@@ -1,0 +1,23 @@
+!: BOLT 6.0
+
+A: HELLO {"{}": "*"}
+A: LOGON {"{}": "*"}
+*: RESET
+C: RUN "*" "*" "*"
+S: SUCCESS {"t_first": 2001, "fields": ["n"]}
+{{
+    {+
+        C: PULL {"n": 1}
+        S: RECORD [1]
+        S: SUCCESS {"has_more": true}
+    +}
+    C: DISCARD {"n": -1}
+----
+    C: PULL {"n": "*"}
+    S: RECORD [1]
+----
+    C: DISCARD {"n": -1}
+}}
+S: SUCCESS {"type": "r", "db": "apple", "t_last": 2002, "profile": #PROFILE#}
+*: RESET
+?: GOODBYE

--- a/tests/stub/summary/test_summary.py
+++ b/tests/stub/summary/test_summary.py
@@ -1433,7 +1433,7 @@ class TestSummaryPlan4x4(_TestSummaryBase):
             "summary_with_plan.script",
             vars_={"#PLAN#": json.dumps(plan)},
         )
-        self.assert_plan_equal(plan, summary.plan)
+        self.assert_plan_equal(summary.plan, plan)
 
     def test_profile(self):
         profile = {
@@ -1556,7 +1556,7 @@ class TestSummaryPlan6x0(_TestSummaryBase):
             "summary_with_plan.script",
             vars_={"#PLAN#": json.dumps(plan)},
         )
-        self.assert_plan_equal(plan, summary.plan)
+        self.assert_plan_equal(summary.plan, plan)
 
     def test_profile(self):
         profile = {

--- a/tests/stub/summary/test_summary.py
+++ b/tests/stub/summary/test_summary.py
@@ -49,6 +49,31 @@ class _TestSummaryBase(TestkitTestCase):
             list(result)
             return result.consume()
 
+    def assert_plan_equal(self, actual, expected):
+        def adjust_expected(actual_child, expected_child):
+            # drivers are free to represent lack of children with either:
+            #   * an empty list
+            #   * a null value
+            #   * lack of the key
+            expected_children = expected_child.get("children")
+            expected_has_children = expected_children not in (None, [])
+            actual_children = actual_child.get("children")
+            actual_has_children = actual_children not in (None, [])
+
+            if not expected_has_children and not actual_has_children:
+                expected_child.pop("children", None)
+                actual_child.pop("children", None)
+                return
+
+            expected_children = expected_children or []
+            actual_children = actual_children or []
+            if len(expected_children) == len(actual_children):
+                for ac, ec in zip(actual_children, expected_children):
+                    adjust_expected(ac, ec)
+
+        adjust_expected(actual, expected)
+        self.assertEqual(actual, expected)
+
 
 class _TestSummaryDiscardMixin(_TestSummaryBase):
     def _get_summary(self, script, vars_=None):
@@ -1353,9 +1378,9 @@ class TestSummaryGqlStatusObjects5x6Discard(
         super().test_fill_diagnostic_record_values()
 
 
-class TestSummaryPlan(_TestSummaryBase):
-    required_features = types.Feature.BOLT_4_4,
-    version_folder = "v4x4",
+class TestSummaryPlan4x4(_TestSummaryBase):
+    required_features = (types.Feature.BOLT_4_4,)
+    version_folder = ("v4x4",)
 
     def test_plan(self):
         plan = {
@@ -1368,7 +1393,8 @@ class TestSummaryPlan(_TestSummaryBase):
                 "runtime": "PIPELINED",
                 "runtime-impl": "PIPELINED",
                 "version": "CYPHER 4.3",
-                "EstimatedRows": 1.5, "planner": "COST"
+                "EstimatedRows": 1.5,
+                "planner": "COST",
             },
             "operatorType": "ProduceResults@neo4j",
             "children": [
@@ -1376,20 +1402,20 @@ class TestSummaryPlan(_TestSummaryBase):
                     "args": {
                         "Details": "(n)",
                         "EstimatedRows": 1.5,
-                        "PipelineInfo": "Fused in Pipeline 0"
+                        "PipelineInfo": "Fused in Pipeline 0",
                     },
                     "operatorType": "Create@neo4j",
                     "children": [],
-                    "identifiers": ["n"]
+                    "identifiers": ["n"],
                 }
             ],
-            "identifiers": ["n"]
+            "identifiers": ["n"],
         }
         summary = self._get_summary(
             "summary_with_plan.script",
-            vars_={"#PLAN#": json.dumps(plan)}
+            vars_={"#PLAN#": json.dumps(plan)},
         )
-        self.assertEqual(summary.plan, plan)
+        self.assert_plan_equal(plan, summary.plan)
 
     def test_profile(self):
         profile = {
@@ -1406,7 +1432,7 @@ class TestSummaryPlan(_TestSummaryBase):
                 "runtime-version": "4.3",
                 "EstimatedRows": 1.1,
                 "planner": "COST",
-                "Rows": 1
+                "Rows": 1,
             },
             "children": [
                 {
@@ -1418,7 +1444,7 @@ class TestSummaryPlan(_TestSummaryBase):
                         "EstimatedRows": 1.1,
                         "DbHits": 1,
                         "Rows": 1,
-                        "PageCacheHits": 0
+                        "PageCacheHits": 0,
                     },
                     "pageCacheMisses": 0,
                     "children": [],
@@ -1428,22 +1454,171 @@ class TestSummaryPlan(_TestSummaryBase):
                     "time": 0,
                     "rows": 1,
                     "pageCacheHitRatio": 0.1,
-                    "pageCacheHits": 0
+                    "pageCacheHits": 0,
                 }
             ],
             "dbHits": 1,
             "identifiers": ["n"],
             "operatorType": "ProduceResults@neo4j",
-            "rows": 1
+            "rows": 1,
         }
         summary = self._get_summary(
             "summary_with_profile.script",
-            vars_={"#PROFILE#": json.dumps(profile)}
+            vars_={"#PROFILE#": json.dumps(profile)},
         )
-        self.assertEqual(summary.profile, profile)
+        self.assert_plan_equal(profile, summary.profile)
 
 
-class TestSummaryPlanDiscard(_TestSummaryDiscardMixin,  TestSummaryPlan):
+class TestSummaryPlanDiscard4x4(_TestSummaryDiscardMixin, TestSummaryPlan4x4):
+    def test_plan(self):
+        super().test_plan()
+
+    def test_profile(self):
+        super().test_profile()
+
+
+class TestSummaryPlan6x0(_TestSummaryBase):
+    required_features = (types.Feature.BOLT_6_0,)
+    version_folder = ("v6x0",)
+
+    def test_plan(self):
+        plan = {
+            "args": {
+                "planner-impl": "IDP",
+                "string-representation": (  # noqa: PAR001
+                    "Cypher 5"
+                    "\n"
+                    "\nPlanner COST"
+                    "\n"
+                    "\nRuntime PIPELINED"
+                    "\n"
+                    "\nRuntime version 2026.01"
+                    "\n"
+                    "\nBatch size 128"
+                    "\n"
+                    "\n+-----------------+----+---------+----------------+---------------------+"  # noqa: E501
+                    "\n| Operator        | Id | Details | Estimated Rows | Pipeline            |"  # noqa: E501
+                    "\n+-----------------+----+---------+----------------+---------------------+"  # noqa: E501
+                    "\n| +ProduceResults |  0 | n       |             10 |                     |"  # noqa: E501
+                    "\n| |               +----+---------+----------------+                     |"  # noqa: E501
+                    "\n| +AllNodesScan   |  1 | n       |             10 | Fused in Pipeline 0 |"  # noqa: E501
+                    "\n+-----------------+----+---------+----------------+---------------------+"  # noqa: E501
+                    "\n"
+                    "\nTotal database accesses: ?"
+                    "\n"
+                ),
+                "runtime": "PIPELINED",
+                "runtime-impl": "PIPELINED",
+                "version": "5",
+                "batch-size": 128,
+                "Details": "n",
+                "planner-version": "2026.01",
+                "PipelineInfo": "Fused in Pipeline 0",
+                "runtime-version": "2026.01",
+                "Id": 0,
+                "EstimatedRows": 10.0,
+                "planner": "COST",
+            },
+            "children": [
+                {
+                    "args": {
+                        "Details": "n",
+                        "Id": 1,
+                        "EstimatedRows": 10.0,
+                        "PipelineInfo": "Fused in Pipeline 0",
+                    },
+                    "identifiers": ["n"],
+                    "operatorType": "AllNodesScan@neo4j",
+                }
+            ],
+            "identifiers": ["n"],
+            "operatorType": "ProduceResults@neo4j",
+        }
+        summary = self._get_summary(
+            "summary_with_plan.script",
+            vars_={"#PLAN#": json.dumps(plan)},
+        )
+        self.assert_plan_equal(plan, summary.plan)
+
+    def test_profile(self):
+        profile = {
+            "args": {
+                "GlobalMemory": 312,
+                "planner-impl": "IDP",
+                "Memory": 0,
+                "string-representation": (  # noqa: PAR001
+                    "Cypher 5\n"
+                    "\n"
+                    "Planner COST\n"
+                    "\n"
+                    "Runtime PIPELINED\n"
+                    "\n"
+                    "Runtime version 2026.01\n"
+                    "\n"
+                    "Batch size 128\n"
+                    "\n"
+                    "+-----------------+----+---------+----------------+------+---------+----------------+------------------------+-----------+---------------------+\n"  # noqa: E501
+                    "| Operator        | Id | Details | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |\n"  # noqa: E501
+                    "+-----------------+----+---------+----------------+------+---------+----------------+------------------------+-----------+---------------------+\n"  # noqa: E501
+                    "| +ProduceResults |  0 | n       |             10 |    0 |       0 |              0 |                        |           |                     |\n"  # noqa: E501
+                    "| |               +----+---------+----------------+------+---------+----------------+                        |           |                     |\n"  # noqa: E501
+                    "| +AllNodesScan   |  1 | n       |             10 |    0 |       1 |            248 |                    0/0 |     0.274 | Fused in Pipeline 0 |\n"  # noqa: E501
+                    "+-----------------+----+---------+----------------+------+---------+----------------+------------------------+-----------+---------------------+\n"  # noqa: E501
+                    "\n"
+                    "Total database accesses: 1, total allocated memory: 312\n"
+                    ""
+                ),
+                "runtime": "PIPELINED",
+                "runtime-impl": "PIPELINED",
+                "version": "5",
+                "DbHits": 0,
+                "batch-size": 128,
+                "Details": "n",
+                "planner-version": "2026.01",
+                "PipelineInfo": "Fused in Pipeline 0",
+                "runtime-version": "2026.01",
+                "Id": 0,
+                "EstimatedRows": 10.0,
+                "planner": "COST",
+                "Rows": 0,
+            },
+            "children": [
+                {
+                    "args": {
+                        "Details": "n",
+                        "PipelineInfo": "Fused in Pipeline 0",
+                        "Memory": 248,
+                        "Time": 273643,
+                        "Id": 1,
+                        "EstimatedRows": 10.0,
+                        "PageCacheMisses": 0,
+                        "DbHits": 1,
+                        "Rows": 0,
+                        "PageCacheHits": 0,
+                    },
+                    "pageCacheMisses": 0,
+                    "dbHits": 1,
+                    "identifiers": ["n"],
+                    "operatorType": "AllNodesScan@neo4j",
+                    "time": 273643,
+                    "rows": 0,
+                    "pageCacheHitRatio": 0.0,
+                    "pageCacheHits": 0,
+                }
+            ],
+            "dbHits": 0,
+            "identifiers": ["n"],
+            "operatorType": "ProduceResults@neo4j",
+            "rows": 0,
+        }
+        summary = self._get_summary(
+            "summary_with_profile.script",
+            vars_={"#PROFILE#": json.dumps(profile)},
+        )
+        self.assert_plan_equal(profile, summary.profile)
+
+
+class TestSummaryPlanDiscard6x0(_TestSummaryDiscardMixin, TestSummaryPlan6x0):
     def test_plan(self):
         super().test_plan()
 

--- a/tests/stub/summary/test_summary.py
+++ b/tests/stub/summary/test_summary.py
@@ -57,9 +57,9 @@ class _TestSummaryBase(TestkitTestCase):
 
         def adjust_expected(actual_child, expected_child):
             for key in [k for k, v in expected_child.items() if v is None]:
-                if key not in expected_child:
+                if key not in actual_child:
                     expected_child.pop(key)
-            for key in (k for k, v in expected_child.items() if v is None):
+            for key in (k for k, v in actual_child.items() if v is None):
                 expected_child.setdefault(key, None)
 
             if not missing_stats_detectable:

--- a/tests/stub/summary/test_summary.py
+++ b/tests/stub/summary/test_summary.py
@@ -72,13 +72,15 @@ class _TestSummaryBase(TestkitTestCase):
             #   * a null value
             #   * lack of the key
             expected_children = expected_child.get("children")
-            expected_has_children = expected_children not in (None, [])
+            expected_has_no_children = expected_children in (None, [])
             actual_children = actual_child.get("children")
-            actual_has_children = actual_children not in (None, [])
+            actual_has_no_children = actual_children in (None, [])
 
-            if not expected_has_children and not actual_has_children:
-                expected_child.pop("children", None)
-                actual_child.pop("children", None)
+            if expected_has_no_children and actual_has_no_children:
+                if "children" in actual_child:
+                    expected_child["children"] = actual_children
+                else:
+                    expected_child.pop("children", None)
                 return
 
             expected_children = expected_children or []

--- a/tests/stub/summary/test_summary.py
+++ b/tests/stub/summary/test_summary.py
@@ -50,7 +50,22 @@ class _TestSummaryBase(TestkitTestCase):
             return result.consume()
 
     def assert_plan_equal(self, actual, expected):
+        missing_stats_detectable = self.driver_supports_features(
+            types.Feature.API_SUMMARY_PROFILE_OPTIONAL_STATS
+        )
+
         def adjust_expected(actual_child, expected_child):
+            for key in [k for k, v in expected_child.items() if v is None]:
+                if key not in expected_child:
+                    expected_child.pop(key)
+            for key in (k for k, v in expected_child.items() if v is None):
+                expected_child.setdefault(key, None)
+
+            if not missing_stats_detectable:
+                for key, actual_value in actual_child.items():
+                    if actual_value == 0 and expected_child.get(key) is None:
+                        expected_child[key] = 0
+
             # drivers are free to represent lack of children with either:
             #   * an empty list
             #   * a null value
@@ -190,7 +205,7 @@ class TestSummaryNotifications4x4(_TestSummaryBase):
 
     def test_no_notifications(self):
         summary = self._get_summary("empty_summary_type_r.script")
-        self.assertEqual(summary.notifications, None)
+        self.assertIn(summary.notifications, ([], None))
 
     def test_empty_notifications(self):
         notifications = []
@@ -200,7 +215,7 @@ class TestSummaryNotifications4x4(_TestSummaryBase):
                 "#NOTIFICATIONS#": json.dumps(notifications)
             }
         )
-        self.assertEqual(summary.notifications, notifications)
+        self.assertIn(summary.notifications, ([], None))
 
     def test_full_notification(self):
         in_notifications = [{
@@ -334,7 +349,7 @@ class TestSummaryNotifications5x6(_TestSummaryBase):
 
     def test_no_notifications(self):
         summary = self._get_summary("empty_summary_type_r.script")
-        self.assertEqual(summary.notifications, [])
+        self.assertIn(summary.notifications, ([], None))
 
     def test_empty_notifications(self):
         statuses = [SUCCESS_GQL_STATUS_OBJECT]
@@ -344,7 +359,7 @@ class TestSummaryNotifications5x6(_TestSummaryBase):
                 "#STATUSES#": json.dumps(statuses)
             }
         )
-        self.assertEqual(summary.notifications, [])
+        self.assertIn(summary.notifications, ([], None))
 
     def test_full_notification(self):
         in_statuses = [
@@ -1466,7 +1481,7 @@ class TestSummaryPlan4x4(_TestSummaryBase):
             "summary_with_profile.script",
             vars_={"#PROFILE#": json.dumps(profile)},
         )
-        self.assert_plan_equal(profile, summary.profile)
+        self.assert_plan_equal(summary.profile, profile)
 
 
 class TestSummaryPlanDiscard4x4(_TestSummaryDiscardMixin, TestSummaryPlan4x4):
@@ -1615,7 +1630,167 @@ class TestSummaryPlan6x0(_TestSummaryBase):
             "summary_with_profile.script",
             vars_={"#PROFILE#": json.dumps(profile)},
         )
-        self.assert_plan_equal(profile, summary.profile)
+        self.assert_plan_equal(summary.profile, profile)
+
+    def test_profile_no_db_hit(self):
+        profile = {
+            "args": {},
+            "children": [
+                {
+                    "args": {},
+                    "identifiers": ["n"],
+                    "operatorType": "AllNodesScan@neo4j",
+                    "time": 273643,
+                    "rows": 1,
+                    "pageCacheHitRatio": 1.2,
+                    "pageCacheHits": 3,
+                    "pageCacheMisses": 4,
+                }
+            ],
+            "rows": 0,
+            "pageCacheHitRatio": 0.0,
+            "pageCacheHits": 0,
+            "pageCacheMisses": 0,
+            "time": 123456,
+            "identifiers": ["n"],
+            "operatorType": "ProduceResults@neo4j",
+        }
+        if not self.driver_supports_features(
+            types.Feature.API_SUMMARY_PROFILE_OPTIONAL_STATS
+        ):
+            # cutting unified drivers some extra slack:
+            # some drivers assume that the top-level profile element never
+            # contains stats
+            profile = {
+                "args": {},
+                "children": [profile],
+                "identifiers": ["coolio!"],
+                "operatorType": "TestKitWrapperForStrictDrivers",
+            }
+        summary = self._get_summary(
+            "summary_with_profile.script",
+            vars_={"#PROFILE#": json.dumps(profile)},
+        )
+        self.assert_plan_equal(summary.profile, profile)
+
+    def test_profile_no_time(self):
+        profile = {
+            "args": {},
+            "children": [
+                {
+                    "args": {},
+                    "identifiers": ["n"],
+                    "operatorType": "AllNodesScan@neo4j",
+                    "dbHits": 0,
+                    "rows": 0,
+                    "pageCacheHitRatio": 1.2,
+                    "pageCacheHits": 3,
+                    "pageCacheMisses": 4,
+                }
+            ],
+            "dbHits": 123,
+            "rows": 1,
+            "pageCacheHitRatio": 0.0,
+            "pageCacheHits": 0,
+            "pageCacheMisses": 0,
+            "identifiers": ["n"],
+            "operatorType": "ProduceResults@neo4j",
+        }
+        if not self.driver_supports_features(
+            types.Feature.API_SUMMARY_PROFILE_OPTIONAL_STATS
+        ):
+            # cutting unified drivers some extra slack:
+            # some drivers assume that the top-level profile element never
+            # contains stats
+            profile = {
+                "args": {},
+                "children": [profile],
+                "identifiers": ["coolio!"],
+                "operatorType": "TestKitWrapperForStrictDrivers",
+            }
+        summary = self._get_summary(
+            "summary_with_profile.script",
+            vars_={"#PROFILE#": json.dumps(profile)},
+        )
+        self.assert_plan_equal(summary.profile, profile)
+
+    def test_profile_no_rows(self):
+        profile = {
+            "args": {},
+            "children": [
+                {
+                    "args": {},
+                    "identifiers": ["n"],
+                    "operatorType": "AllNodesScan@neo4j",
+                    "dbHits": 123,
+                    "time": 0,
+                    "pageCacheHitRatio": 0.0,
+                    "pageCacheHits": 0,
+                    "pageCacheMisses": 0,
+                }
+            ],
+            "dbHits": 0,
+            "time": 0,
+            "pageCacheHitRatio": 1.2,
+            "pageCacheHits": 3,
+            "pageCacheMisses": 4,
+            "identifiers": ["n"],
+            "operatorType": "ProduceResults@neo4j",
+        }
+        if not self.driver_supports_features(
+            types.Feature.API_SUMMARY_PROFILE_OPTIONAL_STATS
+        ):
+            # cutting unified drivers some extra slack:
+            # some drivers assume that the top-level profile element never
+            # contains stats
+            profile = {
+                "args": {},
+                "children": [profile],
+                "identifiers": ["coolio!"],
+                "operatorType": "TestKitWrapperForStrictDrivers",
+            }
+        summary = self._get_summary(
+            "summary_with_profile.script",
+            vars_={"#PROFILE#": json.dumps(profile)},
+        )
+        self.assert_plan_equal(summary.profile, profile)
+
+    def test_profile_no_page_cache_stats(self):
+        profile = {
+            "args": {},
+            "children": [
+                {
+                    "args": {},
+                    "identifiers": ["n"],
+                    "operatorType": "AllNodesScan@neo4j",
+                    "dbHits": 123,
+                    "rows": 3456,
+                    "time": 0,
+                }
+            ],
+            "dbHits": 0,
+            "rows": 5,
+            "time": 0,
+            "identifiers": ["n"],
+            "operatorType": "ProduceResults@neo4j",
+        }
+        if not self.driver_supports_features(
+            types.Feature.API_SUMMARY_PROFILE_OPTIONAL_STATS
+        ):
+            # cutting unified drivers some extra slack:
+            # some drivers assume that the top-level profile element never
+            # contains stats
+            profile = {
+                "args": {},
+                "children": [profile],
+                "identifiers": ["coolio!"],
+                "operatorType": "TestKitWrapperForStrictDrivers",
+            }
+        summary = self._get_summary(
+            "summary_with_profile.script",
+            vars_={"#PROFILE#": json.dumps(profile)},
+        )
+        self.assert_plan_equal(summary.profile, profile)
 
 
 class TestSummaryPlanDiscard6x0(_TestSummaryDiscardMixin, TestSummaryPlan6x0):

--- a/tests/stub/summary/test_summary.py
+++ b/tests/stub/summary/test_summary.py
@@ -1,3 +1,4 @@
+import copy
 import json
 from contextlib import contextmanager
 
@@ -86,6 +87,8 @@ class _TestSummaryBase(TestkitTestCase):
                 for ac, ec in zip(actual_children, expected_children):
                     adjust_expected(ac, ec)
 
+        actual = copy.deepcopy(actual)
+        expected = copy.deepcopy(expected)
         adjust_expected(actual, expected)
         self.assertEqual(actual, expected)
 


### PR DESCRIPTION
  * Allow missing children key, null children value, empty list children value are now considered equivalent.
  * Add tests for bolt 6.0 where the structure of profiles and plans has changed a fair bit. Most prominently will `children` be omitted by the bolt server when it's empty.
  * Adding tests under new feature flag `"Feature:API:Summary:Profile:OptionalStats"`:  
    Drivers should be able to differentiate missing profile stats (e.g., `dbHits = 0` has a different meaning that absent `dbHits`)
  
  Closes: DRIVERS-281
  
  Depends on:
   * https://github.com/neo4j/neo4j-javascript-driver/pull/1397
   * https://github.com/neo4j/neo4j-java-driver/pull/1731