### PR TITLE
Allow the stub suite and the server config list to be sharded across parallel CI jobs

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,10 @@ import runner
 import settings
 import waiter
 from teamcity.messages import test_suite
-from tests.testenv import in_teamcity
+from tests.testenv import (
+    in_teamcity,
+    shard_list,
+)
 
 # TODO: Move to docker.py
 networks = ["testkit_1", "testkit_2"]
@@ -242,6 +245,9 @@ def parse_command_line(configurations, argv):
     set_test_flags(args.tests, args.external_integration,
                    args.run_only_selected)
     configs = construct_configuration_list(configurations, args.configs)
+    config_shard = os.environ.get("TEST_CONFIG_SHARD")
+    if config_shard:
+        configs = shard_list(configs, config_shard)
     print("Accepted configurations:")
     for item in configs:
         print("     ", item.name)

--- a/tests/stub/suites.py
+++ b/tests/stub/suites.py
@@ -4,7 +4,10 @@ import os
 import sys
 import unittest
 
-from tests.testenv import get_test_result_class
+from tests.testenv import (
+    get_test_result_class,
+    shard_suite,
+)
 
 loader = unittest.TestLoader()
 
@@ -17,8 +20,14 @@ stub_suite.addTest(loader.discover(
     ))
 ))
 
+suite_name = "Stub tests"
+
+shard = os.environ.get("TEST_SHARD")
+if shard:
+    stub_suite = shard_suite(stub_suite, shard)
+    suite_name += " (shard %s)" % (shard,)
+
 if __name__ == "__main__":
