### PR TITLE
Add ruby error-type branches to errorType assertions

### DIFF
--- a/tests/stub/authorization/test_authorization.py
+++ b/tests/stub/authorization/test_authorization.py
@@ -57,6 +57,9 @@ class AuthorizationBase(TestkitTestCase):
         elif driver in ["java"]:
             expected_type = \
                 "org.neo4j.driver.exceptions.SecurityRetryableException"
+        elif driver in ["ruby"]:
+            expected_type = \
+                "Neo4j::Driver::Exceptions::SecurityRetryableException"
         elif driver in ["go"]:
             expected_type = "Neo4jError"
         else:
@@ -106,6 +109,9 @@ class AuthorizationBase(TestkitTestCase):
         elif driver in ["java"]:
             expected_type = \
                 "org.neo4j.driver.exceptions.SecurityRetryableException"
+        elif driver in ["ruby"]:
+            expected_type = \
+                "Neo4j::Driver::Exceptions::SecurityRetryableException"
         elif driver == "go":
             expected_type = "TokenExpiredError"
         else:
@@ -134,6 +140,9 @@ class AuthorizationBase(TestkitTestCase):
         elif driver in ["java"]:
             expected_type = \
                 "org.neo4j.driver.exceptions.AuthenticationException"
+        elif driver in ["ruby"]:
+            expected_type = \
+                "Neo4j::Driver::Exceptions::AuthenticationException"
         elif driver in ["go"]:
             expected_type = "Neo4jError"
         else:
@@ -154,6 +163,9 @@ class AuthorizationBase(TestkitTestCase):
         elif driver in ["java"]:
             expected_type = \
                 "org.neo4j.driver.exceptions.SecurityRetryableException"
+        elif driver in ["ruby"]:
+            expected_type = \
+                "Neo4j::Driver::Exceptions::SecurityRetryableException"
         elif driver in ["go"]:
             expected_type = "Neo4jError"
         else:
@@ -179,6 +191,8 @@ class AuthorizationBase(TestkitTestCase):
             expected_type = "OtherSecurityException"
         elif driver in ["java"]:
             expected_type = "org.neo4j.driver.exceptions.SecurityException"
+        elif driver in ["ruby"]:
+            expected_type = "Neo4j::Driver::Exceptions::SecurityException"
         elif driver in ["go"]:
             expected_type = "Neo4jError"
         else:
@@ -197,6 +211,9 @@ class AuthorizationBase(TestkitTestCase):
         elif driver in ["java"]:
             expected_type = \
                 "org.neo4j.driver.exceptions.SecurityRetryableException"
+        elif driver in ["ruby"]:
+            expected_type = \
+                "Neo4j::Driver::Exceptions::SecurityRetryableException"
         elif driver in ["dotnet"]:
             expected_type = "OtherSecurityException"
         elif driver in ["go"]:
@@ -220,6 +237,8 @@ class AuthorizationBase(TestkitTestCase):
             pass
         elif driver in ["java"]:
             expected_type = "org.neo4j.driver.exceptions.TransientException"
+        elif driver in ["ruby"]:
+            expected_type = "Neo4j::Driver::Exceptions::TransientException"
         elif driver in ["dotnet"]:
             expected_type = "DriverError"
         elif driver in ["go"]:
@@ -243,6 +262,8 @@ class AuthorizationBase(TestkitTestCase):
             pass
         elif driver in ["java"]:
             expected_type = "org.neo4j.driver.exceptions.ClientException"
+        elif driver in ["ruby"]:
+            expected_type = "Neo4j::Driver::Exceptions::ClientException"
         elif driver in ["dotnet"]:
             expected_type = "ClientError"
         elif driver in ["go"]:

--- a/tests/stub/basic_query/test_basic_query.py
+++ b/tests/stub/basic_query/test_basic_query.py
@@ -41,6 +41,11 @@ class TestBasicQuery(TestkitTestCase):
         if get_driver_name() in ["java"]:
             self.assertEqual("java.lang.IllegalStateException",
                              exc.exception.errorType)
+        if get_driver_name() in ["ruby"]:
+            self.assertEqual(
+                "Neo4j::Driver::Exceptions::IllegalStateException",
+                exc.exception.errorType
+            )
 
     @contextmanager
     def _get_session(self, script_path, vars_=None):

--- a/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
+++ b/tests/stub/configuration_hints/test_connection_recv_timeout_seconds.py
@@ -82,7 +82,7 @@ class TestDirectConnectionRecvTimeout(TestkitTestCase):
             )
         elif driver in ["ruby"]:
             self.assertEqual(
-                "Neo4j::Driver::Exceptions::ClientException",
+                "Neo4j::Driver::Exceptions::TransactionTerminatedException",
                 e.errorType
             )
         elif driver in ["python"]:

--- a/tests/stub/routing/test_routing_v5x0.py
+++ b/tests/stub/routing/test_routing_v5x0.py
@@ -720,6 +720,11 @@ class RoutingV5x0(RoutingBase):
                 "org.neo4j.driver.exceptions.SessionExpiredException",
                 exc.exception.errorType
             )
+        elif driver_name in ["ruby"]:
+            self.assertEqual(
+                "Neo4j::Driver::Exceptions::SessionExpiredException",
+                exc.exception.errorType
+            )
         elif driver_name in ["python"]:
             self.assertEqual(
                 "<class 'neo4j.exceptions.SessionExpired'>",
@@ -2633,6 +2638,11 @@ class RoutingV5x0(RoutingBase):
                     "org.neo4j.driver.exceptions.SessionExpiredException",
                     e.errorType
                 )
