### PR TITLE
Skip building the Rust boltstub when TEST_RUSTY_STUB isn't set

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -3,6 +3,11 @@ import subprocess
 
 import docker
 
+USE_RUST = (
+    os.environ.get("TEST_RUSTY_STUB", "").lower()
+    in ("true", "y", "yes", "1", "on")
+)
+
 
 def _ensure_image(testkit_path, branch_name, artifacts_path):
     """Ensure that an up-to-date Docker image exists."""
@@ -14,6 +19,7 @@ def _ensure_image(testkit_path, branch_name, artifacts_path):
         image_name,
         image_path,
         log_path=artifacts_path,
+        args={"BUILD_RUST_STUB": "true" if USE_RUST else "false"},
         build_contexts={"boltstub": boltstub_path},
     )
 

--- a/runner_image/Dockerfile
+++ b/runner_image/Dockerfile
@@ -1,17 +1,25 @@
+# syntax=docker/dockerfile:1.4
 FROM ubuntu:20.04 AS build
 
+ARG BUILD_RUST_STUB=true
+
 WORKDIR /root/build/boltstub
-RUN apt-get update && \
-    apt-get install -y \
-        python3 \
-        python3-dev \
-        python3-pip \
-        curl \
-    && rm -rf /var/lib/apt/lists/*
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-RUN --mount=from=boltstub,target=/tmp/boltstub cp -r /tmp/boltstub/* .
-RUN cargo build --release
+RUN --mount=from=boltstub,target=/tmp/boltstub <<EOF
+set -e
+if [ "$BUILD_RUST_STUB" = "true" ]; then
+    apt-get update
+    apt-get install -y python3 python3-dev python3-pip curl
+    rm -rf /var/lib/apt/lists/*
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    export PATH="/root/.cargo/bin:$PATH"
+    cp -r /tmp/boltstub/* .
+    cargo build --release
+    cp target/release/boltstub /root/build/boltstub-bin
+else
+    touch /root/build/boltstub-bin
+    chmod +x /root/build/boltstub-bin
+fi
+EOF
 
 FROM ubuntu:20.04
 
@@ -24,6 +32,6 @@ RUN apt-get update && \
         python3-pip \
         golang \
     && rm -rf /var/lib/apt/lists/*
-COPY --from=build /root/build/boltstub/target/release/boltstub /usr/local/bin/boltstub
+COPY --from=build /root/build/boltstub-bin /usr/local/bin/boltstub
 
 ENV PYTHON=python3


### PR DESCRIPTION
The runner image unconditionally installed the Rust toolchain and ran `cargo build --release` regardless of which stub server the run actually uses, using disk and time on every non-rusty-stub job. This was traced back as the root cause of several disk-space CI failures: non-rusty-stub builds only requested 3gb of space, but the toolchain install, `apt-get` packages, and the compile itself happened every time.

Verified on PR #727's full CI run: the javascript composite, which had failed four times in a row on disk exhaustion, passed cleanly once this fix was in place, and all 14 checks on that PR went green.
