### PR TITLE
Avoid race condition on which error is reported for the JS driver

### DIFF
--- a/tests/stub/idempotent_retries/test_idempotent_retries.py
+++ b/tests/stub/idempotent_retries/test_idempotent_retries.py
@@ -166,7 +166,10 @@ class TestIdempotentRetries(TestkitTestCase):
             with driver.session("r") as session:
                 with self.assertRaises(types.DriverError) as exc:
                     tx = session.begin_transaction()
-                    tx.run("RETURN 1")
+                    if get_driver_name() in ["javascript"]:
+                        tx.run("RETURN 1").next()
+                    else:
+                        tx.run("RETURN 1")
                     tx.commit()
                 self.assertEqual(
                     exc.exception.code,


### PR DESCRIPTION
Part of: DRIVERS-309

Due to similar reasons that JS and dotnet have to call next() on `session.run()` results to get an error, not consuming the result of `tx.run()` triggers a race condition in the JS backend, leaving it up to timing if the correct error gets reported or if it's an error relating to committing a failed transaction.