-    suite_name = "Stub tests"
     runner = unittest.TextTestRunner(
         resultclass=get_test_result_class(suite_name),
         verbosity=100, stream=sys.stdout,

--- a/tests/testenv.py
+++ b/tests/testenv.py
@@ -39,14 +39,18 @@ def parse_shard(spec):
     return index, count
 
 
-def shard_suite(suite, spec):
-    # Tests are taken round-robin so tests from an expansive
-    # module are spread across shards.
+def shard_list(items, spec):
+    # Items are taken round-robin so a run of expensive items is spread
+    # across shards.
     index, count = parse_shard(spec)
+    return items[index - 1::count]
+
+
+def shard_suite(suite, spec):
     tests = list(_flatten(suite))
-    selected = tests[index - 1::count]
+    selected = shard_list(tests, spec)
     print(
-        "Shard %d/%d: running %d of %d tests"
-        % (index, count, len(selected), len(tests))
+        "Shard %s: running %d of %d tests"
+        % (spec.strip(), len(selected), len(tests))
     )
     return unittest.TestSuite(selected)

--- a/tests/testenv.py
+++ b/tests/testenv.py
@@ -26,7 +26,7 @@ def parse_shard(spec):
     parts = [part.strip() for part in spec.split("/")]
     if len(parts) != 2 or not all(part.isdigit() for part in parts):
         raise ValueError(
-            'shard must look like "index/count", for example "2/5", got %r'
+            'shard must look like "index/count", for example "2/5", got "%r"'
             % (spec,)
         )
     index, count = (int(part) for part in parts)
@@ -40,12 +40,8 @@ def parse_shard(spec):
 
 
 def shard_suite(suite, spec):
-    """Take every count-th test from suite, starting at index.
-
-    Tests are taken round-robin over the discovery order rather than in
-    contiguous blocks, so a single expensive module is spread across every
-    shard instead of landing wholly in one.
-    """
+    # Tests are taken round-robin so tests from an expansive
+    # module are spread across shards.
     index, count = parse_shard(spec)
     tests = list(_flatten(suite))
     selected = tests[index - 1::count]

--- a/tests/testenv.py
+++ b/tests/testenv.py
@@ -31,7 +31,7 @@ def parse_shard(spec):
         raise ValueError("shard count must be at least 1")
 
     if not 1 <= index <= count:
-        raise ValueError("shard index must be >= 1 and <= %d" % (count,))
+        raise ValueError(f"shard index must be >= 1 and <= {count}")
 
     return index, count
 

--- a/tests/testenv.py
+++ b/tests/testenv.py
@@ -26,7 +26,7 @@ def parse_shard(spec):
     parts = [part.strip() for part in spec.split("/")]
     if len(parts) != 2 or not all(part.isdigit() for part in parts):
         raise ValueError(
-            'shard must look like "index/count", for example "2/5", got "%r"'
+            'shard must look like "index/count", for example "2/5", got %r'
             % (spec,)
         )
     index, count = (int(part) for part in parts)

--- a/tests/testenv.py
+++ b/tests/testenv.py
@@ -38,7 +38,14 @@ def parse_shard(spec):
 
 def shard_list(items, spec):
     index, count = parse_shard(spec)
-    return items[index - 1::count]
+    selected = items[index - 1::count]
+    if not selected:
+        raise ValueError(
+            f"shard {index}/{count} selects nothing: there are only "
+            f"{len(items)} items to shard"
+        )
+
+    return selected
 
 
 def shard_suite(suite, spec):

--- a/tests/testenv.py
+++ b/tests/testenv.py
@@ -1,3 +1,5 @@
+import unittest
+
 from teamcity import (
     in_teamcity,
     team_city_test_result,
@@ -9,3 +11,46 @@ def get_test_result_class(name):
     if not in_teamcity:
         return test_kit_basic_test_result(name)
     return team_city_test_result(name)
+
+
+def _flatten(suite):
+    for item in suite:
+        if isinstance(item, unittest.TestSuite):
+            yield from _flatten(item)
+        else:
+            yield item
+
+
+def parse_shard(spec):
+    """Parse an "index/count" shard spec into a 1-based (index, count)."""
+    parts = [part.strip() for part in spec.split("/")]
+    if len(parts) != 2 or not all(part.isdigit() for part in parts):
+        raise ValueError(
+            'shard must look like "index/count", for example "2/5", got %r'
+            % (spec,)
+        )
+    index, count = (int(part) for part in parts)
+    if count < 1:
+        raise ValueError("shard count must be at least 1, got %r" % (spec,))
+    if not 1 <= index <= count:
+        raise ValueError(
+            "shard index must be between 1 and %d, got %r" % (count, spec)
+        )
+    return index, count
+
+
+def shard_suite(suite, spec):
+    """Take every count-th test from suite, starting at index.
+
+    Tests are taken round-robin over the discovery order rather than in
+    contiguous blocks, so a single expensive module is spread across every
+    shard instead of landing wholly in one.
+    """
+    index, count = parse_shard(spec)
+    tests = list(_flatten(suite))
+    selected = tests[index - 1::count]
+    print(
+        "Shard %d/%d: running %d of %d tests"
+        % (index, count, len(selected), len(tests))
+    )
+    return unittest.TestSuite(selected)

--- a/tests/testenv.py
+++ b/tests/testenv.py
@@ -22,26 +22,21 @@ def _flatten(suite):
 
 
 def parse_shard(spec):
-    """Parse an "index/count" shard spec into a 1-based (index, count)."""
     parts = [part.strip() for part in spec.split("/")]
     if len(parts) != 2 or not all(part.isdigit() for part in parts):
-        raise ValueError(
-            'shard must look like "index/count", for example "2/5", got %r'
-            % (spec,)
-        )
+        raise ValueError('shard must be in the form "#/#"')
+
     index, count = (int(part) for part in parts)
     if count < 1:
-        raise ValueError("shard count must be at least 1, got %r" % (spec,))
+        raise ValueError("shard count must be at least 1")
+
     if not 1 <= index <= count:
-        raise ValueError(
-            "shard index must be between 1 and %d, got %r" % (count, spec)
-        )
+        raise ValueError("shard index must be >= 1 and <= %d")
+
     return index, count
 
 
 def shard_list(items, spec):
-    # Items are taken round-robin so a run of expensive items is spread
-    # across shards.
     index, count = parse_shard(spec)
     return items[index - 1::count]
 

--- a/tests/testenv.py
+++ b/tests/testenv.py
@@ -31,7 +31,7 @@ def parse_shard(spec):
         raise ValueError("shard count must be at least 1")
 
     if not 1 <= index <= count:
-        raise ValueError("shard index must be >= 1 and <= %d")
+        raise ValueError("shard index must be >= 1 and <= %d" % (count,))
 
     return index, count
 


### PR DESCRIPTION
Two env vars for CI sharding, with no effect if not set.

| Variable | Shards | Applied in |
|---|---|---|
| `TEST_SHARD` | tests within the stub suite | `tests/stub/suites.py` |
| `TEST_CONFIG_SHARD` | the Neo4j server configuration list | `main.py` |


In a .NET driver test run, `tests.stub.routing` is 504 tests of roughly 1200 and ~21% of the entire CI build on its own. Sharding on the basis of test type would create a big slow routing shard and several small cheap ones. This PR allows sharding through round-robin collection of tests.

Doing it by index avoids a hand-written list of modlues somewhere that could risk new tests being missed.

The .NET driver `INTEGRATION_TESTS` build currently takes 43.8 min, of which about 18 min is server boots. Sharding like this reduces the number of servers that need to be booted.
