### PR TITLE
Add dotnet to lazy error surfacing condition in idempotent retry tests

### DIFF
--- a/tests/stub/idempotent_retries/test_idempotent_retries.py
+++ b/tests/stub/idempotent_retries/test_idempotent_retries.py
@@ -48,7 +48,7 @@ class TestIdempotentRetries(TestkitTestCase):
         self._session = self._driver.session("r")
         with self.assertRaises(types.DriverError) as exc:
             # TODO: remove this block once all languages work
-            if get_driver_name() in ["javascript"]:
+            if get_driver_name() in ["javascript", "dotnet"]:
                 self._session.run("RETURN 1 AS n").next()
             else:
                 self._session.run("RETURN 1 AS n")
@@ -62,7 +62,7 @@ class TestIdempotentRetries(TestkitTestCase):
         self._session = self._driver.session("r")
         with self.assertRaises(types.DriverError) as exc:
             # TODO: remove this block once all languages work
-            if get_driver_name() in ["javascript"]:
+            if get_driver_name() in ["javascript", "dotnet"]:
                 self._session.run("RETURN 1 AS n").next()
             else:
                 self._session.run("RETURN 1 AS n")


### PR DESCRIPTION
dotnet surfaces RUN errors lazily
