### PR TITLE
Remove UUID preview env flags now UUID is GA in 2026.09 nightlies

### DIFF
--- a/neo4j.py
+++ b/neo4j.py
@@ -70,16 +70,6 @@ class Standalone:
         if self._edition != "community":
             env_map["NEO4J_ACCEPT_LICENSE_AGREEMENT"] = "yes"
 
-        # TODO: remove once UUID is GA
-        # [uuid-preview] search tag for removal of UUID preview workarounds
-        if (2026, 4) < self._version:
-            env_map.update({
-                "NEO4J_internal_dbms_latest__runtime__version": "2147483647",
-                "NEO4J_internal_dbms_latest__kernel__version": "254",
-                "NEO4J_internal_cypher_uuid__type__enabled": "true",
-                "NEO4J_internal_dbms_bolt_max__protocol__version": "6.1",
-            })
-
         logs_path = join(self._artifacts_path, "logs")
         self._container = docker.run(
             self._image, self._hostname,
@@ -266,16 +256,6 @@ class Core:
             env_map.update({
                 "NEO4J_dbms_cluster_raft_leader__transfer_balancing__strategy":
                     "NO_BALANCING",  # noqa: E131
-            })
-
-        # TODO: remove once UUID is GA
-        # [uuid-preview] search tag for removal of UUID preview workarounds
-        if (2026, 4) < self._version:
-            env_map.update({
-                "NEO4J_internal_dbms_latest__runtime__version": "2147483647",
-                "NEO4J_internal_dbms_latest__kernel__version": "254",
-                "NEO4J_internal_cypher_uuid__type__enabled": "true",
-                "NEO4J_internal_dbms_bolt_max__protocol__version": "6.1",
             })
 
         logs_path = join(self._artifacts_path, "logs")


### PR DESCRIPTION
The `2026-community-debian-nightly` image is now 2026.09.0, where UUID went GA and `internal.cypher.uuid_type_enabled` was removed. Testkit still passes it, which fails strict config validation, so the server exits about 4 seconds after start, and the run aborts.

I ran the current nightly with no overrides at all: it boots fine, negotiates Bolt 6.1 by default, and `RETURN uuid('...')` round-trips with `valueType` reporting `UUID NOT NULL`. The whole `[uuid-preview]` env block is obsolete, not just the one removed setting, so this deletes both copies (`Standalone.start` and `Core.start`).

The two remaining `[uuid-preview]` comments (the `max_protocol_version` bound in `tests/neo4j/shared.py` and the released-version matrix TODO in `main.py`) need the final GA version number when the UUID stuff actually ships.