### PR TITLE
Add neo4j integration tests for UUID type (Bolt 6.1)

### DIFF
--- a/tests/neo4j/datatypes/test_uuid.py
+++ b/tests/neo4j/datatypes/test_uuid.py
@@ -1,0 +1,55 @@
+import uuid
+
+import nutkit.protocol as types
+from tests.neo4j.datatypes._base import _TestTypesBase
+
+
+class TestUuidTypes(_TestTypesBase):
+
+    required_features = (
+        types.Feature.API_TYPE_UUID,
+        types.Feature.BOLT_6_1,
+    )
+
+    def test_should_echo_uuid(self):
+        values = [
+            uuid.UUID("00000000-0000-0000-0000-000000000000"),  # nil UUID
+            uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff"),  # all-ones
+            uuid.UUID("01020304-0506-0708-090a-0b0c0d0e0f12"),  # sequential bytes
+            uuid.uuid4(),
+        ]
+        self._create_driver_and_session()
+        for value in values:
+            with self.subTest(value=str(value)):
+                self._verify_can_echo(types.CypherUUID(value))
+
+    def test_uuid_in_list(self):
+        self._create_driver_and_session()
+        data = types.CypherList([
+            types.CypherUUID(uuid.UUID("00000000-0000-0000-0000-000000000000")),
+            types.CypherUUID(uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")),
+            types.CypherUUID(uuid.uuid4()),
+        ])
+        self._verify_can_echo(data)
+
+    def test_uuid_in_map(self):
+        value = uuid.uuid4()
+        self._create_driver_and_session()
+        self._verify_can_echo(
+            types.CypherMap({"id": types.CypherUUID(value)})
+        )
+
+    def test_cypher_created_uuid(self):
+        self._create_driver_and_session()
+        values = self._read_query_values("RETURN uuid()")
+        self.assertEqual(len(values), 1)
+        self.assertIsInstance(values[0], types.CypherUUID)
+
+    def test_uuid_stored_on_node(self):
+        uid = uuid.uuid4()
+        self._create_driver_and_session()
+        values = self._write_query_values(
+            "CREATE (n:Thing {uid: $uid}) RETURN n.uid",
+            params={"uid": types.CypherUUID(uid)},
+        )
+        self.assertEqual(values, [types.CypherUUID(uid)])

--- a/tests/neo4j/datatypes/test_uuid.py
+++ b/tests/neo4j/datatypes/test_uuid.py
@@ -15,7 +15,7 @@ class TestUuidTypes(_TestTypesBase):
         values = [
             uuid.UUID("00000000-0000-0000-0000-000000000000"),  # nil UUID
             uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff"),  # all-ones
-            uuid.UUID("01020304-0506-0708-090a-0b0c0d0e0f12"),  # sequential bytes
+            uuid.UUID("01020304-0506-0708-090a-0b0c0d0e0f12"),  # sequential
             uuid.uuid4(),
         ]
         self._create_driver_and_session()
@@ -25,9 +25,11 @@ class TestUuidTypes(_TestTypesBase):
 
     def test_uuid_in_list(self):
         self._create_driver_and_session()
+        nil = uuid.UUID("00000000-0000-0000-0000-000000000000")
+        ones = uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")
         data = types.CypherList([
-            types.CypherUUID(uuid.UUID("00000000-0000-0000-0000-000000000000")),
-            types.CypherUUID(uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")),
+            types.CypherUUID(nil),
+            types.CypherUUID(ones),
             types.CypherUUID(uuid.uuid4()),
         ])
         self._verify_can_echo(data)

--- a/tests/neo4j/datatypes/test_uuid.py
+++ b/tests/neo4j/datatypes/test_uuid.py
@@ -2,6 +2,7 @@ import uuid
 
 import nutkit.protocol as types
 from tests.neo4j.datatypes._base import _TestTypesBase
+from tests.neo4j.shared import requires_min_bolt_version
 
 
 class TestUuidTypes(_TestTypesBase):
@@ -11,6 +12,7 @@ class TestUuidTypes(_TestTypesBase):
         types.Feature.BOLT_6_1,
     )
 
+    @requires_min_bolt_version("6.1")
     def test_should_echo_uuid(self):
         values = [
             uuid.UUID("00000000-0000-0000-0000-000000000000"),  # nil UUID
@@ -23,6 +25,7 @@ class TestUuidTypes(_TestTypesBase):
             with self.subTest(value=str(value)):
                 self._verify_can_echo(types.CypherUUID(value))
 
+    @requires_min_bolt_version("6.1")
     def test_uuid_in_list(self):
         self._create_driver_and_session()
         nil = uuid.UUID("00000000-0000-0000-0000-000000000000")
@@ -34,6 +37,7 @@ class TestUuidTypes(_TestTypesBase):
         ])
         self._verify_can_echo(data)
 
+    @requires_min_bolt_version("6.1")
     def test_uuid_in_map(self):
         value = uuid.uuid4()
         self._create_driver_and_session()
@@ -41,12 +45,14 @@ class TestUuidTypes(_TestTypesBase):
             types.CypherMap({"id": types.CypherUUID(value)})
         )
 
+    @requires_min_bolt_version("6.1")
     def test_cypher_created_uuid(self):
         self._create_driver_and_session()
         values = self._read_query_values("RETURN uuid()")
         self.assertEqual(len(values), 1)
         self.assertIsInstance(values[0], types.CypherUUID)
 
+    @requires_min_bolt_version("6.1")
     def test_uuid_stored_on_node(self):
         uid = uuid.uuid4()
         self._create_driver_and_session()


### PR DESCRIPTION
## Summary

Adds integration tests for the UUID type introduced in Bolt 6.1, running against a real Neo4j instance.

**`tests/neo4j/datatypes/test_uuid.py`:**
- `test_should_echo_uuid` — scalar UUIDs (nil, all-ones, sequential, random) sent as parameters and echoed back
- `test_uuid_in_list` — list of UUIDs round-trips correctly
- `test_uuid_in_map` — UUID as a map value
- `test_cypher_created_uuid` — server-generated UUID via `uuid()` returns a native `CypherUUID`
- `test_uuid_stored_on_node` — UUID written and read back as a node property

All tests require `Feature:API:Type.UUID` and `Feature:Bolt:6.1`.

Closes: DRIVERS-441