### PR TITLE
Let --run-only-selected name several tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -223,7 +223,8 @@ def parse_command_line(configurations, argv):
         servers_help += config.name + ", "
 
     run_only_help = (
-        "Runs only the selected tests "
+        "Runs only the selected tests. Accepts several whitespace-separated "
+        "test names, which lets CI shard a suite across parallel jobs "
         "(see https://docs.python.org/3/library/unittest.html#command-line-interface)"  # noqa: 501
     )
 

--- a/runner.py
+++ b/runner.py
@@ -152,14 +152,18 @@ class Container:
         )
 
     def run_selected_stub_tests(self, testpattern):
-        self._container.exec(["python3", "-m", "unittest", "-v", testpattern])
+        self._container.exec(
+            ["python3", "-m", "unittest", "-v", *testpattern.split()]
+        )
 
     def run_selected_tls_tests(self, testpattern):
         # Build TLS server
         self._container.exec(
             ["go", "build", "-v", "."], workdir="/testkit/tlsserver"
         )
-        self._container.exec(["python3", "-m", "unittest", "-v", testpattern])
+        self._container.exec(
+            ["python3", "-m", "unittest", "-v", *testpattern.split()]
+        )
 
     def run_selected_neo4j_tests(self, test_pattern, hostname, username,
                                  password, neo4j_config):


### PR DESCRIPTION
`run_selected_stub_tests` and `run_selected_tls_tests` pass the selector to the container as a single argv element:

```python
self._container.exec(["python3", "-m", "unittest", "-v", testpattern])
```

so `TEST_SELECTOR` can name exactly one module. That makes it impossible to shard a suite across parallel CI jobs — there's no way to name a set, and no way to subtract one module from the rest.

Splitting on whitespace lifts the restriction. `python -m unittest` already accepts several test names, so shards can be balanced however CI likes.

**Backwards compatible**: a selector containing no whitespace splits to a single-element list and behaves exactly as before.

### Why not select a package instead?

Because it silently passes having run nothing. The stub packages have empty `__init__.py` files and no `load_tests`, so `loadTestsFromName` resolves them to an empty suite — and `unittest` exits 0:

```
$ python3 -m unittest -v pkg.test_a pkg.test_b
Ran 3 tests ... OK

$ python3 -m unittest -v pkg
Ran 0 tests ... OK          # <- silently green
```

A CI job sharding by package would report success having executed no tests at all, which is worse than failing.

### Motivation

The .NET driver's testkit build is being split into parallel jobs. `tests.stub.routing` is ~21% of the entire build on its own — 504 tests across five near-duplicate protocol-version modules — so it needs sharding rather than running whole. Without this change the only options are one job per module (61 of them, most under 48s, so setup cost dominates) or leaving the suite monolithic.

Python and Go split their testkit builds by category too, and have the same single-dominant-module shape in their stub suites, so this should be useful beyond .NET.
