### PR TITLE
Remove dotnet skip for retry-clustering tests

### DIFF
--- a/tests/stub/retry/test_retry_clustering.py
+++ b/tests/stub/retry/test_retry_clustering.py
@@ -115,27 +115,18 @@ class TestRetryClustering(TestkitTestCase):
         self._readServer.done()
 
     def test_retry_ForbiddenOnReadOnlyDatabase(self):  # noqa: N802
-        if get_driver_name() in ["dotnet"]:
-            self.skipTest("Behaves strange")
-
         self._run_with_transient_error(
             "retry_with_fail_after_pull.script",
             "Neo.ClientError.General.ForbiddenOnReadOnlyDatabase"
         )
 
     def test_retry_NotALeader(self):  # noqa: N802
-        if get_driver_name() in ["dotnet"]:
-            self.skipTest("Behaves strange")
-
         self._run_with_transient_error(
             "retry_with_fail_after_pull.script",
             "Neo.ClientError.Cluster.NotALeader"
         )
 
     def test_retry_ForbiddenOnReadOnlyDatabase_ChangingWriter(self):  # noqa: N802,E501
-        if get_driver_name() in ["dotnet"]:
-            self.skipTest("Behaves strange")
-
         self._routingServer.start(
             path=self.script_path("clustering",
                                   "router_swap_reader_and_writer.script"),


### PR DESCRIPTION
Fixes DRIVERS-511

Removes the three hardcoded dotnet skips ("Behaves strange") from `test_retry_clustering.py`. The rewritten .NET testkit backend handles the retryable-negative flow correctly, and all three tests pass against it (verified locally against the rewrite at its current head).

neo4j/neo4j-dotnet-driver#957 has now merged, so this PR is now safe to merge too.