### PR TITLE
Add ruby error assertion for test_rejects_uuid_result

### DIFF
--- a/tests/stub/datatypes/test_uuid.py
+++ b/tests/stub/datatypes/test_uuid.py
@@ -140,7 +140,7 @@ class TestUuid6x0(_UuidTestCase):
         elif driver_name in ["javascript"]:
             self.assertIn("unknown packed", msg)
             self.assertIn("e0", msg)  # UUID PackStream type marker byte
-        elif driver_name in ["java"]:
+        elif driver_name in ["java", "ruby"]:
             self.assertIn("unknown packstream", msg)
             self.assertIn("e0", msg)  # UUID PackStream type marker byte
         elif driver_name in ["go"]:


### PR DESCRIPTION
`test_rejects_uuid_result` (UUID over Bolt 6.0) branches on `driver_name` for the expected error, but has no `ruby` case, so the Ruby driver hits `raise NotImplementedError(f"Add error assertion for {driver_name}")`.

The Ruby driver's JRuby implementation wraps the official Java driver, so a UUID PackStream marker (`0xE0`) received over Bolt 6.0 surfaces the **same** error as the Java driver. This adds `"ruby"` alongside `"java"`, asserting `"unknown packstream"` and `"e0"`.

All other UUID tests (`test_uuid`, `test_uuid_as_node_property`, `test_uuid_in_list`, `test_uuid_in_map`, `test_rejects_uuid_parameter`) already pass for the Ruby driver unchanged.