### PR TITLE
ITs: skip ITs for server versions that are not supported by the driver

### DIFF
--- a/main.py
+++ b/main.py
@@ -415,14 +415,17 @@ def main(settings, configurations):
         server_name = neo4j_config.name
         stress_duration = neo4j_config.stress_test_duration
 
-        if not (
-            test_flags["TESTKIT_TESTS"]
-            or (test_flags["STRESS_TESTS"] and stress_duration > 0)
-            or test_flags["INTEGRATION_TESTS"]
-            or (
-                is_neo4j_test_selected_to_run()
-                and not test_flags["EXTERNAL_TESTKIT_TESTS"]
+        if (
+            not (
+                test_flags["TESTKIT_TESTS"]
+                or (test_flags["STRESS_TESTS"] and stress_duration > 0)
+                or test_flags["INTEGRATION_TESTS"]
+                or (
+                    is_neo4j_test_selected_to_run()
+                    and not test_flags["EXTERNAL_TESTKIT_TESTS"]
+                )
             )
+            or runner_container.should_run_neo4j_tests(neo4j_config)
         ):
             continue
         with test_suite(neo4j_config.name):

--- a/runner.py
+++ b/runner.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 import docker
 
@@ -77,23 +78,51 @@ class Container:
             ["python3", "-m", "tests.tls.suites"]
         )
 
+    def should_run_neo4j_tests(self, neo4j_config):
+        self._update_neo4j_tests_env_config(neo4j_config)
+        try:
+            self._container.exec(
+                ["python3", "-m", "tests.neo4j.version_check"],
+                env_map=self._env
+            )
+        except subprocess.CalledProcessError as e:
+            if e.returncode == 99:
+                print(
+                    "Neo4j tests will be skipped due to incompatible protocol "
+                    "versions between driver and server."
+                )
+                return True
+            raise
+        return False
+
     def run_neo4j_tests(self, suite, hostname, username, password,
                         neo4j_config):
+        self._update_neo4j_tests_env(
+            hostname, username, password, neo4j_config
+        )
+        self._container.exec(
+            ["python3", "-m", "tests.neo4j.suites", suite, neo4j_config.name],
+            env_map=self._env
+        )
+
+    def _update_neo4j_tests_env(self, hostname, username, password,
+                                neo4j_config):
+        self._update_neo4j_tests_env_config(neo4j_config)
         self._env.update({
             # Hostname of Docker container running db
             "TEST_NEO4J_HOST": hostname,
             "TEST_NEO4J_USER": username,
             "TEST_NEO4J_PASS": password,
+            "TEST_NEO4J_DEFAULT_DB": "neo4j",
+        })
+
+    def _update_neo4j_tests_env_config(self, neo4j_config):
+        self._env.update({
             "TEST_NEO4J_SCHEME": neo4j_config.scheme,
             "TEST_NEO4J_VERSION": neo4j_config.version,
             "TEST_NEO4J_EDITION": neo4j_config.edition,
             "TEST_NEO4J_CLUSTER": neo4j_config.cluster,
-            "TEST_NEO4J_DEFAULT_DB": "neo4j",
         })
-        self._container.exec(
-            ["python3", "-m", "tests.neo4j.suites", suite, neo4j_config.name],
-            env_map=self._env
-        )
 
     def run_neo4j_tests_env_config(self):
         for key in ("TEST_NEO4J_HOST",

--- a/tests/neo4j/version_check.py
+++ b/tests/neo4j/version_check.py
@@ -1,0 +1,24 @@
+from tests.neo4j.shared import get_server_info
+from tests.shared import (
+    get_driver_features,
+    new_backend,
+)
+
+
+def main():
+    backend = new_backend()
+    features = get_driver_features(backend, silence_error=False)
+
+    info = get_server_info()
+    common_versions = info.common_protocol_versions(features)
+    if common_versions:
+        print("Common protocol versions:")
+        print(f"  {' '.join(map(str, common_versions))}")
+        exit(0)
+    else:
+        print("No common protocol versions found.")
+        exit(99)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -121,7 +121,7 @@ class MemoizedSupplier:
 
 
 @MemoizedSupplier
-def get_driver_features(backend):
+def get_driver_features(backend, silence_error=True):
     try:
         response = backend.send_and_receive(protocol.GetFeatures())
         if not isinstance(response, protocol.FeatureList):
@@ -135,9 +135,10 @@ def get_driver_features(backend):
         if get_driver_name() in ["go"]:
             assert protocol.Feature.API_SSL_SCHEMES not in features
             features.add(protocol.Feature.API_SSL_SCHEMES)
-        print("features", features)
         return features
     except (OSError, protocol.BaseError) as e:
+        if not silence_error:
+            raise
         warnings.warn(f"Could not fetch FeatureList: {e}")  # noqa: B028
         return set()
 


### PR DESCRIPTION
Before spinning up a DBMS, check the driver backend's reported features to see if a shared protocol version exists.