### PR TITLE
FIX: errors for all non-javascript drivers in one of the uuid tests

### DIFF
--- a/tests/stub/datatypes/test_uuid.py
+++ b/tests/stub/datatypes/test_uuid.py
@@ -134,10 +134,10 @@ class TestUuid6x0(_UuidTestCase):
         if driver_name in ["python"]:
             self.assertIn("packstream", msg)
             self.assertIn("e0", msg)  # UUID PackStream type marker byte
-        if driver_name in ["dotnet"]:
+        elif driver_name in ["dotnet"]:
             self.assertIn("uuid", msg)
             self.assertIn("6.1", msg)  # demands bolt 6.1
-        if driver_name in ["javascript"]:
+        elif driver_name in ["javascript"]:
             self.assertIn("unknown packed", msg)
             self.assertIn("e0", msg)  # UUID PackStream type marker byte
         else:


### PR DESCRIPTION
Quick fix for if/elif/else in one of the tests that was causing failures for all non-javascript drivers.