+            elif driver_name in ["ruby"]:
+                self.assertEqual(
+                    "Neo4j::Driver::Exceptions::SessionExpiredException",
+                    e.errorType
+                )
             elif driver_name in ["python"]:
                 self.assertEqual(
                     "<class 'neo4j.exceptions.SessionExpired'>",
@@ -2680,6 +2690,11 @@ class RoutingV5x0(RoutingBase):
             if get_driver_name() in ["java"]:
                 self.assertEqual(
                     "org.neo4j.driver.exceptions.SessionExpiredException",
+                    e.exception.errorType
+                )
+            elif get_driver_name() in ["ruby"]:
+                self.assertEqual(
+                    "Neo4j::Driver::Exceptions::SessionExpiredException",
                     e.exception.errorType
                 )
             elif get_driver_name() in ["python"]:
@@ -2983,6 +2998,15 @@ class RoutingV5x0(RoutingBase):
         if get_driver_name() in ["java"]:
             self.assertEqual(
                 "org.neo4j.driver.exceptions.ClientException",
+                exc.exception.errorType
+            )
+            self.assertTrue("Unable to acquire connection from the "
+                            "pool within configured maximum time of "
+                            f"{acq_timeout_ms}ms"
+                            in exc.exception.msg)
+        elif get_driver_name() in ["ruby"]:
+            self.assertEqual(
+                "Neo4j::Driver::Exceptions::ClientException",
                 exc.exception.errorType
             )
             self.assertTrue("Unable to acquire connection from the "

--- a/tests/stub/server_side_routing/test_server_side_routing.py
+++ b/tests/stub/server_side_routing/test_server_side_routing.py
@@ -59,6 +59,7 @@ class TestServerSideRouting(TestkitTestCase):
             self.assertIn(uri, exc.exception.msg)
         elif get_driver_name() in ["ruby"]:
             self.assertEqual("ArgumentError", exc.exception.errorType)
+            self.assertIn(uri, exc.exception.msg)
         elif get_driver_name() in ["python"]:
             self.assertEqual(
                 "<class 'neo4j.exceptions.ConfigurationError'>",

--- a/tests/stub/summary/test_summary.py
+++ b/tests/stub/summary/test_summary.py
@@ -163,6 +163,11 @@ class TestSummaryBasicInfo(_TestSummaryBase):
                     e.exception.errorType,
                     "org.neo4j.driver.exceptions.ProtocolException"
                 )
+            elif driver in ["ruby"]:
+                self.assertEqual(
+                    e.exception.errorType,
+                    "Neo4j::Driver::Exceptions::ProtocolException"
+                )
             elif driver in ["go"]:
                 self.assertEqual(e.exception.errorType, "ProtocolError")
 

--- a/tests/stub/tx_run/test_tx_run.py
+++ b/tests/stub/tx_run/test_tx_run.py
@@ -507,6 +507,11 @@ class TestTxRun(TestkitTestCase):
                 "org.neo4j.driver.exceptions.ClientException",
                 e.exception.errorType
             )
+        elif driver in ["ruby"]:
+            self.assertEqual(
+                "Neo4j::Driver::Exceptions::ClientException",
+                e.exception.errorType
+            )
         elif driver in ["python"]:
             if e.exception.code.endswith(".SyntaxError"):
                 self.assertEqual(
@@ -533,6 +538,11 @@ class TestTxRun(TestkitTestCase):
         if driver in ["java"]:
             self.assertEqual(
                 "org.neo4j.driver.exceptions.TransactionTerminatedException",
+                e.exception.errorType
+            )
+        elif driver in ["ruby"]:
+            self.assertEqual(
+                "Neo4j::Driver::Exceptions::TransactionTerminatedException",
                 e.exception.errorType
             )
         elif driver in ["python"]:


### PR DESCRIPTION
## Summary
Several per-driver `errorType` assertions across `tests/stub/` have a `java` branch but no `ruby` one, so the Ruby driver fails them with `no error mapping is defined for ruby driver`. This adds the missing `ruby` branches.

## How to verify
Ruby's exception hierarchy mirrors Java's, so the mapping is a simple, checkable rule:

> `org.neo4j.driver.exceptions.X` → `Neo4j::Driver::Exceptions::X`

with two `java.lang` cases: `IllegalStateException` → `Neo4j::Driver::Exceptions::IllegalStateException`, and `IllegalArgumentException` → `ArgumentError` (Ruby's built-in).

## Changes
**Added ruby branches** (by file):
- `authorization/test_authorization.py` — `SecurityRetryableException` (retryable auth/token/unauthorized/security), `AuthenticationException`, `SecurityException`, `TransientException`, `ClientException`
- `tx_run` — `ClientException`, `TransactionTerminatedException`
- `summary` — `ProtocolException`
- `routing/test_routing_v5x0` — `SessionExpiredException` (×3), `ClientException`
- `basic_query` — `IllegalStateException`

**Mirrored message assertions** where the java branch also asserts on `.msg` (the JRuby driver wraps the Java driver, so the message is identical): `server_side_routing` (`assertIn(uri, …)`) and the routing pool-size error.

**One correction** — `configuration_hints/test_connection_recv_timeout_seconds.py`'s `_assert_is_tx_terminated_exception` expected ruby `ClientException`; the Ruby driver reports `TransactionTerminatedException` (mirroring Java), so the branch is aligned.

## Verification
Every affected stub module was run against the Ruby (JRuby) driver; all `errorType` assertions pass. No other driver is affected — only `ruby` branches are added.

Note: the Ruby driver is a community driver (neo4jrb/neo4j-ruby-driver) and isn't in testkit's own CI; these assertions were validated locally against it.